### PR TITLE
Add explicit unreviewed Beta release evidence

### DIFF
--- a/.github/workflows/source-policy.yml
+++ b/.github/workflows/source-policy.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - name: Check out the reviewed commit
+      - name: Check out the target commit
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Install the pinned Flutter SDK commit

--- a/.github/workflows/verify-release-assets.yml
+++ b/.github/workflows/verify-release-assets.yml
@@ -147,66 +147,127 @@ jobs:
           done
 
           jq -r '.body // ""' <<<"${release_json}" > "${download_dir}/RELEASE_NOTES.md"
-          mapfile -t review_markers < <(
-            grep -Eo '<!--[[:space:]]*tetotv-native-license-review-sha256:[[:space:]]*[0-9a-f]{64}[[:space:]]*-->' \
-              "${download_dir}/RELEASE_NOTES.md" || true
-          )
-          if [[ "${#review_markers[@]}" -ne 1 ]]; then
-            echo "Release notes must contain exactly one native-license review digest marker."
-            exit 1
-          fi
-          review_digest="$(sed -E 's/.*:[[:space:]]*([0-9a-f]{64})[[:space:]]*-->.*/\1/' <<<"${review_markers[0]}")"
-          all_review_marker_count="$(grep -Eic '<!--[[:space:]]*tetotv-native-license-review-sha256:' "${download_dir}/RELEASE_NOTES.md" || true)"
-          if [[ "${all_review_marker_count}" -ne 1 ]]; then
-            echo "Release notes contain an unexpected native-license review marker."
-            exit 1
-          fi
-
-          mapfile -t attestation_markers < <(
-            grep -Eo '<!--[[:space:]]*tetotv-native-license-review-attestation-base64:[[:space:]]*[A-Za-z0-9+/]+={0,2}[[:space:]]*-->' \
-              "${download_dir}/RELEASE_NOTES.md" || true
-          )
-          if [[ "${#attestation_markers[@]}" -ne 1 ]] || \
-             [[ "$(grep -Eic '<!--[[:space:]]*tetotv-native-license-review-attestation-base64:' "${download_dir}/RELEASE_NOTES.md" || true)" -ne 1 ]]; then
-            echo "Release notes must contain exactly one encoded native-license review attestation."
-            exit 1
-          fi
-          mapfile -t signature_markers < <(
-            grep -Eo '<!--[[:space:]]*tetotv-native-license-review-signature-base64:[[:space:]]*[A-Za-z0-9+/]+={0,2}[[:space:]]*-->' \
-              "${download_dir}/RELEASE_NOTES.md" || true
-          )
-          if [[ "${#signature_markers[@]}" -ne 1 ]] || \
-             [[ "$(grep -Eic '<!--[[:space:]]*tetotv-native-license-review-signature-base64:' "${download_dir}/RELEASE_NOTES.md" || true)" -ne 1 ]]; then
-            echo "Release notes must contain exactly one encoded native-license review signature."
-            exit 1
-          fi
-
-          attestation_base64="$(sed -E 's|.*:[[:space:]]*([A-Za-z0-9+/]+={0,2})[[:space:]]*-->.*|\1|' <<<"${attestation_markers[0]}")"
-          signature_base64="$(sed -E 's|.*:[[:space:]]*([A-Za-z0-9+/]+={0,2})[[:space:]]*-->.*|\1|' <<<"${signature_markers[0]}")"
-          if ! printf '%s' "${attestation_base64}" | base64 --decode > "${download_dir}/native-license-review.json" || \
-             ! printf '%s' "${signature_base64}" | base64 --decode > "${download_dir}/native-license-review.json.sig"; then
-            echo "Release notes contain invalid encoded native-license review evidence."
-            exit 1
-          fi
-          if [[ "$(sha256sum "${download_dir}/native-license-review.json" | awk '{print $1}')" != "${review_digest}" ]]; then
-            echo "Encoded native-license review attestation does not match its digest marker."
-            exit 1
-          fi
-
-          reviewer_allowlist="tool/release/qualified_native_license_reviewers.allowed_signers"
-          if ! grep -Eq '^[^#[:space:]][^[:space:]]*[[:space:]]+.*ssh-(ed25519|rsa)[[:space:]]+' "${reviewer_allowlist}"; then
-            echo "No qualified native-license reviewer key is active in the release revision."
-            exit 1
-          fi
-
           tag_commit="$(git rev-parse "${RELEASE_TAG}^{commit}")"
-          pwsh -File ./tool/release/verify_native_license_review.ps1 \
-            -AttestationPath "${download_dir}/native-license-review.json" \
-            -SignaturePath "${download_dir}/native-license-review.json.sig" \
-            -ReleaseTag "${RELEASE_TAG}" \
-            -GitCommit "${tag_commit}" \
-            -ApkPath "${download_dir}/${apk_name}" \
-            -NativeSourcePath "${download_dir}/${source_name}"
+          review_status="independently-reviewed"
+          review_digest=""
+          declaration_digest=""
+          disclosure='No independent native-license review: This Beta has not received independent native-library licensing review. Automated checks verify the APK, native-source bundle, notices, pinned inputs, and checksums, but do not establish legal compliance or reproducible builds.'
+          status_marker_count="$(grep -Eic '<!--[[:space:]]*tetotv-native-license-review-status:' "${download_dir}/RELEASE_NOTES.md" || true)"
+          exact_unreviewed_status_count="$(grep -Fxc '<!-- tetotv-native-license-review-status: unreviewed-beta -->' "${download_dir}/RELEASE_NOTES.md" || true)"
+          if [[ "${status_marker_count}" -gt 0 ]]; then
+            if [[ "${status_marker_count}" -ne 1 ]] || [[ "${exact_unreviewed_status_count}" -ne 1 ]]; then
+              echo "Release notes contain an invalid or duplicate native-license review status."
+              exit 1
+            fi
+            review_status="unreviewed-beta"
+            mapfile -t warning_lines < <(head -n 4 "${download_dir}/RELEASE_NOTES.md")
+            if [[ "${#warning_lines[@]}" -ne 4 ]] || \
+               [[ "${warning_lines[0]}" != "# TetoTV ${version} Beta" ]] || \
+               [[ -n "${warning_lines[1]}" ]] || \
+               [[ "${warning_lines[2]}" != "> [!WARNING]" ]] || \
+               [[ "${warning_lines[3]}" != "> ${disclosure}" ]]; then
+              echo "Unreviewed Beta release notes must begin with the exact visible warning block."
+              exit 1
+            fi
+            if [[ "$(grep -Foc "${disclosure}" "${download_dir}/RELEASE_NOTES.md" || true)" -ne 1 ]]; then
+              echo "Unreviewed Beta release notes must contain the disclosure exactly once."
+              exit 1
+            fi
+            if grep -Eiq '<!--[[:space:]]*tetotv-native-license-review-(sha256|attestation-base64|signature-base64):' "${download_dir}/RELEASE_NOTES.md"; then
+              echo "Unreviewed Beta release notes must not contain qualified-review evidence."
+              exit 1
+            fi
+            mapfile -t declaration_digest_markers < <(
+              grep -Eo '<!--[[:space:]]*tetotv-unreviewed-beta-declaration-sha256:[[:space:]]*[0-9a-f]{64}[[:space:]]*-->' \
+                "${download_dir}/RELEASE_NOTES.md" || true
+            )
+            if [[ "${#declaration_digest_markers[@]}" -ne 1 ]] || \
+               [[ "$(grep -Eic '<!--[[:space:]]*tetotv-unreviewed-beta-declaration-sha256:' "${download_dir}/RELEASE_NOTES.md" || true)" -ne 1 ]]; then
+              echo "Release notes must contain exactly one unreviewed Beta declaration digest."
+              exit 1
+            fi
+            declaration_digest="$(sed -E 's/.*:[[:space:]]*([0-9a-f]{64})[[:space:]]*-->.*/\1/' <<<"${declaration_digest_markers[0]}")"
+            mapfile -t declaration_markers < <(
+              grep -Eo '<!--[[:space:]]*tetotv-unreviewed-beta-declaration-base64:[[:space:]]*[A-Za-z0-9+/]+={0,2}[[:space:]]*-->' \
+                "${download_dir}/RELEASE_NOTES.md" || true
+            )
+            if [[ "${#declaration_markers[@]}" -ne 1 ]] || \
+               [[ "$(grep -Eic '<!--[[:space:]]*tetotv-unreviewed-beta-declaration-base64:' "${download_dir}/RELEASE_NOTES.md" || true)" -ne 1 ]]; then
+              echo "Release notes must contain exactly one encoded unreviewed Beta declaration."
+              exit 1
+            fi
+            declaration_base64="$(sed -E 's|.*:[[:space:]]*([A-Za-z0-9+/]+={0,2})[[:space:]]*-->.*|\1|' <<<"${declaration_markers[0]}")"
+            if ! printf '%s' "${declaration_base64}" | base64 --decode > "${download_dir}/unreviewed-beta-release-declaration.json"; then
+              echo "Release notes contain invalid encoded unreviewed Beta evidence."
+              exit 1
+            fi
+            if [[ "$(sha256sum "${download_dir}/unreviewed-beta-release-declaration.json" | awk '{print $1}')" != "${declaration_digest}" ]]; then
+              echo "Encoded unreviewed Beta declaration does not match its digest marker."
+              exit 1
+            fi
+            pwsh -File ./tool/release/verify_unreviewed_beta_release_declaration.ps1 \
+              -DeclarationPath "${download_dir}/unreviewed-beta-release-declaration.json" \
+              -ReleaseTag "${RELEASE_TAG}" \
+              -GitCommit "${tag_commit}" \
+              -ApkPath "${download_dir}/${apk_name}" \
+              -NativeSourcePath "${download_dir}/${source_name}"
+          else
+            if grep -Fq "${disclosure}" "${download_dir}/RELEASE_NOTES.md"; then
+              echo "Reviewed release notes must not claim that independent native-license review was not performed."
+              exit 1
+            fi
+            if grep -Eiq '<!--[[:space:]]*tetotv-unreviewed-beta-declaration-(sha256|base64):' "${download_dir}/RELEASE_NOTES.md"; then
+              echo "Reviewed release notes must not contain unreviewed Beta evidence."
+              exit 1
+            fi
+            mapfile -t review_markers < <(
+              grep -Eo '<!--[[:space:]]*tetotv-native-license-review-sha256:[[:space:]]*[0-9a-f]{64}[[:space:]]*-->' \
+                "${download_dir}/RELEASE_NOTES.md" || true
+            )
+            if [[ "${#review_markers[@]}" -ne 1 ]] || \
+               [[ "$(grep -Eic '<!--[[:space:]]*tetotv-native-license-review-sha256:' "${download_dir}/RELEASE_NOTES.md" || true)" -ne 1 ]]; then
+              echo "Release notes must contain exactly one native-license review digest marker."
+              exit 1
+            fi
+            review_digest="$(sed -E 's/.*:[[:space:]]*([0-9a-f]{64})[[:space:]]*-->.*/\1/' <<<"${review_markers[0]}")"
+            mapfile -t attestation_markers < <(
+              grep -Eo '<!--[[:space:]]*tetotv-native-license-review-attestation-base64:[[:space:]]*[A-Za-z0-9+/]+={0,2}[[:space:]]*-->' \
+                "${download_dir}/RELEASE_NOTES.md" || true
+            )
+            mapfile -t signature_markers < <(
+              grep -Eo '<!--[[:space:]]*tetotv-native-license-review-signature-base64:[[:space:]]*[A-Za-z0-9+/]+={0,2}[[:space:]]*-->' \
+                "${download_dir}/RELEASE_NOTES.md" || true
+            )
+            if [[ "${#attestation_markers[@]}" -ne 1 ]] || [[ "${#signature_markers[@]}" -ne 1 ]] || \
+               [[ "$(grep -Eic '<!--[[:space:]]*tetotv-native-license-review-attestation-base64:' "${download_dir}/RELEASE_NOTES.md" || true)" -ne 1 ]] || \
+               [[ "$(grep -Eic '<!--[[:space:]]*tetotv-native-license-review-signature-base64:' "${download_dir}/RELEASE_NOTES.md" || true)" -ne 1 ]]; then
+              echo "Release notes must contain exactly one encoded native-license review and signature."
+              exit 1
+            fi
+            attestation_base64="$(sed -E 's|.*:[[:space:]]*([A-Za-z0-9+/]+={0,2})[[:space:]]*-->.*|\1|' <<<"${attestation_markers[0]}")"
+            signature_base64="$(sed -E 's|.*:[[:space:]]*([A-Za-z0-9+/]+={0,2})[[:space:]]*-->.*|\1|' <<<"${signature_markers[0]}")"
+            if ! printf '%s' "${attestation_base64}" | base64 --decode > "${download_dir}/native-license-review.json" || \
+               ! printf '%s' "${signature_base64}" | base64 --decode > "${download_dir}/native-license-review.json.sig"; then
+              echo "Release notes contain invalid encoded native-license review evidence."
+              exit 1
+            fi
+            if [[ "$(sha256sum "${download_dir}/native-license-review.json" | awk '{print $1}')" != "${review_digest}" ]]; then
+              echo "Encoded native-license review attestation does not match its digest marker."
+              exit 1
+            fi
+            reviewer_allowlist="tool/release/qualified_native_license_reviewers.allowed_signers"
+            if ! grep -Eq '^[^#[:space:]][^[:space:]]*[[:space:]]+.*ssh-(ed25519|rsa)[[:space:]]+' "${reviewer_allowlist}"; then
+              echo "No qualified native-license reviewer key is active in the release revision."
+              exit 1
+            fi
+            pwsh -File ./tool/release/verify_native_license_review.ps1 \
+              -AttestationPath "${download_dir}/native-license-review.json" \
+              -SignaturePath "${download_dir}/native-license-review.json.sig" \
+              -ReleaseTag "${RELEASE_TAG}" \
+              -GitCommit "${tag_commit}" \
+              -ApkPath "${download_dir}/${apk_name}" \
+              -NativeSourcePath "${download_dir}/${source_name}"
+          fi
 
           artifact_dir="${RUNNER_TEMP}/tetotv-pinned-native-artifacts"
           mkdir -p "${artifact_dir}"
@@ -234,6 +295,12 @@ jobs:
             exit 1
           fi
 
+          evidence_arguments=()
+          if [[ "${review_status}" == "independently-reviewed" ]]; then
+            evidence_arguments+=( -NativeLicenseReviewSha256 "${review_digest}" )
+          else
+            evidence_arguments+=( -UnreviewedBetaDeclarationSha256 "${declaration_digest}" )
+          fi
           pwsh -File ./tool/release/verify_release_payloads.ps1 \
             -Channel "${CHANNEL}" \
             -ApkPath "${download_dir}/${apk_name}" \
