### PR TITLE
Flatten paginated GitHub release results

### DIFF
--- a/test/release_repository_policy_test.dart
+++ b/test/release_repository_policy_test.dart
@@ -206,6 +206,11 @@ void main() {
     expect(publisher, contains('"repos/\$Repository/releases?per_page=100"'));
     expect(
       publisher,
+      contains(r'$releases = @($pages | ForEach-Object { @($_) })'),
+      reason: 'slurped release pages must be flattened before exact tag lookup',
+    );
+    expect(
+      publisher,
       isNot(contains('"repos/\$Repository/releases/tags/\$encodedTag"')),
       reason: 'GitHub\'s release-by-tag endpoint hides drafts',
     );

--- a/tool/release/publish_release.ps1
+++ b/tool/release/publish_release.ps1
@@ -180,7 +180,8 @@ function Get-GitHubRelease([string]$Repository, [string]$Tag, [switch]$AllowMiss
         "repos/$Repository/releases?per_page=100"
     )
     try {
-        $releases = @(($result.Output -join "`n") | ConvertFrom-Json)
+        $pages = @(($result.Output -join "`n") | ConvertFrom-Json)
+        $releases = @($pages | ForEach-Object { @($_) })
     }
     catch {
         throw "GitHub returned invalid release-list data for $Repository."


### PR DESCRIPTION
## Summary
- flatten gh api --paginate --slurp page arrays before exact tag lookup
- preserve draft visibility, duplicate-tag rejection, and bounded state synchronization
- add a regression guard for the slurped-page shape

## Validation
- flutter test test/release_repository_policy_test.dart (5/5 passed)
- PowerShell AST parse passed
- live paginated lookup finds v2.0.41 exactly once and no stale v2.0.42 release