### PR TITLE
Fix exact release declaration timestamp validation

### DIFF
--- a/test/release_repository_policy_test.dart
+++ b/test/release_repository_policy_test.dart
@@ -171,6 +171,9 @@ void main() {
     final declarationVerifier = File(
       'tool/release/verify_unreviewed_beta_release_declaration.ps1',
     ).readAsStringSync();
+    final reviewedAttestationVerifier = File(
+      'tool/release/verify_native_license_review.ps1',
+    ).readAsStringSync();
     final hostedReleaseVerifier = File(
       '.github/workflows/verify-release-assets.yml',
     ).readAsStringSync();
@@ -234,6 +237,32 @@ void main() {
     expect(
       declarationVerifier,
       contains("ReleaseTag must be a canonical Beta v2.x.y tag."),
+    );
+    expect(
+      declarationVerifier,
+      contains('function Get-CanonicalUtcJsonString('),
+      reason:
+          'timestamp validation must inspect the exact JSON string instead of '
+          'PowerShell\'s culture-formatted DateTime conversion',
+    );
+    expect(
+      declarationVerifier,
+      contains(r'$declaredAtText = Get-CanonicalUtcJsonString `'),
+    );
+    expect(
+      declarationVerifier,
+      contains(r'if ($keyOccurrences.Count -ne 1)'),
+      reason: 'duplicate timestamp properties must fail closed',
+    );
+    expect(declarationVerifier, isNot(contains('[Text.Json.JsonDocument]')));
+    expect(
+      reviewedAttestationVerifier,
+      contains('function Get-CanonicalUtcJsonString('),
+      reason: 'the reviewed path must preserve exact timestamp text too',
+    );
+    expect(
+      reviewedAttestationVerifier,
+      isNot(contains(r'$reviewedAtText = [string]$attestation.reviewedAtUtc')),
     );
 
     expect(

--- a/tool/release/verify_native_license_review.ps1
+++ b/tool/release/verify_native_license_review.ps1
@@ -58,6 +58,36 @@ function Get-TextSha256([string]$Value) {
     }
 }
 
+function Get-CanonicalUtcJsonString(
+    [string]$Json,
+    [string]$PropertyName,
+    [string]$Label
+) {
+    # Newer PowerShell versions may deserialize ISO-8601 JSON strings as
+    # DateTime values. Validate the exact raw JSON property and value so the
+    # signed review behaves consistently in Windows PowerShell 5.1 and 7+.
+    $keyPattern = '(?<!\\)"{0}"\s*:' -f `
+        [regex]::Escape($PropertyName)
+    $keyOccurrences = @([regex]::Matches(
+        $Json,
+        $keyPattern,
+        [Text.RegularExpressions.RegexOptions]::CultureInvariant
+    ))
+    if ($keyOccurrences.Count -ne 1) {
+        throw "$Label must appear exactly once as a JSON property."
+    }
+    $pattern = $keyPattern + '\s*"(?<value>\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z)"'
+    $occurrences = @([regex]::Matches(
+        $Json,
+        $pattern,
+        [Text.RegularExpressions.RegexOptions]::CultureInvariant
+    ))
+    if ($occurrences.Count -ne 1) {
+        throw "$Label must appear exactly once as a canonical UTC JSON string."
+    }
+    return $occurrences[0].Groups['value'].Value
+}
+
 function Invoke-SshReviewVerification(
     [string]$MessagePath,
     [string]$ReviewSignaturePath,
@@ -129,7 +159,8 @@ if ($GitCommit -notmatch '^[0-9a-f]{40}$') {
 }
 
 try {
-    $attestation = Get-Content -Raw -LiteralPath $resolvedAttestation | ConvertFrom-Json
+    $attestationJson = Get-Content -Raw -LiteralPath $resolvedAttestation
+    $attestation = $attestationJson | ConvertFrom-Json
 }
 catch {
     throw "Native-license review attestation is not valid JSON: $($_.Exception.Message)"
@@ -164,6 +195,15 @@ Assert-ExactProperties $attestation.artifacts @(
     "nativeManifestSha256",
     "nativePlaybackNoticeSha256"
 ) "Native-license review artifact binding"
+
+$reviewedAtText = Get-CanonicalUtcJsonString `
+    -Json $attestationJson `
+    -PropertyName "reviewedAtUtc" `
+    -Label "reviewedAtUtc"
+$appInventoryCheckedAtText = Get-CanonicalUtcJsonString `
+    -Json $attestationJson `
+    -PropertyName "checkedAtUtc" `
+    -Label "GitHub App inventory checkedAtUtc"
 
 if (
     $attestation.schemaVersion -isnot [int] -and
@@ -213,7 +253,6 @@ if ([string]::IsNullOrWhiteSpace($reviewerRole) -or $reviewerRole.Length -gt 160
     throw "reviewerRole must identify the reviewer's qualification in 160 characters or fewer."
 }
 
-$reviewedAtText = [string]$attestation.reviewedAtUtc
 if ($reviewedAtText -notmatch '^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$') {
     throw "reviewedAtUtc must use UTC form YYYY-MM-DDTHH:MM:SSZ."
 }
@@ -247,7 +286,6 @@ if (
 if (@($appInventory.installations).Count -ne 0) {
     throw "Publication is blocked while any GitHub App is installed for the Beta repository."
 }
-$appInventoryCheckedAtText = [string]$appInventory.checkedAtUtc
 if ($appInventoryCheckedAtText -notmatch '^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$') {
     throw "GitHub App inventory checkedAtUtc must use UTC form YYYY-MM-DDTHH:MM:SSZ."
 }

--- a/tool/release/verify_unreviewed_beta_release_declaration.ps1
+++ b/tool/release/verify_unreviewed_beta_release_declaration.ps1
@@ -62,6 +62,36 @@ function Get-TextSha256([string]$Value) {
     }
 }
 
+function Get-CanonicalUtcJsonString(
+    [string]$Json,
+    [string]$PropertyName,
+    [string]$Label
+) {
+    # ConvertFrom-Json in newer PowerShell versions may deserialize ISO-8601
+    # strings as DateTime values. Match the raw JSON lexeme so validation is
+    # exact and behaves the same in Windows PowerShell 5.1 and PowerShell 7+.
+    $keyPattern = '(?<!\\)"{0}"\s*:' -f `
+        [regex]::Escape($PropertyName)
+    $keyOccurrences = @([regex]::Matches(
+        $Json,
+        $keyPattern,
+        [Text.RegularExpressions.RegexOptions]::CultureInvariant
+    ))
+    if ($keyOccurrences.Count -ne 1) {
+        throw "$Label must appear exactly once as a JSON property."
+    }
+    $pattern = $keyPattern + '\s*"(?<value>\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z)"'
+    $occurrences = @([regex]::Matches(
+        $Json,
+        $pattern,
+        [Text.RegularExpressions.RegexOptions]::CultureInvariant
+    ))
+    if ($occurrences.Count -ne 1) {
+        throw "$Label must appear exactly once as a canonical UTC JSON string."
+    }
+    return $occurrences[0].Groups['value'].Value
+}
+
 $resolvedDeclaration = Resolve-RequiredFile $DeclarationPath "Unreviewed Beta release declaration"
 $resolvedApk = Resolve-RequiredFile $ApkPath "Release APK"
 $resolvedNativeSource = Resolve-RequiredFile $NativeSourcePath "Native source bundle"
@@ -85,7 +115,8 @@ if ([IO.Path]::GetFileName($resolvedNativeSource) -cne $expectedNativeSourceName
 }
 
 try {
-    $declaration = Get-Content -Raw -LiteralPath $resolvedDeclaration | ConvertFrom-Json
+    $declarationJson = Get-Content -Raw -LiteralPath $resolvedDeclaration
+    $declaration = $declarationJson | ConvertFrom-Json
 }
 catch {
     throw "Unreviewed Beta release declaration is not valid JSON: $($_.Exception.Message)"
@@ -118,6 +149,15 @@ Assert-ExactProperties $declaration.artifacts @(
     "nativeManifestSha256",
     "nativePlaybackNoticeSha256"
 ) "Unreviewed Beta artifact binding"
+
+$declaredAtText = Get-CanonicalUtcJsonString `
+    -Json $declarationJson `
+    -PropertyName "declaredAtUtc" `
+    -Label "declaredAtUtc"
+$inventoryCheckedAtText = Get-CanonicalUtcJsonString `
+    -Json $declarationJson `
+    -PropertyName "checkedAtUtc" `
+    -Label "GitHub App inventory checkedAtUtc"
 
 if (
     $declaration.schemaVersion -isnot [int] -and
@@ -155,7 +195,6 @@ if ($acknowledgement -isnot [bool] -or $acknowledgement -ne $true) {
     throw "knownProvenanceLimitsAcknowledged must be the JSON boolean true."
 }
 
-$declaredAtText = [string]$declaration.declaredAtUtc
 if ($declaredAtText -notmatch '^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$') {
     throw "declaredAtUtc must use UTC form YYYY-MM-DDTHH:MM:SSZ."
 }
@@ -186,7 +225,6 @@ if (
 if (@($appInventory.installations).Count -ne 0) {
     throw "Publication is blocked while any GitHub App is installed for the Beta repository."
 }
-$inventoryCheckedAtText = [string]$appInventory.checkedAtUtc
 if ($inventoryCheckedAtText -notmatch '^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$') {
     throw "GitHub App inventory checkedAtUtc must use UTC form YYYY-MM-DDTHH:MM:SSZ."
 }


### PR DESCRIPTION
## Summary
- validate declaration timestamp text directly from canonical raw JSON
- keep verification compatible with Windows PowerShell 5.1 and PowerShell 7+
- add a release-policy regression guard

## Validation
- verifier passes in pwsh
- verifier passes in Windows PowerShell 5.1
- flutter test test/release_repository_policy_test.dart (5/5 passed)