@@ -241,26 +308,51 @@ jobs:
             -ChecksumsPath "${download_dir}/${checksums_name}" \
             -ReleaseNotesPath "${download_dir}/RELEASE_NOTES.md" \
             -ResolvedBinaryDirectory "${artifact_dir}" \
-            -NativeLicenseReviewSha256 "${review_digest}"
+            "${evidence_arguments[@]}"
 
           jq -n \
             --arg releaseTag "${RELEASE_TAG}" \
             --arg gitCommit "${tag_commit}" \
+            --arg reviewStatus "${review_status}" \
             --arg nativeLicenseReviewSha256 "${review_digest}" \
+            --arg unreviewedBetaDeclarationSha256 "${declaration_digest}" \
             '{
-              schemaVersion: 1,
+              schemaVersion: 2,
               verificationType: "tetotv-release-payload-verification",
               releaseTag: $releaseTag,
               gitCommit: $gitCommit,
-              nativeLicenseReviewSha256: $nativeLicenseReviewSha256,
-              checksPerformed: [
-                "allowlisted-reviewer-ssh-signature",
-                "artifact-bound-native-license-review",
-                "hosted-asset-digests-and-sizes",
-                "apk-signature-abi-and-alignment",
-                "native-source-and-notice-bundle",
-                "pinned-native-binary-inputs"
-              ]
+              nativeLicenseReviewStatus: $reviewStatus,
+              nativeLicenseReviewSha256: (
+                if $reviewStatus == "independently-reviewed"
+                then $nativeLicenseReviewSha256
+                else null
+                end
+              ),
+              unreviewedBetaDeclarationSha256: (
+                if $reviewStatus == "unreviewed-beta"
+                then $unreviewedBetaDeclarationSha256
+                else null
+                end
+              ),
+              checksPerformed: (
+                if $reviewStatus == "independently-reviewed"
+                then [
+                  "allowlisted-reviewer-ssh-signature",
+                  "artifact-bound-native-license-review",
+                  "hosted-asset-digests-and-sizes",
+                  "apk-signature-abi-and-alignment",
+                  "native-source-and-notice-bundle",
+                  "pinned-native-binary-inputs"
+                ]
+                else [
+                  "owner-unreviewed-beta-declaration",
+                  "hosted-asset-digests-and-sizes",
+                  "apk-signature-abi-and-alignment",
+                  "native-source-and-notice-bundle",
+                  "pinned-native-binary-inputs"
+                ]
+                end
+              )
             }' > "${download_dir}/release-verification-predicate.json"
 
           latest_tag="$(gh api "repos/${GITHUB_REPOSITORY}/releases/latest" --jq '.tag_name')"
@@ -269,7 +361,7 @@ jobs:
             exit 1
           fi
 
-      - name: Attest the independently verified release payload
+      - name: Attest the verified release payload
         id: release-attestation
         uses: actions/attest@508db95dd578ae2727ebd6217d5ba78e4fbda05d # v4.2.1
         with:
@@ -277,7 +369,7 @@ jobs:
             ${{ runner.temp }}/tetotv-release/TetoTV-${{ github.event.release.tag_name }}-universal.apk
             ${{ runner.temp }}/tetotv-release/TetoTV-${{ github.event.release.tag_name }}-native-playback-sources.zip
             ${{ runner.temp }}/tetotv-release/SHA256SUMS
-          predicate-type: https://github.com/LindersOSX/TetoTV-Beta/attestations/release-verification/v1
+          predicate-type: https://github.com/LindersOSX/TetoTV-Beta/attestations/release-verification/v2
           predicate-path: ${{ runner.temp }}/tetotv-release/release-verification-predicate.json
 
       - name: Verify the emitted release attestation bundle
@@ -307,7 +399,7 @@ jobs:
             gh attestation verify "${artifact}" \
               --repo "${GITHUB_REPOSITORY}" \
               --bundle "${ATTESTATION_BUNDLE}" \
-              --predicate-type "https://github.com/LindersOSX/TetoTV-Beta/attestations/release-verification/v1" \
+              --predicate-type "https://github.com/LindersOSX/TetoTV-Beta/attestations/release-verification/v2" \
               --signer-workflow "LindersOSX/TetoTV-Beta/.github/workflows/verify-release-assets.yml" \
               --source-ref "refs/tags/${RELEASE_TAG}" \
               --deny-self-hosted-runners

--- a/README.md
+++ b/README.md
@@ -44,6 +44,12 @@ This repository contains the complete TetoTV source code as well as the Beta rel
 | Public | Not published | Source and release-readiness documents are available, but no Public APK is currently offered |
 | Beta | [2.0.42](docs/RELEASE_NOTES_2.0.42.md) | Testing current fixes and features before a separately reviewed Public release |
 
+Beta 2.0.42 uses the repository's explicit unreviewed-Beta exception: its
+native-library and corresponding-source material did not receive independent
+license review. Automated integrity and source-bundle checks are not a legal
+compliance determination. The release notes preserve the exact disclosure and
+owner declaration; this exception does not apply to a future Public release.
+
 The Public updater repository intentionally has no release while the Public build is held for review. Existing Beta installations continue to update from the Beta repository. Android never permits an in-place install of an APK with a lower build code; Developer Mode does not bypass that platform rule.
 
 ## Android TV / Fire TV

--- a/docs/BUILD_WINDOWS.md
+++ b/docs/BUILD_WINDOWS.md
@@ -259,11 +259,13 @@ plugin build output and exact-name Gradle transform outputs, and the three
 libtorrent4j inputs in the Gradle module cache. A missing or digest-mismatched
 artifact blocks release preparation.
 
-Before `-Publish`, complete the separate qualified-reviewer procedure in
+Before `-Publish`, choose exactly one evidence path documented in
 [`NATIVE_LICENSE_RELEASE_REVIEW.md`](NATIVE_LICENSE_RELEASE_REVIEW.md). The
-publisher requires that SSH-signed attestation, creates a private GitHub draft,
-re-downloads and fully verifies the hosted draft payload, and only then makes
-the release public. No fourth custom release asset is added.
+default path requires an SSH-signed qualified-review attestation. A separate,
+explicit Beta-only exception requires a fresh unsigned owner declaration and a
+prominent warning that independent review was not performed. Both paths create
+a private GitHub draft, re-download and fully verify the hosted payload, and
+only then make the release public. No fourth custom release asset is added.
 
 The Beta GitHub release has exactly three custom assets: the universal APK, the
 versioned native playback source ZIP, and `SHA256SUMS`. GitHub also adds its

--- a/docs/NATIVE_LICENSE_RELEASE_REVIEW.md
+++ b/docs/NATIVE_LICENSE_RELEASE_REVIEW.md
@@ -7,9 +7,9 @@ every applicable license.
 
 ## Security boundary
 
-`-Publish` is blocked unless `publish_beta_release.ps1` can verify an OpenSSH
-signature over the exact attestation bytes. The attestation binds the review
-to all of the following:
+Reviewed `-Publish` is blocked unless `publish_beta_release.ps1` can verify an
+OpenSSH signature over the exact attestation bytes. The attestation binds the
+review to all of the following:
 
 - canonical release tag and full Git commit;
 - final universal APK SHA-256;
@@ -33,6 +33,55 @@ The checked-in allowlist intentionally starts with no active keys. That is a
 fail-closed release state, not a sample key to replace automatically. A project
 administrator must independently verify both a reviewer's qualification and
 public-key fingerprint before committing one exact allowed-signers entry.
