### PR TITLE
Handle missing GitHub release during publish preflight

### DIFF
--- a/test/release_repository_policy_test.dart
+++ b/test/release_repository_policy_test.dart
@@ -198,6 +198,17 @@ void main() {
         r'$unreviewedBetaAcknowledgementText = "PUBLISH UNREVIEWED BETA"',
       ),
     );
+    expect(
+      publisher,
+      contains('"api", "--paginate", "--slurp"'),
+      reason: 'draft verification must enumerate every release page',
+    );
+    expect(publisher, contains('"repos/\$Repository/releases?per_page=100"'));
+    expect(
+      publisher,
+      isNot(contains('"repos/\$Repository/releases/tags/\$encodedTag"')),
+      reason: 'GitHub\'s release-by-tag endpoint hides drafts',
+    );
     expect(publisher, contains('[StringComparison]::Ordinal'));
     expect(
       publisher,

--- a/tool/release/publish_release.ps1
+++ b/tool/release/publish_release.ps1
@@ -172,24 +172,28 @@ function Invoke-GitHubCli {
 }
 
 function Get-GitHubRelease([string]$Repository, [string]$Tag, [switch]$AllowMissing) {
-    $encodedTag = [Uri]::EscapeDataString($Tag)
-    $allowedExitCodes = if ($AllowMissing) { @(0, 1) } else { @(0) }
-    $result = Invoke-GitHubCli `
-        -Arguments @("api", "repos/$Repository/releases/tags/$encodedTag") `
-        -AllowedExitCodes $allowedExitCodes
-    if ($result.ExitCode -ne 0) {
-        $details = ($result.Output -join "`n").Trim()
-        if ($AllowMissing -and $details -match '(?i)(HTTP\s+404|not\s+found)') {
-            return $null
-        }
-        throw "Could not read release $Tag from $Repository.`n$details"
-    }
+    # GitHub's release-by-tag endpoint returns 404 for private drafts, even to
+    # an authenticated repository owner. Enumerate all pages so verification
+    # and rollback can see both drafts and published releases.
+    $result = Invoke-GitHubCli -Arguments @(
+        "api", "--paginate", "--slurp",
+        "repos/$Repository/releases?per_page=100"
+    )
     try {
-        return ($result.Output -join "`n") | ConvertFrom-Json
+        $releases = @(($result.Output -join "`n") | ConvertFrom-Json)
     }
     catch {
-        throw "GitHub returned invalid release data for $Repository $Tag."
+        throw "GitHub returned invalid release-list data for $Repository."
     }
+    $matches = @($releases | Where-Object { [string]$_.tag_name -ceq $Tag })
+    if ($matches.Count -gt 1) {
+        throw "GitHub returned more than one release for exact tag $Tag in $Repository."
+    }
+    if ($matches.Count -eq 0) {
+        if ($AllowMissing) { return $null }
+        throw "Release $Tag does not exist in $Repository."
+    }
+    return $matches[0]
 }
 
 function Get-LatestGitHubRelease([string]$Repository) {


### PR DESCRIPTION
## Summary
- treat GitHub's HTTP 404 as the expected absent-release state only when explicitly allowed
- preserve fail-closed handling for every other CLI error
- add a release-policy regression guard

## Validation
- flutter test test/release_repository_policy_test.dart (5/5 passed)
- reproduced gh api 404 exit code 1 against the not-yet-created v2.0.42 release