+
+## Explicit unreviewed Beta exception
+
+The Beta publisher also supports a deliberately conspicuous exception when an
+independent reviewer is not yet available. This exception is Beta-only, is
+never the default, and cannot be combined with reviewer evidence. It requires:
+
+- `-PublishWithoutIndependentNativeLicenseReview`;
+- the exact acknowledgement `PUBLISH UNREVIEWED BETA`;
+- a fresh `tetotv-unreviewed-beta-release-declaration` created from the final
+  tag, commit, APK, native-source ZIP, manifest, notice, and provenance limits;
+- an owner-confirmed complete empty GitHub App inventory for the Beta
+  repository, created within 24 hours; and
+- a prominent public warning that no independent native-license or
+  corresponding-source review occurred.
+
+The unsigned owner declaration is not an approval, qualified review, legal
+advice, or a compliance determination. It never contains reviewer fields or a
+fake signature. The publisher and hosted workflow reject mixed reviewed and
+unreviewed evidence while retaining the same draft-first asset, checksum, APK,
+native-source, pinned-input, repository-authority, immutable-release, and
+GitHub attestation checks. This exception must not be used for a Public release.
+
+After the final tag and payloads exist, create it with:
+
+```powershell
+.\tool\release\new_unreviewed_beta_release_declaration.ps1 `
+  -ApkPath .\build\fire-tv\v2.x.y\TetoTV-v2.x.y-universal.apk `
+  -NativeSourcePath .\build\release-compliance\v2.x.y\TetoTV-v2.x.y-native-playback-sources.zip `
+  -OutputPath .\build\release-compliance\v2.x.y\unreviewed-beta-release-declaration.json `
+  -ConfirmNoIndependentNativeLicenseReview `
+  -ConfirmCorrespondingSourceNotIndependentlyReviewed `
+  -AcknowledgeKnownProvenanceLimits `
+  -ConfirmNoGitHubAppsInstalledForRepository
+```
+
+Pass it only through the explicit exception path:
+
+```powershell
+.\tool\release\publish_beta_release.ps1 `
+  -ApkPath .\build\fire-tv\v2.x.y\TetoTV-v2.x.y-universal.apk `
+  -NativeSourcePath .\build\release-compliance\v2.x.y\TetoTV-v2.x.y-native-playback-sources.zip `
+  -ChecksumsPath .\build\fire-tv\v2.x.y\SHA256SUMS `
+  -ReleaseNotesPath .\docs\RELEASE_NOTES_2.x.y.md `
+  -UnreviewedBetaDeclarationPath .\build\release-compliance\v2.x.y\unreviewed-beta-release-declaration.json `
+  -PublishWithoutIndependentNativeLicenseReview `
+  -UnreviewedBetaAcknowledgement "PUBLISH UNREVIEWED BETA" `
+  -Publish
+```
 
 ## Create and sign the statement
 
@@ -88,10 +137,10 @@ stricter: it must be empty, complete, signed as part of the same statement, and
 no more than 24 hours old. GitHub's personal-account API does not expose this
 complete inventory to a normal `gh` OAuth token, so the qualified reviewer must
 open **Repository settings > Integrations > GitHub Apps** and confirm that no
-App is installed for `LindersOSX/TetoTV-Beta`. Publication fails closed if that
-confirmation is absent or stale.
+  App is installed for `LindersOSX/TetoTV-Beta`. Reviewed publication fails
+  closed if that confirmation is absent or stale.
 
-## Draft-first publication
+## Reviewed draft-first publication
 
 Pass the attestation when publishing:
 
@@ -112,7 +161,7 @@ fourth release asset. Do not put private keys or private reviewer details in
 the attestation; its stable reviewer identity and role become public release
 evidence.
 
-GitHub receives a private draft first. The script re-downloads all three
+In reviewed mode, GitHub receives a private draft first. The script re-downloads all three
 assets, decodes the exact public evidence, verifies the allowlisted OpenSSH
 signature and every artifact binding, verifies hosted sizes and hashes, and
 runs the complete APK, native-source, binary-artifact, checksum, and notes
@@ -126,6 +175,12 @@ performed. It is verification provenance; it does not falsely claim that
 GitHub Actions built the locally signed APK. The workflow also requires
 GitHub's immutable-release attestation (`gh release verify`) and verifies its
 own generic attestation bundle against the exact signer workflow and tag ref.
+
+The unreviewed Beta path uses the same draft-first hosted payload checks, but it
+verifies the fresh owner declaration and exact public `unreviewed-beta` status
+instead of a reviewer signature. Its GitHub predicate records
+`nativeLicenseReviewStatus: unreviewed-beta`, the declaration digest, and only
+the automated checks actually performed. It does not claim independent review.
 
 Failed drafts are deleted automatically. A release that may already be public
 is never deleted or mutated by rollback logic, which preserves immutable

--- a/docs/NATIVE_PLAYBACK_REDISTRIBUTION.md
+++ b/docs/NATIVE_PLAYBACK_REDISTRIBUTION.md
@@ -45,7 +45,9 @@ does not publish source-archive SHA-256 values, and contains a floating
 `media_kit` clone that is not used by the final helper bundling step. A fresh
 build therefore cannot be proven bit-for-bit identical from the recorded
 metadata alone. The staging tool records the resolved commit of every such
-tag; release review must retain and evaluate that report.
+tag. Release evidence must retain that report. Public and reviewed Beta paths
+must have it independently evaluated; an unreviewed Beta must disclose that
+the evaluation was not performed.
 
 The same staged source bundle includes libtorrent4j commit
 `09ffd391d4ef12e668cc032bffcbab47d9e2d5cb`, libtorrent-rasterbar commit
@@ -90,20 +92,34 @@ corresponding universal APK and `SHA256SUMS`, and retain the same verified
 bundle for as long as the binary remains available. GitHub also supplies the
 tagged TetoTV source archives automatically. A qualified reviewer must confirm
 those archives and the durable public source locations referenced here meet
-every applicable corresponding-source obligation. Do not publish if they do
-not, or if a revision, binary hash, license asset, or source snapshot is
-missing.
+every applicable corresponding-source obligation before a Public release or a
+reviewed Beta release. Do not use either reviewed path if they do not, or if a
+revision, binary hash, license asset, or source snapshot is missing. The
+explicit unreviewed Beta exception below may only record that this confirmation
+was deferred; it does not resolve a source-offer gap.
 
-The review is enforced by the SSH-signed, artifact-bound gate documented in
+The default review path is enforced by the SSH-signed, artifact-bound gate
+documented in
 [`NATIVE_LICENSE_RELEASE_REVIEW.md`](NATIVE_LICENSE_RELEASE_REVIEW.md).
-`-Publish` requires a fresh approval signed by an exact principal in the
-checked-in qualified-reviewer allowlist. The repository starts with no active
-reviewer key, so publication intentionally fails closed until a project
-administrator independently verifies and commits a qualified reviewer's public
-key. The signed record and its validation are review evidence, not legal advice
-or a claim of compliance.
+Reviewed `-Publish` requires a fresh approval signed by an exact principal in
+the checked-in qualified-reviewer allowlist. The repository starts with no
+active reviewer key, so reviewed publication intentionally fails closed until
+a project administrator independently verifies and commits a qualified
+reviewer's public key. The signed record and its validation are review
+evidence, not legal advice or a claim of compliance.
+
+A Beta-only owner-declared exception may be used when independent review is
+explicitly deferred. That path publicly states that neither the native-license
+material nor corresponding source received independent review, binds a fresh
+unsigned declaration to the final artifacts and documented provenance limits,
+and retains all automated source, APK, checksum, pinned-input, draft, and
+repository-authority verification. It is not an approval or compliance
+determination and must not be represented as one. The exception is described
+in `NATIVE_LICENSE_RELEASE_REVIEW.md` and is not permitted for Public releases.
 
 The checked-in full GPL/LGPL texts are conservative. Component copyright and
 license notices inside the staged sources determine the actual license of each
-file. A qualified release reviewer must resolve the documented upstream
-provenance gaps and confirm the final source offer before distribution.
+file. Public and reviewed Beta distribution require a qualified release
+reviewer to resolve the documented upstream provenance gaps and confirm the
+final source offer. An unreviewed Beta must instead disclose that those steps
+were not independently completed and must not claim compliance.

--- a/docs/PUBLIC_RELEASE_CHECKLIST.md
+++ b/docs/PUBLIC_RELEASE_CHECKLIST.md
@@ -40,16 +40,19 @@ the same as legal, store, or codec certification.
   `powershell -ExecutionPolicy Bypass -File tool/release/verify_native_redistribution.ps1`
   before building, then run it with `-StageBundle` and retain the generated
   native source bundle as release evidence. Review every reported upstream
-  provenance limit before approving distribution. A qualified release reviewer
-  must confirm that the tagged repository archive and linked public source
-  locations satisfy the exact binary's source obligations; if they do not, the
-  three-asset GitHub release contract is a release blocker.
-  Record that approval with the SSH-signed attestation in
-  `NATIVE_LICENSE_RELEASE_REVIEW.md`. Publication must remain blocked when the
-  reviewer allowlist is empty, the signature is invalid, the review is stale,
-  or any tag, commit, APK, source ZIP, manifest, notice, or provenance-limit
-  digest differs from the signed statement. This evidence is not itself a
-  legal-compliance claim.
+  provenance limit before approving distribution. Every Public release requires
+  a qualified release reviewer to confirm that the tagged repository archive
+  and linked public source locations satisfy the exact binary's source
+  obligations; if they do not, the three-asset GitHub release contract is a
+  release blocker. Record that approval with the SSH-signed attestation in
+  `NATIVE_LICENSE_RELEASE_REVIEW.md`. Public publication must remain blocked
+  when the reviewer allowlist is empty, the signature is invalid, the review is
+  stale, or any tag, commit, APK, source ZIP, manifest, notice, or
+  provenance-limit digest differs from the signed statement. This evidence is
+  not itself a legal-compliance claim. A Beta may instead use only the explicit,
+  prominently disclosed owner-declaration exception documented there. That
+  exception records that independent review did not occur; it never satisfies
+  this Public-release checklist or establishes compliance.
 - Run
   `powershell -ExecutionPolicy Bypass -File tool/release/stage_third_party_notices.ps1 -StageBundle -RequireDiscordSdkBinary`
   from the release revision. Retain the generated notices ZIP with the release
@@ -198,12 +201,17 @@ must use phishing-resistant two-factor authentication (preferably a passkey or
 hardware security key), offline recovery codes, and narrowly scoped/revocable
 credentials.
 
-The publisher automatically verifies collaborators, invitations, write deploy
-keys, immutable-release settings, and Actions permissions. A normal GitHub CLI
-OAuth token cannot enumerate the complete GitHub App installation inventory for
-a personal account, so the signed release review must also contain a complete,
-empty inventory confirmed from **Repository settings > Integrations > GitHub
-Apps** within the previous 24 hours. Any installed App blocks publication.
+The publisher automatically verifies collaborators, invitations, webhooks,
+write deploy keys, self-hosted runners, immutable-release settings, and Actions
+permissions. Actions must require full commit-SHA pins and allow GitHub-owned
+actions plus only `subosito/flutter-action` and `android-actions/setup-android`,
+which the hosted verifier pins to exact commits. A normal GitHub CLI OAuth token cannot enumerate the complete
+GitHub App installation inventory for a personal account, so the selected
+release evidence must also contain a complete, empty inventory confirmed from
+**Repository settings > Integrations > GitHub Apps** within the previous 24
+hours. For a reviewed release that inventory is part of the signed statement;
+for the explicit unreviewed Beta exception it is an owner confirmation and is
+not represented as independent review. Any installed App blocks publication.
 
 If release creation must be technically independent of the owner, transfer the
 repositories to a GitHub organization, enforce immutable releases at the
@@ -211,8 +219,9 @@ organization level, and place publication behind an organization-controlled
 environment/custom role with a separate reviewer. Branch and tag rules cannot
 govern GitHub release creation, and a post-publication workflow cannot erase
 the brief visibility window of an unauthorized manual release. Never announce
-a release unless its signed native review, payload verification workflow, and
-GitHub verification attestation all pass.
+a release unless its exact selected evidence mode, payload verification
+workflow, and GitHub verification attestation all pass. Public releases always
+require the signed native review; the owner-declared exception is Beta-only.
 
 ## Content/source policy
 

--- a/docs/RELEASE_NOTES_2.0.42.md
+++ b/docs/RELEASE_NOTES_2.0.42.md
@@ -1,5 +1,8 @@
 # TetoTV 2.0.42 Beta
 
+> [!WARNING]
+> No independent native-license review: This Beta has not received independent native-library licensing review. Automated checks verify the APK, native-source bundle, notices, pinned inputs, and checksums, but do not establish legal compliance or reproducible builds.
+
 This Beta strengthens account setup, privacy handling, and release integrity while keeping the existing updater, playback, downloads, and account connections compatible.
 
 ## What's changed
@@ -9,7 +12,7 @@ This Beta strengthens account setup, privacy handling, and release integrity whi
 - Existing linked Discord sessions continue to refresh, reconnect, toggle Rich Presence, and survive cache clearing without a forced migration. Unlinking removes both the token and its confirmation marker.
 - The privacy disclosure now provides an account-free private request route and accurately separates TetoTV's application retention from Wispbyte and Discord infrastructure processing.
 - Featured TV titles use roughly the left half of the sponsor panel and scale/wrap the complete localized title without covering the right-side artwork. Phone and tablet title sizing is unchanged.
-- Native redistribution publication now requires a signed, digest-bound qualified-review attestation and verifies a private GitHub draft before making a release public.
+- Native redistribution publication supports either the default signed qualified-review path or this explicitly disclosed, owner-declared unreviewed Beta exception. Both paths verify a private GitHub draft before making a release public; the exception never represents automated checks as legal review.
 - GitHub workflows use commit-pinned actions, dependency review, CodeQL, protected branches/tags, secret scanning, push protection, and immutable future release controls.
 - The known libtorrent4j API-28-only update is held back so Fire OS 6 and Android 7 support remain intact.
 

--- a/docs/THIRD_PARTY_NOTICES.md
+++ b/docs/THIRD_PARTY_NOTICES.md
@@ -79,11 +79,14 @@ texts under `assets/legal/native/`. Exact binary hashes, source revisions, rebui
 relink instructions, and known evidence limits are in
 [`NATIVE_PLAYBACK_REDISTRIBUTION.md`](NATIVE_PLAYBACK_REDISTRIBUTION.md).
 A distributor must run the verifier and stage the corresponding-source bundle
-as release evidence. Before using the one-APK GitHub asset policy, a qualified
-reviewer must confirm that GitHub's tagged source archives and the durable
-public source locations referenced by this repository satisfy every applicable
-source obligation. Neither this summary nor the in-APK notice is, by itself, a
-source-code offer.
+as release evidence. The default release path requires a qualified reviewer to
+confirm that GitHub's tagged source archives and the durable public source
+locations referenced by this repository satisfy every applicable source
+obligation. A prominently disclosed Beta-only exception can instead record
+that independent native-license and corresponding-source review was deferred;
+automated verification and an owner declaration do not establish compliance
+or cure an incomplete source offer. Neither this summary nor the in-APK notice
+is, by itself, a source-code offer.
 
 The direct-torrent JNI artifacts are ordinary Maven dependencies rather than
 part of the libmpv corresponding-source bundle. A distributor must separately

--- a/docs/UPDATE_CHANNELS.md
+++ b/docs/UPDATE_CHANNELS.md
@@ -105,17 +105,22 @@ this Android rule.
 
 Before publishing either channel:
 
-1. Start from a reviewed clean public root and verify the proprietary Discord
+1. Start from a clean public-source checkout and verify the proprietary Discord
    SDK AAR is absent from every public branch, tag, pull-request ref, archive,
    release asset, and reachable Git object.
 2. Build one production-signed universal APK with ARM32 and ARM64.
 3. Stage and verify the versioned native source bundle.
 4. Generate `SHA256SUMS` from the final APK and native source ZIP.
 5. Run `tool/release/verify_release_payloads.ps1` (which requires all five
-   pinned native binary artifacts) and the full checklist in
-   `PUBLIC_RELEASE_CHECKLIST.md`.
-6. Obtain and verify the SSH-signed, artifact-bound qualified-reviewer record
-   described in `NATIVE_LICENSE_RELEASE_REVIEW.md`.
+   pinned native binary artifacts) and every applicable common technical check
+   in `PUBLIC_RELEASE_CHECKLIST.md`. A Public release must satisfy that complete
+   checklist. An explicitly unreviewed Beta does not satisfy its independent
+   review gate and must use the warning and evidence path in step 6 instead.
+6. Use exactly one evidence path from `NATIVE_LICENSE_RELEASE_REVIEW.md`:
+   either obtain the SSH-signed, artifact-bound qualified-reviewer record, or
+   for an explicitly unreviewed Beta only, create the fresh owner declaration
+   and publish the required warning. The exception is not legal review and is
+   never permitted for Public.
 7. Let the publisher create a private draft with exactly the three named
    assets. It re-downloads and fully verifies the hosted draft before making it
    a normal release, then verifies `/releases/latest`. Install that result over
@@ -123,8 +128,8 @@ Before publishing either channel:
    TV devices.
 
 For Beta, use `tool/release/publish_beta_release.ps1`; it is a dry run unless
-`-Publish` and the signed native-license review are passed, and publishes only
-to `LindersOSX/TetoTV-Beta`. Public
+`-Publish` and exactly one explicit reviewed or unreviewed evidence mode are
+passed, and publishes only to `LindersOSX/TetoTV-Beta`. Public
 publication is intentionally absent from the release scripts and rejected by
 the release workflow. Re-enabling it requires a separately reviewed source
 change after the Public channel is approved.

--- a/lib/features/settings/data/phone_setup_pairing_client.dart
+++ b/lib/features/settings/data/phone_setup_pairing_client.dart
@@ -363,10 +363,7 @@ class PhoneSetupPairingClient implements PhoneSetupPairingApi {
   final digest = sha256.convert(<int>[0x04, ...key.publicX, ...key.publicY]);
   final bytes = digest.bytes;
   final value =
-      (bytes[0] << 24) |
-      (bytes[1] << 16) |
-      (bytes[2] << 8) |
-      bytes[3];
+      (bytes[0] << 24) | (bytes[1] << 16) | (bytes[2] << 8) | bytes[3];
   return (
     fingerprint: base64UrlEncode(bytes).replaceAll('=', ''),
     confirmationCode: (value % 1000000).toString().padLeft(6, '0'),

--- a/lib/features/tracking/presentation/my_list_screen.dart
+++ b/lib/features/tracking/presentation/my_list_screen.dart
@@ -304,7 +304,8 @@ class _MyListScreenState extends ConsumerState<MyListScreen> {
                         _SortButton(
                           sort: sort,
                           compact: true,
-                          iconOnly: layout.usesPhoneBottomNavigation &&
+                          iconOnly:
+                              layout.usesPhoneBottomNavigation &&
                               constraints.maxWidth < 420,
                           focusNode: _sortFocus,
                           onKeyEvent: (_, event) =>

--- a/test/phone_setup_pairing_client_test.dart
+++ b/test/phone_setup_pairing_client_test.dart
@@ -124,53 +124,53 @@ void main() {
       );
     });
 
-    test('derives the QR identity locally instead of trusting the relay', () async {
-      for (final field in const [
-        'device_key_fingerprint',
-        'confirmation_code',
-      ]) {
-        final harness = _Harness((_) {
-          final response = _sessionResponse();
-          response[field] = field == 'confirmation_code'
-              ? '000000'
-              : List.filled(43, 'A').join();
-          if (field == 'device_key_fingerprint') {
-            response['verification_uri_complete'] =
-                'https://setup.example/setup#code=ABCD-EFGH&key=${response[field]}';
-          }
-          return response;
-        });
-        await expectLater(
-          harness.client.createSession(_keyMaterial()),
-          throwsFormatException,
-          reason: field,
-        );
-      }
-    });
-
     test(
-      'requires same-origin fragment-only verification completion',
+      'derives the QR identity locally instead of trusting the relay',
       () async {
-        final mutations = <String>[
-          'https://evil.example/setup#code=ABCD-EFGH&key=${_testIdentity.fingerprint}',
-          'https://setup.example/setup?code=ABCD-EFGH&key=${_testIdentity.fingerprint}',
-          'https://setup.example/setup#code=WXYZ-2345&key=${_testIdentity.fingerprint}',
-          'https://setup.example/setup#code=ABCD-EFGH&key=WRONG_KEY',
-          'https://setup.example/setup#code=ABCD-EFGH&key=${_testIdentity.fingerprint}&extra=1',
-          'https://setup.example/other#code=ABCD-EFGH&key=${_testIdentity.fingerprint}',
-        ];
-        for (final uri in mutations) {
-          final harness = _Harness(
-            (_) => _sessionResponse(verificationUriComplete: uri),
-          );
+        for (final field in const [
+          'device_key_fingerprint',
+          'confirmation_code',
+        ]) {
+          final harness = _Harness((_) {
+            final response = _sessionResponse();
+            response[field] = field == 'confirmation_code'
+                ? '000000'
+                : List.filled(43, 'A').join();
+            if (field == 'device_key_fingerprint') {
+              response['verification_uri_complete'] =
+                  'https://setup.example/setup#code=ABCD-EFGH&key=${response[field]}';
+            }
+            return response;
+          });
           await expectLater(
             harness.client.createSession(_keyMaterial()),
             throwsFormatException,
-            reason: uri,
+            reason: field,
           );
         }
       },
     );
+
+    test('requires same-origin fragment-only verification completion', () async {
+      final mutations = <String>[
+        'https://evil.example/setup#code=ABCD-EFGH&key=${_testIdentity.fingerprint}',
+        'https://setup.example/setup?code=ABCD-EFGH&key=${_testIdentity.fingerprint}',
+        'https://setup.example/setup#code=WXYZ-2345&key=${_testIdentity.fingerprint}',
+        'https://setup.example/setup#code=ABCD-EFGH&key=WRONG_KEY',
+        'https://setup.example/setup#code=ABCD-EFGH&key=${_testIdentity.fingerprint}&extra=1',
+        'https://setup.example/other#code=ABCD-EFGH&key=${_testIdentity.fingerprint}',
+      ];
+      for (final uri in mutations) {
+        final harness = _Harness(
+          (_) => _sessionResponse(verificationUriComplete: uri),
+        );
+        await expectLater(
+          harness.client.createSession(_keyMaterial()),
+          throwsFormatException,
+          reason: uri,
+        );
+      }
+    });
 
     test(
       'poll sends device capability in header and parses a 65-byte envelope',
@@ -312,9 +312,7 @@ class _Harness {
   late final PhoneSetupPairingClient client;
 }
 
-Map<String, Object?> _sessionResponse({
-  String? verificationUriComplete,
-}) {
+Map<String, Object?> _sessionResponse({String? verificationUriComplete}) {
   final now = DateTime.now().toUtc();
   return {
     'version': 1,
@@ -371,14 +369,13 @@ final _testIdentity = _keyIdentity(_keyMaterial());
 ({String fingerprint, String confirmationCode}) _keyIdentity(
   PhoneSetupKeyMaterial key,
 ) {
-  final bytes = sha256
-      .convert(<int>[0x04, ...key.publicX, ...key.publicY])
-      .bytes;
+  final bytes = sha256.convert(<int>[
+    0x04,
+    ...key.publicX,
+    ...key.publicY,
+  ]).bytes;
   final value =
-      (bytes[0] << 24) |
-      (bytes[1] << 16) |
-      (bytes[2] << 8) |
-      bytes[3];
+      (bytes[0] << 24) | (bytes[1] << 16) | (bytes[2] << 8) | bytes[3];
   return (
     fingerprint: _b64(bytes),
     confirmationCode: (value % 1000000).toString().padLeft(6, '0'),

--- a/test/release_repository_policy_test.dart
+++ b/test/release_repository_policy_test.dart
@@ -58,7 +58,7 @@ void main() {
     expect(apkVerifier, isNot(contains(r'$IsWindows')));
   });
 
-  test('publication is draft-first and requires signed native review', () {
+  test('reviewed publication remains draft-first and verifies signed review', () {
     final publisher = File(
       'tool/release/publish_release.ps1',
     ).readAsStringSync();
@@ -84,6 +84,9 @@ void main() {
     expect(publisher, contains('unexpected collaborators are present'));
     expect(publisher, contains('immutable future releases must be enabled'));
     expect(publisher, contains('sha_pinning_required'));
+    expect(publisher, contains('android-actions/setup-android@*'));
+    expect(publisher, contains('subosito/flutter-action@*'));
+    expect(publisher, contains(r'$selectedActionsPolicy.verified_allowed'));
     expect(publisher, contains('default_workflow_permissions'));
     expect(
       publisher,
@@ -115,11 +118,8 @@ void main() {
       reviewVerifier,
       contains('Publication is blocked while any GitHub App is installed'),
     );
-    expect(publisher, contains('SignedReviewAttestationPath'));
-    expect(
-      publisher,
-      contains('complete empty GitHub App inventory'),
-    );
+    expect(publisher, contains(r'$reviewEvidence.githubAppInventory'));
+    expect(publisher, contains('complete empty GitHub App inventory'));
     expect(
       hostedReleaseVerifier,
       contains('tetotv-native-license-review-attestation-base64'),
@@ -152,6 +152,223 @@ void main() {
       activeReviewers,
       isEmpty,
       reason: 'release must remain fail-closed until a reviewer is vetted',
+    );
+  });
+
+  test('unreviewed publication is explicit, Beta-only, and cannot claim review', () {
+    final betaPublisher = File(
+      'tool/release/publish_beta_release.ps1',
+    ).readAsStringSync();
+    final publisher = File(
+      'tool/release/publish_release.ps1',
+    ).readAsStringSync();
+    final payloadVerifier = File(
+      'tool/release/verify_release_payloads.ps1',
+    ).readAsStringSync();
+    final declarationCreator = File(
+      'tool/release/new_unreviewed_beta_release_declaration.ps1',
+    ).readAsStringSync();
+    final declarationVerifier = File(
+      'tool/release/verify_unreviewed_beta_release_declaration.ps1',
+    ).readAsStringSync();
+    final hostedReleaseVerifier = File(
+      '.github/workflows/verify-release-assets.yml',
+    ).readAsStringSync();
+    final releaseNotes = File(
+      'docs/RELEASE_NOTES_2.0.42.md',
+    ).readAsStringSync();
+
+    expect(
+      betaPublisher,
+      contains('[switch]\$PublishWithoutIndependentNativeLicenseReview'),
+    );
+    expect(
+      betaPublisher,
+      contains(
+        r'$arguments.PublishWithoutIndependentNativeLicenseReview = $true',
+      ),
+    );
+    expect(betaPublisher, contains(r'Channel = "Beta"'));
+    expect(
+      publisher,
+      contains(
+        r'$unreviewedBetaAcknowledgementText = "PUBLISH UNREVIEWED BETA"',
+      ),
+    );
+    expect(publisher, contains('[StringComparison]::Ordinal'));
+    expect(
+      publisher,
+      contains(
+        'Reviewed native-license evidence and the unreviewed Beta exception are mutually exclusive.',
+      ),
+    );
+    expect(
+      publisher,
+      contains(
+        'Unreviewed Beta inputs require -PublishWithoutIndependentNativeLicenseReview.',
+      ),
+    );
+    expect(
+      publisher,
+      contains(
+        'Reviewed publication requires -NativeLicenseReviewPath and fails closed without a signed qualified-reviewer attestation.',
+      ),
+    );
+    expect(
+      publisher,
+      contains(
+        'Unreviewed Beta publication requires -UnreviewedBetaDeclarationPath.',
+      ),
+    );
+    expect(
+      RegExp(
+        r'\[ValidateSet\("Beta"\)\]\s*\[string\]\$Channel',
+      ).hasMatch(publisher),
+      isTrue,
+    );
+    expect(payloadVerifier, contains(r'if ($Channel -cne "Beta")'));
+    expect(
+      declarationCreator,
+      contains(r"'(?m)^version:\s*(2\.\d+\.\d+)\+\d+\s*$'"),
+    );
+    expect(
+      declarationVerifier,
+      contains("ReleaseTag must be a canonical Beta v2.x.y tag."),
+    );
+
+    expect(
+      declarationCreator,
+      contains(r'independentNativeLicenseReview = $false'),
+    );
+    expect(
+      declarationCreator,
+      contains(r'correspondingSourceIndependentlyReviewed = $false'),
+    );
+    expect(
+      declarationVerifier,
+      contains(r'$value -isnot [bool] -or $value -ne $false'),
+    );
+    expect(
+      declarationVerifier,
+      contains(
+        'This evidence explicitly records that no independent native-license or corresponding-source review was performed.',
+      ),
+    );
+    expect(declarationCreator, isNot(contains('ssh-keygen')));
+    expect(declarationVerifier, isNot(contains('-Y verify')));
+
+    const statusMarker =
+        '<!-- tetotv-native-license-review-status: unreviewed-beta -->';
+    final disclosureMatch = RegExp(
+      r'\$unreviewedBetaDisclosureText\s*=\s*"([^"]+)"',
+    ).firstMatch(publisher);
+    expect(disclosureMatch, isNotNull);
+    final disclosure = disclosureMatch!.group(1)!;
+    expect(releaseNotes, contains(disclosure));
+    expect(hostedReleaseVerifier, contains("disclosure='$disclosure'"));
+    expect(publisher, contains(r'$unreviewedBetaVisibleWarningPrefix'));
+    expect(
+      hostedReleaseVerifier,
+      contains(r'[[ "${warning_lines[2]}" != "> [!WARNING]" ]]'),
+    );
+    expect(declarationVerifier, contains('Compare-Object -CaseSensitive'));
+    const reviewedDisclosureRejection =
+        'Reviewed release notes must not claim that independent native-license review was not performed.';
+    expect(
+      publisher,
+      contains(
+        r'[regex]::Matches($normalizedReleaseBody, [regex]::Escape($unreviewedBetaDisclosureText))',
+      ),
+    );
+    expect(publisher, contains(reviewedDisclosureRejection));
+    expect(
+      payloadVerifier,
+      contains(r'$releaseNotesText.Contains($unreviewedDisclosure)'),
+    );
+    expect(payloadVerifier, contains(reviewedDisclosureRejection));
+    expect(
+      hostedReleaseVerifier,
+      contains(
+        r'if grep -Fq "${disclosure}" "${download_dir}/RELEASE_NOTES.md"; then',
+      ),
+    );
+    expect(hostedReleaseVerifier, contains(reviewedDisclosureRejection));
+    expect(publisher, contains(statusMarker));
+    expect(hostedReleaseVerifier, contains(statusMarker));
+    expect(
+      publisher,
+      contains(
+        'Unreviewed Beta release notes must not contain qualified-review evidence.',
+      ),
+    );
+    expect(
+      payloadVerifier,
+      contains(
+        'Unreviewed Beta release notes must not contain qualified-review evidence.',
+      ),
+    );
+    expect(
+      hostedReleaseVerifier,
+      contains(
+        'Unreviewed Beta release notes must not contain qualified-review evidence.',
+      ),
+    );
+    expect(hostedReleaseVerifier, contains('review_status="unreviewed-beta"'));
+    expect(
+      hostedReleaseVerifier,
+      contains('"owner-unreviewed-beta-declaration"'),
+    );
+    expect(hostedReleaseVerifier, contains('else null'));
+    expect(
+      hostedReleaseVerifier,
+      isNot(contains('Attest the independently verified release payload')),
+    );
+    expect(
+      hostedReleaseVerifier,
+      contains('Attest the verified release payload'),
+    );
+  });
+
+  test('both release-evidence paths preserve the three-asset contract', () {
+    final publisher = File(
+      'tool/release/publish_release.ps1',
+    ).readAsStringSync();
+    final hostedReleaseVerifier = File(
+      '.github/workflows/verify-release-assets.yml',
+    ).readAsStringSync();
+
+    expect(
+      RegExp(
+        r'\$assetPaths\s*=\s*@\(\$resolvedApk,\s*\$resolvedNativeSource,\s*\$resolvedChecksums\)',
+      ).hasMatch(publisher),
+      isTrue,
+    );
+    expect(
+      RegExp(
+        r'"release",\s*"create",\s*\$releaseTag,\s*\$resolvedApk,\s*\$resolvedNativeSource,\s*\$resolvedChecksums,\s*"--repo"',
+        multiLine: true,
+      ).hasMatch(publisher),
+      isTrue,
+    );
+    expect(
+      publisher,
+      contains(
+        r'Release must contain exactly $($ExpectedAssets.Count) assets.',
+      ),
+    );
+    expect(hostedReleaseVerifier, contains(r'"${#actual_assets[@]}" -ne 3'));
+    final subjectBlock = RegExp(
+      r'subject-path:\s*\|([\s\S]*?)predicate-type:',
+    ).firstMatch(hostedReleaseVerifier);
+    expect(subjectBlock, isNotNull);
+    final subjects = RegExp(
+      r'^\s+\$\{\{ runner\.temp \}\}/tetotv-release/',
+      multiLine: true,
+    ).allMatches(subjectBlock!.group(1)!).length;
+    expect(subjects, 3);
+    expect(
+      subjectBlock.group(1),
+      isNot(contains('unreviewed-beta-release-declaration')),
     );
   });
 }

--- a/tool/release/new_unreviewed_beta_release_declaration.ps1
+++ b/tool/release/new_unreviewed_beta_release_declaration.ps1
@@ -1,0 +1,172 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$ApkPath,
+
+    [Parameter(Mandatory = $true)]
+    [string]$NativeSourcePath,
+
+    [Parameter(Mandatory = $true)]
+    [string]$OutputPath,
+
+    [Parameter(Mandatory = $true)]
+    [switch]$ConfirmNoIndependentNativeLicenseReview,
+
+    [Parameter(Mandatory = $true)]
+    [switch]$ConfirmCorrespondingSourceNotIndependentlyReviewed,
+
+    [Parameter(Mandatory = $true)]
+    [switch]$AcknowledgeKnownProvenanceLimits,
+
+    [Parameter(Mandatory = $true)]
+    [switch]$ConfirmNoGitHubAppsInstalledForRepository
+)
+
+$ErrorActionPreference = "Stop"
+Set-StrictMode -Version Latest
+
+$repositoryRoot = (Resolve-Path (Join-Path $PSScriptRoot "..\..")).Path
+$manifestPath = Join-Path $PSScriptRoot "native_playback_manifest.json"
+$noticePath = Join-Path $repositoryRoot "assets\legal\native\NATIVE_PLAYBACK_NOTICE.txt"
+$repository = "LindersOSX/TetoTV-Beta"
+$operatorIdentity = "LindersOSX"
+$inventoryMethod = "github-repository-settings-installed-github-apps-owner-confirmation"
+
+function Resolve-RequiredFile([string]$Path, [string]$Label) {
+    if (-not (Test-Path -LiteralPath $Path -PathType Leaf)) {
+        throw "$Label does not exist: $Path"
+    }
+    return (Resolve-Path -LiteralPath $Path).Path
+}
+
+function Get-TextSha256([string]$Value) {
+    $algorithm = [Security.Cryptography.SHA256]::Create()
+    try {
+        $bytes = [Text.UTF8Encoding]::new($false).GetBytes($Value)
+        return ([BitConverter]::ToString($algorithm.ComputeHash($bytes)) -replace '-', '').ToLowerInvariant()
+    }
+    finally {
+        $algorithm.Dispose()
+    }
+}
+
+foreach ($confirmation in @(
+    $ConfirmNoIndependentNativeLicenseReview,
+    $ConfirmCorrespondingSourceNotIndependentlyReviewed,
+    $AcknowledgeKnownProvenanceLimits,
+    $ConfirmNoGitHubAppsInstalledForRepository
+)) {
+    if (-not $confirmation) {
+        throw "Every explicit unreviewed-Beta confirmation is required before a declaration can be created."
+    }
+}
+
+$pubspecText = Get-Content -Raw -LiteralPath (Join-Path $repositoryRoot "pubspec.yaml")
+$versionMatch = [regex]::Match(
+    $pubspecText,
+    '(?m)^version:\s*(2\.\d+\.\d+)\+\d+\s*$'
+)
+if (-not $versionMatch.Success) {
+    throw "pubspec.yaml does not contain a supported Beta 2.x release version."
+}
+$releaseTag = "v$($versionMatch.Groups[1].Value)"
+
+$resolvedApk = Resolve-RequiredFile $ApkPath "Release APK"
+$resolvedNativeSource = Resolve-RequiredFile $NativeSourcePath "Native source bundle"
+$resolvedManifest = Resolve-RequiredFile $manifestPath "Native playback manifest"
+$resolvedNotice = Resolve-RequiredFile $noticePath "Native playback notice"
+
+$expectedApkName = "TetoTV-$releaseTag-universal.apk"
+$expectedNativeSourceName = "TetoTV-$releaseTag-native-playback-sources.zip"
+if ([IO.Path]::GetFileName($resolvedApk) -cne $expectedApkName) {
+    throw "Expected APK name '$expectedApkName'."
+}
+if ([IO.Path]::GetFileName($resolvedNativeSource) -cne $expectedNativeSourceName) {
+    throw "Expected native source bundle name '$expectedNativeSourceName'."
+}
+
+$resolvedOutput = [IO.Path]::GetFullPath($OutputPath)
+$allowedRoot = [IO.Path]::GetFullPath((Join-Path $repositoryRoot "build\release-compliance"))
+if (-not $resolvedOutput.StartsWith(
+    $allowedRoot + [IO.Path]::DirectorySeparatorChar,
+    [StringComparison]::OrdinalIgnoreCase
+)) {
+    throw "OutputPath must be a child of $allowedRoot."
+}
+if (Test-Path -LiteralPath $resolvedOutput) {
+    throw "Refusing to overwrite an existing unreviewed Beta declaration: $resolvedOutput"
+}
+
+Push-Location $repositoryRoot
+try {
+    if (git status --porcelain) {
+        throw "The working tree must be clean before creating an unreviewed Beta declaration."
+    }
+    $gitCommit = (& git rev-parse HEAD).Trim()
+    if ($LASTEXITCODE -ne 0 -or $gitCommit -notmatch '^[0-9a-f]{40}$') {
+        throw "Could not resolve the declared Git commit."
+    }
+    $tagCommit = (& git rev-list -n 1 $releaseTag 2>$null).Trim()
+    if ($LASTEXITCODE -ne 0 -or $tagCommit -cne $gitCommit) {
+        throw "Local Beta release tag $releaseTag must resolve to the declared Git commit."
+    }
+}
+finally {
+    Pop-Location
+}
+
+& (Join-Path $PSScriptRoot "verify_native_redistribution.ps1") `
+    -BundlePath $resolvedNativeSource `
+    -RequireResolvedBinaries
+
+$manifest = Get-Content -Raw -LiteralPath $resolvedManifest | ConvertFrom-Json
+$knownLimits = @($manifest.knownProvenanceLimits | ForEach-Object { [string]$_ })
+if ($knownLimits.Count -eq 0) {
+    throw "native_playback_manifest.json must record at least one provenance limitation."
+}
+$limitsText = ($knownLimits -join "`n") + "`n"
+$limitsHash = Get-TextSha256 $limitsText
+$declaredAtUtc = [DateTimeOffset]::UtcNow.ToString("yyyy-MM-dd'T'HH:mm:ss'Z'")
+
+$declaration = [ordered]@{
+    schemaVersion = 1
+    statementType = "tetotv-unreviewed-beta-release-declaration"
+    releaseTag = $releaseTag
+    gitCommit = $gitCommit
+    declaredAtUtc = $declaredAtUtc
+    operatorIdentity = $operatorIdentity
+    independentNativeLicenseReview = $false
+    correspondingSourceIndependentlyReviewed = $false
+    knownProvenanceLimitsAcknowledged = $true
+    knownProvenanceLimitsSha256 = $limitsHash
+    githubAppInventory = [ordered]@{
+        repository = $repository
+        checkedAtUtc = $declaredAtUtc
+        reviewMethod = $inventoryMethod
+        inventoryComplete = $true
+        installations = @()
+    }
+    artifacts = [ordered]@{
+        apkSha256 = (Get-FileHash -Algorithm SHA256 -LiteralPath $resolvedApk).Hash.ToLowerInvariant()
+        nativeSourceSha256 = (Get-FileHash -Algorithm SHA256 -LiteralPath $resolvedNativeSource).Hash.ToLowerInvariant()
+        nativeManifestSha256 = (Get-FileHash -Algorithm SHA256 -LiteralPath $resolvedManifest).Hash.ToLowerInvariant()
+        nativePlaybackNoticeSha256 = (Get-FileHash -Algorithm SHA256 -LiteralPath $resolvedNotice).Hash.ToLowerInvariant()
+    }
+}
+
+$outputDirectory = Split-Path -Parent $resolvedOutput
+if (-not (Test-Path -LiteralPath $outputDirectory -PathType Container)) {
+    New-Item -ItemType Directory -Path $outputDirectory -Force | Out-Null
+}
+$json = ($declaration | ConvertTo-Json -Depth 5) + "`n"
+[IO.File]::WriteAllText($resolvedOutput, $json, [Text.UTF8Encoding]::new($false))
+
+Write-Host "Created unsigned unreviewed Beta release declaration"
+Write-Host "  Declaration: $resolvedOutput"
+Write-Host "  Operator:    $operatorIdentity"
+Write-Host "  Release tag: $releaseTag"
+Write-Host "  Git commit:  $gitCommit"
+Write-Host "  Declared at: $declaredAtUtc"
+Write-Warning "This declaration explicitly records that no independent native-license or corresponding-source review was performed."
+Write-Warning "It is not an approval, a legal-compliance determination, or a substitute for qualified review."
+Write-Host "No private key, signature, credential, or other private material was requested or written."

--- a/tool/release/publish_beta_release.ps1
+++ b/tool/release/publish_beta_release.ps1
@@ -15,6 +15,12 @@ param(
 
     [string]$NativeLicenseReviewSignaturePath = "",
 
+    [string]$UnreviewedBetaDeclarationPath = "",
+
+    [switch]$PublishWithoutIndependentNativeLicenseReview,
+
+    [string]$UnreviewedBetaAcknowledgement = "",
+
     [switch]$Publish
 )
 
@@ -33,6 +39,15 @@ if (-not [string]::IsNullOrWhiteSpace($NativeLicenseReviewPath)) {
 }
 if (-not [string]::IsNullOrWhiteSpace($NativeLicenseReviewSignaturePath)) {
     $arguments.NativeLicenseReviewSignaturePath = $NativeLicenseReviewSignaturePath
+}
+if (-not [string]::IsNullOrWhiteSpace($UnreviewedBetaDeclarationPath)) {
+    $arguments.UnreviewedBetaDeclarationPath = $UnreviewedBetaDeclarationPath
+}
+if ($PublishWithoutIndependentNativeLicenseReview) {
+    $arguments.PublishWithoutIndependentNativeLicenseReview = $true
+}
+if (-not [string]::IsNullOrWhiteSpace($UnreviewedBetaAcknowledgement)) {
+    $arguments.UnreviewedBetaAcknowledgement = $UnreviewedBetaAcknowledgement
 }
 
 & (Join-Path $PSScriptRoot "publish_release.ps1") @arguments

--- a/tool/release/publish_release.ps1
+++ b/tool/release/publish_release.ps1
@@ -19,6 +19,12 @@ param(
 
     [string]$NativeLicenseReviewSignaturePath = "",
 
+    [string]$UnreviewedBetaDeclarationPath = "",
+
+    [switch]$PublishWithoutIndependentNativeLicenseReview,
+
+    [string]$UnreviewedBetaAcknowledgement = "",
+
     [switch]$Publish
 )
 
@@ -46,14 +52,71 @@ if ($versionMajor -ne $expectedMajor) {
 $releaseTag = "v$versionName"
 $repository = "LindersOSX/TetoTV-Beta"
 $releaseTitle = "TetoTV $versionName Beta - Android TV / Google TV / Fire TV"
+$unreviewedBetaAcknowledgementText = "PUBLISH UNREVIEWED BETA"
+$unreviewedBetaStatusMarker = "<!-- tetotv-native-license-review-status: unreviewed-beta -->"
+$unreviewedBetaDisclosureText = "No independent native-license review: This Beta has not received independent native-library licensing review. Automated checks verify the APK, native-source bundle, notices, pinned inputs, and checksums, but do not establish legal compliance or reproducible builds."
+$unreviewedBetaVisibleWarningPrefix = "# TetoTV $versionName Beta`n`n> [!WARNING]`n> $unreviewedBetaDisclosureText`n"
 if ([string]::IsNullOrWhiteSpace($ReleaseNotesPath)) {
     $ReleaseNotesPath = Join-Path $repositoryRoot "docs\RELEASE_NOTES_$versionName.md"
+}
+
+$releaseEvidenceMode = if ($PublishWithoutIndependentNativeLicenseReview) {
+    "UnreviewedBeta"
+}
+else {
+    "Reviewed"
+}
+if ($releaseEvidenceMode -ceq "UnreviewedBeta") {
+    if (
+        -not [string]::Equals(
+            $UnreviewedBetaAcknowledgement,
+            $unreviewedBetaAcknowledgementText,
+            [StringComparison]::Ordinal
+        )
+    ) {
+        throw "Unreviewed Beta publication requires the exact acknowledgement '$unreviewedBetaAcknowledgementText'."
+    }
+    if (
+        -not [string]::IsNullOrWhiteSpace($NativeLicenseReviewPath) -or
+        -not [string]::IsNullOrWhiteSpace($NativeLicenseReviewSignaturePath)
+    ) {
+        throw "Reviewed native-license evidence and the unreviewed Beta exception are mutually exclusive."
+    }
+}
+elseif (
+    -not [string]::IsNullOrWhiteSpace($UnreviewedBetaDeclarationPath) -or
+    -not [string]::IsNullOrWhiteSpace($UnreviewedBetaAcknowledgement)
+) {
+    throw "Unreviewed Beta inputs require -PublishWithoutIndependentNativeLicenseReview."
 }
 
 $resolvedApk = (Resolve-Path -LiteralPath $ApkPath).Path
 $resolvedNativeSource = (Resolve-Path -LiteralPath $NativeSourcePath).Path
 $resolvedChecksums = (Resolve-Path -LiteralPath $ChecksumsPath).Path
 $resolvedNotes = (Resolve-Path -LiteralPath $ReleaseNotesPath).Path
+$sourceNotesText = [IO.File]::ReadAllText($resolvedNotes)
+$normalizedSourceNotesText = $sourceNotesText.Replace("`r`n", "`n")
+if ($sourceNotesText -match '(?im)<!--\s*tetotv-(?:native-license-review-(?:sha256|attestation-base64|signature-base64|status)|unreviewed-beta-declaration-(?:sha256|base64)):') {
+    throw "The source release-notes file must not contain publisher-added native-license evidence markers."
+}
+$sourceDisclosureCount = @([regex]::Matches(
+    $sourceNotesText,
+    [regex]::Escape($unreviewedBetaDisclosureText)
+)).Count
+if ($releaseEvidenceMode -ceq "UnreviewedBeta") {
+    if (
+        $sourceDisclosureCount -ne 1 -or
+        -not $normalizedSourceNotesText.StartsWith(
+            $unreviewedBetaVisibleWarningPrefix,
+            [StringComparison]::Ordinal
+        )
+    ) {
+        throw "Unreviewed Beta source release notes must begin with the exact visible warning block."
+    }
+}
+elseif ($sourceDisclosureCount -ne 0) {
+    throw "Reviewed release notes must not claim that independent native-license review was not performed."
+}
 
 & (Join-Path $PSScriptRoot "verify_release_payloads.ps1") `
     -Channel $Channel `
@@ -226,18 +289,11 @@ function Get-GitHubApiJson([string]$Path) {
 function Assert-GitHubReleaseAuthorityBoundary(
     [string]$Repository,
     [string]$ExpectedOwner,
-    [string]$SignedReviewAttestationPath
+    [object]$GitHubAppInventory
 ) {
-    try {
-        $signedReview = Get-Content -Raw -LiteralPath $SignedReviewAttestationPath |
-            ConvertFrom-Json
-    }
-    catch {
-        throw "Could not read the already verified signed release-authority review evidence."
-    }
-    $appInventory = $signedReview.githubAppInventory
+    $appInventory = $GitHubAppInventory
     if ($null -eq $appInventory) {
-        throw "The signed release-authority review is missing its GitHub App inventory."
+        throw "The verified release evidence is missing its GitHub App inventory."
     }
     $appInventoryProperties = @($appInventory.PSObject.Properties.Name | Sort-Object)
     $expectedAppInventoryProperties = @(
@@ -254,7 +310,12 @@ function Assert-GitHubReleaseAuthorityBoundary(
         $appInventory.inventoryComplete -ne $true -or
         @($appInventory.installations).Count -ne 0
     ) {
-        throw "The signed release-authority review must contain a complete empty GitHub App inventory for $Repository."
+        throw "The verified release evidence must contain a complete empty GitHub App inventory for $Repository."
+    }
+
+    $authenticatedUser = Get-GitHubApiJson "user"
+    if ([string]$authenticatedUser.login -cne $ExpectedOwner) {
+        throw "The authenticated GitHub publisher must be exactly $ExpectedOwner."
     }
 
     $metadata = Get-GitHubApiJson "repos/$Repository"
@@ -279,6 +340,13 @@ function Assert-GitHubReleaseAuthorityBoundary(
     if (@(Get-GitHubApiJson "repos/$Repository/invitations").Count -ne 0) {
         throw "Publication is blocked while repository collaborator invitations are pending."
     }
+    if (@(Get-GitHubApiJson "repos/$Repository/hooks").Count -ne 0) {
+        throw "Publication is blocked while a repository webhook is configured."
+    }
+    $runners = Get-GitHubApiJson "repos/$Repository/actions/runners"
+    if ([long]$runners.total_count -ne 0 -or @($runners.runners).Count -ne 0) {
+        throw "Publication is blocked while a self-hosted repository runner is registered."
+    }
     $writeDeployKeys = @(
         @(Get-GitHubApiJson "repos/$Repository/keys") |
             Where-Object { -not [bool]$_.read_only }
@@ -299,6 +367,20 @@ function Assert-GitHubReleaseAuthorityBoundary(
     ) {
         throw "GitHub Actions must allow only selected actions and require full commit-SHA pins before publication."
     }
+    $selectedActionsPolicy = Get-GitHubApiJson "repos/$Repository/actions/permissions/selected-actions"
+    $expectedExternalActionPatterns = @(
+        "android-actions/setup-android@*",
+        "subosito/flutter-action@*"
+    ) | Sort-Object
+    $actualExternalActionPatterns = @($selectedActionsPolicy.patterns_allowed | Sort-Object)
+    if (
+        -not [bool]$selectedActionsPolicy.github_owned_allowed -or
+        [bool]$selectedActionsPolicy.verified_allowed -or
+        $actualExternalActionPatterns.Count -ne $expectedExternalActionPatterns.Count -or
+        (Compare-Object $expectedExternalActionPatterns $actualExternalActionPatterns)
+    ) {
+        throw "GitHub Actions must allow GitHub-owned actions plus only the two pinned external setup actions required by the hosted verifier."
+    }
     $workflowPermissions = Get-GitHubApiJson "repos/$Repository/actions/permissions/workflow"
     if (
         [string]$workflowPermissions.default_workflow_permissions -cne "read" -or
@@ -316,7 +398,8 @@ function Assert-GitHubRelease {
         [string]$ExpectedTagCommit,
         [object[]]$ExpectedAssets,
         [string]$BuildCode,
-        [string]$NativeLicenseReviewSha256,
+        [string]$NativeLicenseReviewSha256 = "",
+        [string]$UnreviewedBetaDeclarationSha256 = "",
         [bool]$ExpectedDraft
     )
 
@@ -334,38 +417,99 @@ function Assert-GitHubRelease {
     if (@([regex]::Matches([string]$release.body, [regex]::Escape($buildMarker))).Count -ne 1) {
         throw "Release notes do not contain the exact Android build-code marker once."
     }
-    $reviewMarker = "<!-- tetotv-native-license-review-sha256: $NativeLicenseReviewSha256 -->"
-    if (@([regex]::Matches([string]$release.body, [regex]::Escape($reviewMarker))).Count -ne 1) {
-        throw "Release notes do not contain the exact native-license review digest marker once."
+    $hasReviewedEvidence = -not [string]::IsNullOrWhiteSpace($NativeLicenseReviewSha256)
+    $hasUnreviewedEvidence = -not [string]::IsNullOrWhiteSpace($UnreviewedBetaDeclarationSha256)
+    if ($hasReviewedEvidence -eq $hasUnreviewedEvidence) {
+        throw "Release verification requires exactly one native-license evidence mode."
     }
-    if (@([regex]::Matches([string]$release.body, '(?im)<!--\s*tetotv-native-license-review-sha256:')).Count -ne 1) {
-        throw "Release notes contain an unexpected native-license review marker."
-    }
-    $attestationEvidenceMatches = @([regex]::Matches(
-        [string]$release.body,
-        '(?im)<!--\s*tetotv-native-license-review-attestation-base64:\s*(?<data>[A-Za-z0-9+/]+={0,2})\s*-->'
-    ))
-    if (
-        $attestationEvidenceMatches.Count -ne 1 -or
-        @([regex]::Matches(
+    $attestationEvidenceMatches = @()
+    $signatureEvidenceMatches = @()
+    $unreviewedDeclarationMatches = @()
+    if ($hasReviewedEvidence) {
+        $normalizedReleaseBody = ([string]$release.body).Replace("`r`n", "`n")
+        if (@([regex]::Matches($normalizedReleaseBody, [regex]::Escape($unreviewedBetaDisclosureText))).Count -ne 0) {
+            throw "Reviewed release notes must not claim that independent native-license review was not performed."
+        }
+        $reviewMarker = "<!-- tetotv-native-license-review-sha256: $NativeLicenseReviewSha256 -->"
+        if (@([regex]::Matches([string]$release.body, [regex]::Escape($reviewMarker))).Count -ne 1) {
+            throw "Release notes do not contain the exact native-license review digest marker once."
+        }
+        if (@([regex]::Matches([string]$release.body, '(?im)<!--\s*tetotv-native-license-review-sha256:')).Count -ne 1) {
+            throw "Release notes contain an unexpected native-license review marker."
+        }
+        $attestationEvidenceMatches = @([regex]::Matches(
             [string]$release.body,
-            '(?im)<!--\s*tetotv-native-license-review-attestation-base64:'
-        )).Count -ne 1
-    ) {
-        throw "Release notes must contain exactly one encoded native-license review attestation."
-    }
-    $signatureEvidenceMatches = @([regex]::Matches(
-        [string]$release.body,
-        '(?im)<!--\s*tetotv-native-license-review-signature-base64:\s*(?<data>[A-Za-z0-9+/]+={0,2})\s*-->'
-    ))
-    if (
-        $signatureEvidenceMatches.Count -ne 1 -or
-        @([regex]::Matches(
+            '(?im)<!--\s*tetotv-native-license-review-attestation-base64:\s*(?<data>[A-Za-z0-9+/]+={0,2})\s*-->'
+        ))
+        if (
+            $attestationEvidenceMatches.Count -ne 1 -or
+            @([regex]::Matches(
+                [string]$release.body,
+                '(?im)<!--\s*tetotv-native-license-review-attestation-base64:'
+            )).Count -ne 1
+        ) {
+            throw "Release notes must contain exactly one encoded native-license review attestation."
+        }
+        $signatureEvidenceMatches = @([regex]::Matches(
             [string]$release.body,
-            '(?im)<!--\s*tetotv-native-license-review-signature-base64:'
-        )).Count -ne 1
-    ) {
-        throw "Release notes must contain exactly one encoded native-license review signature."
+            '(?im)<!--\s*tetotv-native-license-review-signature-base64:\s*(?<data>[A-Za-z0-9+/]+={0,2})\s*-->'
+        ))
+        if (
+            $signatureEvidenceMatches.Count -ne 1 -or
+            @([regex]::Matches(
+                [string]$release.body,
+                '(?im)<!--\s*tetotv-native-license-review-signature-base64:'
+            )).Count -ne 1
+        ) {
+            throw "Release notes must contain exactly one encoded native-license review signature."
+        }
+        if ([string]$release.body -match '(?im)tetotv-(?:native-license-review-status:\s*unreviewed-beta|unreviewed-beta-declaration-)') {
+            throw "Reviewed release notes must not contain unreviewed Beta evidence."
+        }
+    }
+    else {
+        $normalizedReleaseBody = ([string]$release.body).Replace("`r`n", "`n")
+        if ($UnreviewedBetaDeclarationSha256 -notmatch '^[0-9a-f]{64}$') {
+            throw "Unreviewed Beta declaration digest must be lowercase SHA-256."
+        }
+        if ([string]$release.body -match '(?im)<!--\s*tetotv-native-license-review-(?:sha256|attestation-base64|signature-base64):') {
+            throw "Unreviewed Beta release notes must not contain qualified-review evidence."
+        }
+        if (@([regex]::Matches([string]$release.body, [regex]::Escape($unreviewedBetaStatusMarker))).Count -ne 1) {
+            throw "Unreviewed Beta release notes must contain the exact status marker once."
+        }
+        if (@([regex]::Matches([string]$release.body, '(?im)<!--\s*tetotv-native-license-review-status:')).Count -ne 1) {
+            throw "Unreviewed Beta release notes contain an unexpected review-status marker."
+        }
+        if (
+            @([regex]::Matches($normalizedReleaseBody, [regex]::Escape($unreviewedBetaDisclosureText))).Count -ne 1 -or
+            -not $normalizedReleaseBody.StartsWith(
+                $unreviewedBetaVisibleWarningPrefix,
+                [StringComparison]::Ordinal
+            )
+        ) {
+            throw "Unreviewed Beta release notes must begin with the exact visible warning block."
+        }
+        $declarationMarker = "<!-- tetotv-unreviewed-beta-declaration-sha256: $UnreviewedBetaDeclarationSha256 -->"
+        if (@([regex]::Matches([string]$release.body, [regex]::Escape($declarationMarker))).Count -ne 1) {
+            throw "Release notes do not contain the exact unreviewed Beta declaration digest once."
+        }
+        if (@([regex]::Matches([string]$release.body, '(?im)<!--\s*tetotv-unreviewed-beta-declaration-sha256:')).Count -ne 1) {
+            throw "Release notes contain an unexpected unreviewed Beta declaration marker."
+        }
+        $unreviewedDeclarationMatches = @([regex]::Matches(
+            [string]$release.body,
+            '(?im)<!--\s*tetotv-unreviewed-beta-declaration-base64:\s*(?<data>[A-Za-z0-9+/]+={0,2})\s*-->'
+        ))
+        if (
+            $unreviewedDeclarationMatches.Count -ne 1 -or
+            @([regex]::Matches(
+                [string]$release.body,
+                '(?im)<!--\s*tetotv-unreviewed-beta-declaration-base64:'
+            )).Count -ne 1
+        ) {
+            throw "Release notes must contain exactly one encoded unreviewed Beta declaration."
+        }
     }
     foreach ($expected in $ExpectedAssets) {
         if (-not ([string]$release.body).Contains($expected.Name)) {
@@ -420,45 +564,80 @@ function Assert-GitHubRelease {
             [string]$release.body,
             [Text.UTF8Encoding]::new($false)
         )
-        $downloadedAttestationPath = Join-Path $downloadRoot "native-license-review.json"
-        $downloadedSignaturePath = Join-Path $downloadRoot "native-license-review.json.sig"
-        try {
-            [IO.File]::WriteAllBytes(
-                $downloadedAttestationPath,
-                [Convert]::FromBase64String(
-                    $attestationEvidenceMatches[0].Groups['data'].Value
+        if ($hasReviewedEvidence) {
+            $downloadedAttestationPath = Join-Path $downloadRoot "native-license-review.json"
+            $downloadedSignaturePath = Join-Path $downloadRoot "native-license-review.json.sig"
+            try {
+                [IO.File]::WriteAllBytes(
+                    $downloadedAttestationPath,
+                    [Convert]::FromBase64String(
+                        $attestationEvidenceMatches[0].Groups['data'].Value
+                    )
                 )
-            )
-            [IO.File]::WriteAllBytes(
-                $downloadedSignaturePath,
-                [Convert]::FromBase64String(
-                    $signatureEvidenceMatches[0].Groups['data'].Value
+                [IO.File]::WriteAllBytes(
+                    $downloadedSignaturePath,
+                    [Convert]::FromBase64String(
+                        $signatureEvidenceMatches[0].Groups['data'].Value
+                    )
                 )
-            )
+            }
+            catch {
+                throw "Release notes contain invalid encoded native-license review evidence."
+            }
+            $downloadedAttestationSha256 = (
+                Get-FileHash -Algorithm SHA256 -LiteralPath $downloadedAttestationPath
+            ).Hash.ToLowerInvariant()
+            if ($downloadedAttestationSha256 -cne $NativeLicenseReviewSha256) {
+                throw "Encoded native-license review attestation does not match its digest marker."
+            }
+            & (Join-Path $PSScriptRoot "verify_native_license_review.ps1") `
+                -AttestationPath $downloadedAttestationPath `
+                -SignaturePath $downloadedSignaturePath `
+                -ReleaseTag $Tag `
+                -GitCommit $ExpectedTagCommit `
+                -ApkPath (Join-Path $downloadRoot ([IO.Path]::GetFileName($resolvedApk))) `
+                -NativeSourcePath (Join-Path $downloadRoot ([IO.Path]::GetFileName($resolvedNativeSource)))
+            & (Join-Path $PSScriptRoot "verify_release_payloads.ps1") `
+                -Channel $Channel `
+                -ApkPath (Join-Path $downloadRoot ([IO.Path]::GetFileName($resolvedApk))) `
+                -NativeSourcePath (Join-Path $downloadRoot ([IO.Path]::GetFileName($resolvedNativeSource))) `
+                -ChecksumsPath (Join-Path $downloadRoot ([IO.Path]::GetFileName($resolvedChecksums))) `
+                -ReleaseNotesPath $downloadedNotesPath `
+                -NativeLicenseReviewSha256 $NativeLicenseReviewSha256
         }
-        catch {
-            throw "Release notes contain invalid encoded native-license review evidence."
+        else {
+            $downloadedDeclarationPath = Join-Path $downloadRoot "unreviewed-beta-release-declaration.json"
+            try {
+                [IO.File]::WriteAllBytes(
+                    $downloadedDeclarationPath,
+                    [Convert]::FromBase64String(
+                        $unreviewedDeclarationMatches[0].Groups['data'].Value
+                    )
+                )
+            }
+            catch {
+                throw "Release notes contain invalid encoded unreviewed Beta evidence."
+            }
+            $downloadedDeclarationSha256 = (
+                Get-FileHash -Algorithm SHA256 -LiteralPath $downloadedDeclarationPath
+            ).Hash.ToLowerInvariant()
+            if ($downloadedDeclarationSha256 -cne $UnreviewedBetaDeclarationSha256) {
+                throw "Encoded unreviewed Beta declaration does not match its digest marker."
+            }
+            & (Join-Path $PSScriptRoot "verify_unreviewed_beta_release_declaration.ps1") `
+                -DeclarationPath $downloadedDeclarationPath `
+                -ReleaseTag $Tag `
+                -GitCommit $ExpectedTagCommit `
+                -ApkPath (Join-Path $downloadRoot ([IO.Path]::GetFileName($resolvedApk))) `
+                -NativeSourcePath (Join-Path $downloadRoot ([IO.Path]::GetFileName($resolvedNativeSource)))
+            & (Join-Path $PSScriptRoot "verify_release_payloads.ps1") `
+                -Channel $Channel `
+                -ApkPath (Join-Path $downloadRoot ([IO.Path]::GetFileName($resolvedApk))) `
+                -NativeSourcePath (Join-Path $downloadRoot ([IO.Path]::GetFileName($resolvedNativeSource))) `
+                -ChecksumsPath (Join-Path $downloadRoot ([IO.Path]::GetFileName($resolvedChecksums))) `
+                -ReleaseNotesPath $downloadedNotesPath `
+                -UnreviewedBetaDeclarationSha256 $UnreviewedBetaDeclarationSha256
         }
-        $downloadedAttestationSha256 = (
-            Get-FileHash -Algorithm SHA256 -LiteralPath $downloadedAttestationPath
-        ).Hash.ToLowerInvariant()
-        if ($downloadedAttestationSha256 -cne $NativeLicenseReviewSha256) {
-            throw "Encoded native-license review attestation does not match its digest marker."
-        }
-        & (Join-Path $PSScriptRoot "verify_native_license_review.ps1") `
-            -AttestationPath $downloadedAttestationPath `
-            -SignaturePath $downloadedSignaturePath `
-            -ReleaseTag $Tag `
-            -GitCommit $ExpectedTagCommit `
-            -ApkPath (Join-Path $downloadRoot ([IO.Path]::GetFileName($resolvedApk))) `
-            -NativeSourcePath (Join-Path $downloadRoot ([IO.Path]::GetFileName($resolvedNativeSource)))
-        & (Join-Path $PSScriptRoot "verify_release_payloads.ps1") `
-            -Channel $Channel `
-            -ApkPath (Join-Path $downloadRoot ([IO.Path]::GetFileName($resolvedApk))) `
-            -NativeSourcePath (Join-Path $downloadRoot ([IO.Path]::GetFileName($resolvedNativeSource))) `
-            -ChecksumsPath (Join-Path $downloadRoot ([IO.Path]::GetFileName($resolvedChecksums))) `
-            -ReleaseNotesPath $downloadedNotesPath `
-            -NativeLicenseReviewSha256 $NativeLicenseReviewSha256
     }
     finally {
         $safeTempRoot = [IO.Path]::GetFullPath([IO.Path]::GetTempPath())
@@ -492,14 +671,28 @@ foreach ($asset in $expectedAssets) {
 
 if (-not $Publish) {
     Write-Host "Dry run only. No GitHub changes were made."
-    Write-Host "Publication additionally requires an SSH-signed, allowlisted native-license review attestation bound to the final tag, commit, APK, source ZIP, manifest, and native notice."
+    if ($releaseEvidenceMode -ceq "Reviewed") {
+        Write-Host "Reviewed publication additionally requires an SSH-signed, allowlisted native-license review attestation bound to the final tag, commit, APK, source ZIP, manifest, and native notice."
+    }
+    else {
+        Write-Warning "Unreviewed Beta mode selected. Publication requires a fresh owner declaration that explicitly records no independent native-license or corresponding-source review."
+    }
     exit 0
 }
 if (-not (Get-Command gh -ErrorAction SilentlyContinue)) {
     throw "GitHub CLI (gh) is required to publish."
 }
-if ([string]::IsNullOrWhiteSpace($NativeLicenseReviewPath)) {
-    throw "-Publish requires -NativeLicenseReviewPath. Publication fails closed without a signed qualified-reviewer attestation."
+if (
+    $releaseEvidenceMode -ceq "Reviewed" -and
+    [string]::IsNullOrWhiteSpace($NativeLicenseReviewPath)
+) {
+    throw "Reviewed publication requires -NativeLicenseReviewPath and fails closed without a signed qualified-reviewer attestation."
+}
+if (
+    $releaseEvidenceMode -ceq "UnreviewedBeta" -and
+    [string]::IsNullOrWhiteSpace($UnreviewedBetaDeclarationPath)
+) {
+    throw "Unreviewed Beta publication requires -UnreviewedBetaDeclarationPath."
 }
 
 Push-Location $repositoryRoot
@@ -512,31 +705,60 @@ try {
         throw "Could not resolve local HEAD."
     }
     Assert-TagMatchesHead $repository $releaseTag $headCommit
-    $reviewArguments = @{
-        AttestationPath = $NativeLicenseReviewPath
-        ReleaseTag = $releaseTag
-        GitCommit = $headCommit
-        ApkPath = $resolvedApk
-        NativeSourcePath = $resolvedNativeSource
+    $resolvedReview = ""
+    $resolvedReviewSignature = ""
+    $nativeLicenseReviewSha256 = ""
+    $resolvedUnreviewedDeclaration = ""
+    $unreviewedBetaDeclarationSha256 = ""
+    $githubAppInventory = $null
+    if ($releaseEvidenceMode -ceq "Reviewed") {
+        $reviewArguments = @{
+            AttestationPath = $NativeLicenseReviewPath
+            ReleaseTag = $releaseTag
+            GitCommit = $headCommit
+            ApkPath = $resolvedApk
+            NativeSourcePath = $resolvedNativeSource
+        }
+        if (-not [string]::IsNullOrWhiteSpace($NativeLicenseReviewSignaturePath)) {
+            $reviewArguments.SignaturePath = $NativeLicenseReviewSignaturePath
+        }
+        & (Join-Path $PSScriptRoot "verify_native_license_review.ps1") @reviewArguments
+        $resolvedReview = (Resolve-Path -LiteralPath $NativeLicenseReviewPath).Path
+        $reviewEvidence = Get-Content -Raw -LiteralPath $resolvedReview | ConvertFrom-Json
+        $githubAppInventory = $reviewEvidence.githubAppInventory
+        $resolvedReviewSignature = if (
+            [string]::IsNullOrWhiteSpace($NativeLicenseReviewSignaturePath)
+        ) {
+            (Resolve-Path -LiteralPath "$resolvedReview.sig").Path
+        }
+        else {
+            (Resolve-Path -LiteralPath $NativeLicenseReviewSignaturePath).Path
+        }
+        $nativeLicenseReviewSha256 = (Get-FileHash -Algorithm SHA256 -LiteralPath $resolvedReview).Hash.ToLowerInvariant()
     }
-    if (-not [string]::IsNullOrWhiteSpace($NativeLicenseReviewSignaturePath)) {
-        $reviewArguments.SignaturePath = $NativeLicenseReviewSignaturePath
+    else {
+        $unreviewedArguments = @{
+            DeclarationPath = $UnreviewedBetaDeclarationPath
+            ReleaseTag = $releaseTag
+            GitCommit = $headCommit
+            ApkPath = $resolvedApk
+            NativeSourcePath = $resolvedNativeSource
+        }
+        & (Join-Path $PSScriptRoot "verify_unreviewed_beta_release_declaration.ps1") @unreviewedArguments
+        $resolvedUnreviewedDeclaration = (
+            Resolve-Path -LiteralPath $UnreviewedBetaDeclarationPath
+        ).Path
+        $unreviewedEvidence = Get-Content -Raw -LiteralPath $resolvedUnreviewedDeclaration |
+            ConvertFrom-Json
+        $githubAppInventory = $unreviewedEvidence.githubAppInventory
+        $unreviewedBetaDeclarationSha256 = (
+            Get-FileHash -Algorithm SHA256 -LiteralPath $resolvedUnreviewedDeclaration
+        ).Hash.ToLowerInvariant()
     }
-    & (Join-Path $PSScriptRoot "verify_native_license_review.ps1") @reviewArguments
-    $resolvedReview = (Resolve-Path -LiteralPath $NativeLicenseReviewPath).Path
     Assert-GitHubReleaseAuthorityBoundary `
         -Repository $repository `
         -ExpectedOwner "LindersOSX" `
-        -SignedReviewAttestationPath $resolvedReview
-    $resolvedReviewSignature = if (
-        [string]::IsNullOrWhiteSpace($NativeLicenseReviewSignaturePath)
-    ) {
-        (Resolve-Path -LiteralPath "$resolvedReview.sig").Path
-    }
-    else {
-        (Resolve-Path -LiteralPath $NativeLicenseReviewSignaturePath).Path
-    }
-    $nativeLicenseReviewSha256 = (Get-FileHash -Algorithm SHA256 -LiteralPath $resolvedReview).Hash.ToLowerInvariant()
+        -GitHubAppInventory $githubAppInventory
 
     if ($null -ne (Get-GitHubRelease $repository $releaseTag -AllowMissing)) {
         throw "Release $releaseTag already exists in $repository."
@@ -566,31 +788,53 @@ try {
         }
     }
 
-    $notesText = [IO.File]::ReadAllText($resolvedNotes)
-    if ($notesText -match '(?im)<!--\s*tetotv-native-license-review-(?:sha256|attestation-base64|signature-base64):') {
-        throw "The source release-notes file must not contain native-license review markers; the publisher adds verified evidence."
+    $notesText = $sourceNotesText
+    if ($releaseEvidenceMode -ceq "Reviewed") {
+        $reviewMarker = "<!-- tetotv-native-license-review-sha256: $nativeLicenseReviewSha256 -->"
+        $reviewAttestationBase64 = [Convert]::ToBase64String(
+            [IO.File]::ReadAllBytes($resolvedReview)
+        )
+        $reviewSignatureBase64 = [Convert]::ToBase64String(
+            [IO.File]::ReadAllBytes($resolvedReviewSignature)
+        )
+        $reviewAttestationMarker = "<!-- tetotv-native-license-review-attestation-base64: $reviewAttestationBase64 -->"
+        $reviewSignatureMarker = "<!-- tetotv-native-license-review-signature-base64: $reviewSignatureBase64 -->"
+        $verifiedReleaseNotes = (
+            $notesText.TrimEnd() + "`n`n" +
+            $reviewMarker + "`n" +
+            $reviewAttestationMarker + "`n" +
+            $reviewSignatureMarker + "`n"
+        )
     }
-    $reviewMarker = "<!-- tetotv-native-license-review-sha256: $nativeLicenseReviewSha256 -->"
-    $reviewAttestationBase64 = [Convert]::ToBase64String(
-        [IO.File]::ReadAllBytes($resolvedReview)
-    )
-    $reviewSignatureBase64 = [Convert]::ToBase64String(
-        [IO.File]::ReadAllBytes($resolvedReviewSignature)
-    )
-    $reviewAttestationMarker = "<!-- tetotv-native-license-review-attestation-base64: $reviewAttestationBase64 -->"
-    $reviewSignatureMarker = "<!-- tetotv-native-license-review-signature-base64: $reviewSignatureBase64 -->"
-    $releaseNotesWithReview = (
-        $notesText.TrimEnd() + "`n`n" +
-        $reviewMarker + "`n" +
-        $reviewAttestationMarker + "`n" +
-        $reviewSignatureMarker + "`n"
-    )
+    else {
+        $normalizedNotesText = $notesText.Replace("`r`n", "`n")
+        if (
+            @([regex]::Matches($normalizedNotesText, [regex]::Escape($unreviewedBetaDisclosureText))).Count -ne 1 -or
+            -not $normalizedNotesText.StartsWith(
+                $unreviewedBetaVisibleWarningPrefix,
+                [StringComparison]::Ordinal
+            )
+        ) {
+            throw "The source release notes must begin with the exact visible unreviewed Beta warning block."
+        }
+        $declarationMarker = "<!-- tetotv-unreviewed-beta-declaration-sha256: $unreviewedBetaDeclarationSha256 -->"
+        $declarationBase64 = [Convert]::ToBase64String(
+            [IO.File]::ReadAllBytes($resolvedUnreviewedDeclaration)
+        )
+        $declarationEvidenceMarker = "<!-- tetotv-unreviewed-beta-declaration-base64: $declarationBase64 -->"
+        $verifiedReleaseNotes = (
+            $notesText.TrimEnd() + "`n`n" +
+            $unreviewedBetaStatusMarker + "`n" +
+            $declarationMarker + "`n" +
+            $declarationEvidenceMarker + "`n"
+        )
+    }
     $releaseTempRoot = Join-Path ([IO.Path]::GetTempPath()) ("tetotv-release-notes-" + [Guid]::NewGuid().ToString('N'))
     New-Item -ItemType Directory -Path $releaseTempRoot | Out-Null
     $verifiedNotesPath = Join-Path $releaseTempRoot "RELEASE_NOTES.md"
     [IO.File]::WriteAllText(
         $verifiedNotesPath,
-        $releaseNotesWithReview,
+        $verifiedReleaseNotes,
         [Text.UTF8Encoding]::new($false)
     )
 
@@ -618,6 +862,7 @@ try {
             -ExpectedAssets $expectedAssets `
             -BuildCode $buildCode `
             -NativeLicenseReviewSha256 $nativeLicenseReviewSha256 `
+            -UnreviewedBetaDeclarationSha256 $unreviewedBetaDeclarationSha256 `
             -ExpectedDraft $true
 
         Invoke-GitHubCli -Arguments @(
@@ -636,6 +881,7 @@ try {
             -ExpectedAssets $expectedAssets `
             -BuildCode $buildCode `
             -NativeLicenseReviewSha256 $nativeLicenseReviewSha256 `
+            -UnreviewedBetaDeclarationSha256 $unreviewedBetaDeclarationSha256 `
             -ExpectedDraft $false
     }
     catch {

--- a/tool/release/verify_native_redistribution.ps1
+++ b/tool/release/verify_native_redistribution.ps1
@@ -554,4 +554,4 @@ try {
 Test-NativeSourceBundle $bundlePath
 Write-Host "Staged native redistribution bundle: $bundlePath"
 Write-Host "SHA-256: $((Get-FileHash -Algorithm SHA256 -LiteralPath $bundlePath).Hash.ToLowerInvariant())"
-Write-Warning "A qualified release reviewer must resolve the manifest's provenance limits and verify complete corresponding source before publishing."
+Write-Warning "Public and reviewed Beta releases require a qualified reviewer to resolve the manifest's provenance limits and verify complete corresponding source. An explicit unreviewed Beta must disclose that this review was not performed and must not claim compliance."

--- a/tool/release/verify_release_payloads.ps1
+++ b/tool/release/verify_release_payloads.ps1
@@ -18,7 +18,9 @@ param(
 
     [string]$ResolvedBinaryDirectory = "",
 
-    [string]$NativeLicenseReviewSha256 = ""
+    [string]$NativeLicenseReviewSha256 = "",
+
+    [string]$UnreviewedBetaDeclarationSha256 = ""
 )
 
 $ErrorActionPreference = "Stop"
@@ -120,7 +122,12 @@ foreach ($assetName in @($expectedApkName, $expectedNativeSourceName, $expectedC
         throw "Release notes must name the exact release asset '$assetName'."
     }
 }
-if (-not [string]::IsNullOrWhiteSpace($NativeLicenseReviewSha256)) {
+$hasReviewedEvidence = -not [string]::IsNullOrWhiteSpace($NativeLicenseReviewSha256)
+$hasUnreviewedEvidence = -not [string]::IsNullOrWhiteSpace($UnreviewedBetaDeclarationSha256)
+if ($hasReviewedEvidence -and $hasUnreviewedEvidence) {
+    throw "Release notes cannot contain both reviewed and unreviewed native-license evidence."
+}
+if ($hasReviewedEvidence) {
     if ($NativeLicenseReviewSha256 -notmatch '^[0-9a-f]{64}$') {
         throw "NativeLicenseReviewSha256 must be a lowercase SHA-256 digest."
     }
@@ -130,6 +137,59 @@ if (-not [string]::IsNullOrWhiteSpace($NativeLicenseReviewSha256)) {
     }
     if (@([regex]::Matches($releaseNotesText, '(?im)<!--\s*tetotv-native-license-review-sha256:')).Count -ne 1) {
         throw "Release notes must not contain another native-license review marker."
+    }
+    if ($releaseNotesText -match '(?im)tetotv-(?:native-license-review-status:\s*unreviewed-beta|unreviewed-beta-declaration-)') {
+        throw "Reviewed release notes must not contain unreviewed Beta evidence."
+    }
+    $unreviewedDisclosure = "No independent native-license review: This Beta has not received independent native-library licensing review. Automated checks verify the APK, native-source bundle, notices, pinned inputs, and checksums, but do not establish legal compliance or reproducible builds."
+    if ($releaseNotesText.Contains($unreviewedDisclosure)) {
+        throw "Reviewed release notes must not claim that independent native-license review was not performed."
+    }
+}
+if ($hasUnreviewedEvidence) {
+    if ($Channel -cne "Beta") {
+        throw "Unreviewed native-license evidence is permitted only for the Beta channel."
+    }
+    if ($UnreviewedBetaDeclarationSha256 -notmatch '^[0-9a-f]{64}$') {
+        throw "UnreviewedBetaDeclarationSha256 must be a lowercase SHA-256 digest."
+    }
+    if ($releaseNotesText -match '(?im)<!--\s*tetotv-native-license-review-(?:sha256|attestation-base64|signature-base64):') {
+        throw "Unreviewed Beta release notes must not contain qualified-review evidence."
+    }
+    $disclosure = "No independent native-license review: This Beta has not received independent native-library licensing review. Automated checks verify the APK, native-source bundle, notices, pinned inputs, and checksums, but do not establish legal compliance or reproducible builds."
+    $visibleWarningPrefix = "# TetoTV $versionName Beta`n`n> [!WARNING]`n> $disclosure`n"
+    $normalizedReleaseNotesText = $releaseNotesText.Replace("`r`n", "`n")
+    if (
+        @([regex]::Matches($normalizedReleaseNotesText, [regex]::Escape($disclosure))).Count -ne 1 -or
+        -not $normalizedReleaseNotesText.StartsWith(
+            $visibleWarningPrefix,
+            [StringComparison]::Ordinal
+        )
+    ) {
+        throw "Unreviewed Beta release notes must begin with the exact visible warning block."
+    }
+    $statusMarker = "<!-- tetotv-native-license-review-status: unreviewed-beta -->"
+    if (@([regex]::Matches($releaseNotesText, [regex]::Escape($statusMarker))).Count -ne 1) {
+        throw "Unreviewed Beta release notes must contain the exact status marker once."
+    }
+    if (@([regex]::Matches($releaseNotesText, '(?im)<!--\s*tetotv-native-license-review-status:')).Count -ne 1) {
+        throw "Unreviewed Beta release notes must not contain another review-status marker."
+    }
+    $declarationMarker = "<!-- tetotv-unreviewed-beta-declaration-sha256: $UnreviewedBetaDeclarationSha256 -->"
+    if (@([regex]::Matches($releaseNotesText, [regex]::Escape($declarationMarker))).Count -ne 1) {
+        throw "Release notes must contain the exact unreviewed Beta declaration digest marker once."
+    }
+    if (@([regex]::Matches($releaseNotesText, '(?im)<!--\s*tetotv-unreviewed-beta-declaration-sha256:')).Count -ne 1) {
+        throw "Release notes must not contain another unreviewed Beta declaration marker."
+    }
+    if (@([regex]::Matches(
+        $releaseNotesText,
+        '(?im)<!--\s*tetotv-unreviewed-beta-declaration-base64:\s*[A-Za-z0-9+/]+={0,2}\s*-->'
+    )).Count -ne 1 -or @([regex]::Matches(
+        $releaseNotesText,
+        '(?im)<!--\s*tetotv-unreviewed-beta-declaration-base64:'
+    )).Count -ne 1) {
+        throw "Unreviewed Beta release notes must contain exactly one encoded declaration."
     }
 }
 

--- a/tool/release/verify_unreviewed_beta_release_declaration.ps1
+++ b/tool/release/verify_unreviewed_beta_release_declaration.ps1
@@ -1,0 +1,236 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$DeclarationPath,
+
+    [Parameter(Mandatory = $true)]
+    [string]$ReleaseTag,
+
+    [Parameter(Mandatory = $true)]
+    [string]$GitCommit,
+
+    [Parameter(Mandatory = $true)]
+    [string]$ApkPath,
+
+    [Parameter(Mandatory = $true)]
+    [string]$NativeSourcePath
+)
+
+$ErrorActionPreference = "Stop"
+Set-StrictMode -Version Latest
+
+$repositoryRoot = (Resolve-Path (Join-Path $PSScriptRoot "..\..")).Path
+$manifestPath = Join-Path $PSScriptRoot "native_playback_manifest.json"
+$noticePath = Join-Path $repositoryRoot "assets\legal\native\NATIVE_PLAYBACK_NOTICE.txt"
+$repository = "LindersOSX/TetoTV-Beta"
+$operatorIdentity = "LindersOSX"
+$inventoryMethod = "github-repository-settings-installed-github-apps-owner-confirmation"
+
+function Resolve-RequiredFile([string]$Path, [string]$Label) {
+    if (-not (Test-Path -LiteralPath $Path -PathType Leaf)) {
+        throw "$Label does not exist: $Path"
+    }
+    return (Resolve-Path -LiteralPath $Path).Path
+}
+
+function Assert-ExactProperties(
+    [object]$Value,
+    [string[]]$Expected,
+    [string]$Label
+) {
+    if ($null -eq $Value) {
+        throw "$Label is missing."
+    }
+    $actual = @($Value.PSObject.Properties.Name | Sort-Object)
+    $wanted = @($Expected | Sort-Object)
+    if (
+        $actual.Count -ne $wanted.Count -or
+        (Compare-Object -CaseSensitive $wanted $actual)
+    ) {
+        throw "$Label must contain exactly: $($Expected -join ', ')."
+    }
+}
+
+function Get-TextSha256([string]$Value) {
+    $algorithm = [Security.Cryptography.SHA256]::Create()
+    try {
+        $bytes = [Text.UTF8Encoding]::new($false).GetBytes($Value)
+        return ([BitConverter]::ToString($algorithm.ComputeHash($bytes)) -replace '-', '').ToLowerInvariant()
+    }
+    finally {
+        $algorithm.Dispose()
+    }
+}
+
+$resolvedDeclaration = Resolve-RequiredFile $DeclarationPath "Unreviewed Beta release declaration"
+$resolvedApk = Resolve-RequiredFile $ApkPath "Release APK"
+$resolvedNativeSource = Resolve-RequiredFile $NativeSourcePath "Native source bundle"
+$resolvedManifest = Resolve-RequiredFile $manifestPath "Native playback manifest"
+$resolvedNotice = Resolve-RequiredFile $noticePath "Native playback notice"
+
+if ($ReleaseTag -cnotmatch '^v2\.\d+\.\d+$') {
+    throw "ReleaseTag must be a canonical Beta v2.x.y tag."
+}
+if ($GitCommit -cnotmatch '^[0-9a-f]{40}$') {
+    throw "GitCommit must be the lowercase full Git commit ID."
+}
+
+$expectedApkName = "TetoTV-$ReleaseTag-universal.apk"
+$expectedNativeSourceName = "TetoTV-$ReleaseTag-native-playback-sources.zip"
+if ([IO.Path]::GetFileName($resolvedApk) -cne $expectedApkName) {
+    throw "Expected APK name '$expectedApkName'."
+}
+if ([IO.Path]::GetFileName($resolvedNativeSource) -cne $expectedNativeSourceName) {
+    throw "Expected native source bundle name '$expectedNativeSourceName'."
+}
+
+try {
+    $declaration = Get-Content -Raw -LiteralPath $resolvedDeclaration | ConvertFrom-Json
+}
+catch {
+    throw "Unreviewed Beta release declaration is not valid JSON: $($_.Exception.Message)"
+}
+
+Assert-ExactProperties $declaration @(
+    "schemaVersion",
+    "statementType",
+    "releaseTag",
+    "gitCommit",
+    "declaredAtUtc",
+    "operatorIdentity",
+    "independentNativeLicenseReview",
+    "correspondingSourceIndependentlyReviewed",
+    "knownProvenanceLimitsAcknowledged",
+    "knownProvenanceLimitsSha256",
+    "githubAppInventory",
+    "artifacts"
+) "Unreviewed Beta release declaration"
+Assert-ExactProperties $declaration.githubAppInventory @(
+    "repository",
+    "checkedAtUtc",
+    "reviewMethod",
+    "inventoryComplete",
+    "installations"
+) "GitHub App installation inventory"
+Assert-ExactProperties $declaration.artifacts @(
+    "apkSha256",
+    "nativeSourceSha256",
+    "nativeManifestSha256",
+    "nativePlaybackNoticeSha256"
+) "Unreviewed Beta artifact binding"
+
+if (
+    $declaration.schemaVersion -isnot [int] -and
+    $declaration.schemaVersion -isnot [long]
+) {
+    throw "schemaVersion must be a JSON integer."
+}
+if ([long]$declaration.schemaVersion -ne 1) {
+    throw "Unsupported unreviewed Beta declaration schema."
+}
+if ([string]$declaration.statementType -cne "tetotv-unreviewed-beta-release-declaration") {
+    throw "Unexpected unreviewed Beta declaration statement type."
+}
+if ([string]$declaration.releaseTag -cne $ReleaseTag) {
+    throw "Unreviewed Beta declaration is not bound to release tag $ReleaseTag."
+}
+if ([string]$declaration.gitCommit -cne $GitCommit) {
+    throw "Unreviewed Beta declaration is not bound to Git commit $GitCommit."
+}
+if ([string]$declaration.operatorIdentity -cne $operatorIdentity) {
+    throw "Unreviewed Beta declaration operator must be exactly '$operatorIdentity'."
+}
+
+foreach ($falseField in @(
+    "independentNativeLicenseReview",
+    "correspondingSourceIndependentlyReviewed"
+)) {
+    $value = $declaration.$falseField
+    if ($value -isnot [bool] -or $value -ne $false) {
+        throw "$falseField must be the JSON boolean false."
+    }
+}
+$acknowledgement = $declaration.knownProvenanceLimitsAcknowledged
+if ($acknowledgement -isnot [bool] -or $acknowledgement -ne $true) {
+    throw "knownProvenanceLimitsAcknowledged must be the JSON boolean true."
+}
+
+$declaredAtText = [string]$declaration.declaredAtUtc
+if ($declaredAtText -notmatch '^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$') {
+    throw "declaredAtUtc must use UTC form YYYY-MM-DDTHH:MM:SSZ."
+}
+$declaredAt = [DateTimeOffset]::ParseExact(
+    $declaredAtText,
+    "yyyy-MM-dd'T'HH:mm:ss'Z'",
+    [Globalization.CultureInfo]::InvariantCulture,
+    [Globalization.DateTimeStyles]::AssumeUniversal
+)
+$now = [DateTimeOffset]::UtcNow
+if ($declaredAt -gt $now.AddMinutes(5) -or $declaredAt -lt $now.AddHours(-24)) {
+    throw "Unreviewed Beta declaration must be created within 24 hours before publication and may be at most five minutes ahead for clock skew."
+}
+
+$appInventory = $declaration.githubAppInventory
+if ([string]$appInventory.repository -cne $repository) {
+    throw "GitHub App inventory must cover the exact Beta release repository."
+}
+if ([string]$appInventory.reviewMethod -cne $inventoryMethod) {
+    throw "GitHub App inventory must record an owner confirmation from the repository Installed GitHub Apps settings page."
+}
+if (
+    $appInventory.inventoryComplete -isnot [bool] -or
+    $appInventory.inventoryComplete -ne $true
+) {
+    throw "GitHub App inventory must be explicitly marked complete."
+}
+if (@($appInventory.installations).Count -ne 0) {
+    throw "Publication is blocked while any GitHub App is installed for the Beta repository."
+}
+$inventoryCheckedAtText = [string]$appInventory.checkedAtUtc
+if ($inventoryCheckedAtText -notmatch '^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$') {
+    throw "GitHub App inventory checkedAtUtc must use UTC form YYYY-MM-DDTHH:MM:SSZ."
+}
+$inventoryCheckedAt = [DateTimeOffset]::ParseExact(
+    $inventoryCheckedAtText,
+    "yyyy-MM-dd'T'HH:mm:ss'Z'",
+    [Globalization.CultureInfo]::InvariantCulture,
+    [Globalization.DateTimeStyles]::AssumeUniversal
+)
+if ($inventoryCheckedAt -ne $declaredAt) {
+    throw "The complete empty GitHub App inventory must be confirmed when the declaration is created."
+}
+
+$manifest = Get-Content -Raw -LiteralPath $resolvedManifest | ConvertFrom-Json
+$knownLimits = @($manifest.knownProvenanceLimits | ForEach-Object { [string]$_ })
+if ($knownLimits.Count -eq 0) {
+    throw "native_playback_manifest.json must record at least one provenance limitation."
+}
+$limitsText = ($knownLimits -join "`n") + "`n"
+$expectedLimitsHash = Get-TextSha256 $limitsText
+if ([string]$declaration.knownProvenanceLimitsSha256 -cne $expectedLimitsHash) {
+    throw "Unreviewed Beta declaration does not acknowledge the exact recorded provenance-limit set."
+}
+
+$expectedArtifacts = @{
+    apkSha256 = (Get-FileHash -Algorithm SHA256 -LiteralPath $resolvedApk).Hash.ToLowerInvariant()
+    nativeSourceSha256 = (Get-FileHash -Algorithm SHA256 -LiteralPath $resolvedNativeSource).Hash.ToLowerInvariant()
+    nativeManifestSha256 = (Get-FileHash -Algorithm SHA256 -LiteralPath $resolvedManifest).Hash.ToLowerInvariant()
+    nativePlaybackNoticeSha256 = (Get-FileHash -Algorithm SHA256 -LiteralPath $resolvedNotice).Hash.ToLowerInvariant()
+}
+foreach ($name in $expectedArtifacts.Keys) {
+    $actual = [string]$declaration.artifacts.$name
+    if ($actual -notmatch '^[0-9a-f]{64}$' -or $actual -cne $expectedArtifacts[$name]) {
+        throw "Unreviewed Beta artifact binding mismatch: $name."
+    }
+}
+
+$declarationSha256 = (Get-FileHash -Algorithm SHA256 -LiteralPath $resolvedDeclaration).Hash.ToLowerInvariant()
+Write-Host "Unreviewed Beta release declaration verification passed"
+Write-Host "  Operator:       $operatorIdentity"
+Write-Host "  Release tag:    $ReleaseTag"
+Write-Host "  Git commit:     $GitCommit"
+Write-Host "  Declared at:    $declaredAtText"
+Write-Host "  Declaration SHA-256: $declarationSha256"
+Write-Warning "This evidence explicitly records that no independent native-license or corresponding-source review was performed."
+Write-Warning "Verification confirms bindings and acknowledgements only; it is not legal advice or a compliance determination."
+Write-Host "No private key, signature, credential, or other private material was read or required."


### PR DESCRIPTION
## Summary
- add a Beta-only, owner-declared unreviewed release-evidence mode without inventing a reviewer or signature
- retain draft-first APK, native-source, checksum, repository-authority, immutable-release, and hosted attestation verification
- require an exact visible warning and reject mixed or contradictory review states
- keep Public releases strictly gated on independent signed review

## Validation
- flutter analyze
- flutter test (1,855 passed)
- release policy tests (5 passed)
- PowerShell AST parsing
- workflow YAML parsing
- exact unreviewed Beta publisher dry run

This PR does not publish a release.