### PR TITLE
Fix manual release attestation subjects

### DIFF
--- a/.github/workflows/verify-release-assets.yml
+++ b/.github/workflows/verify-release-assets.yml
@@ -413,8 +413,8 @@ jobs:
         uses: actions/attest@508db95dd578ae2727ebd6217d5ba78e4fbda05d # v4.2.1
         with:
           subject-path: |
-            ${{ runner.temp }}/tetotv-release/TetoTV-${{ github.event.release.tag_name }}-universal.apk
-            ${{ runner.temp }}/tetotv-release/TetoTV-${{ github.event.release.tag_name }}-native-playback-sources.zip
+            ${{ runner.temp }}/tetotv-release/TetoTV-${{ env.RELEASE_TAG }}-universal.apk
+            ${{ runner.temp }}/tetotv-release/TetoTV-${{ env.RELEASE_TAG }}-native-playback-sources.zip
             ${{ runner.temp }}/tetotv-release/SHA256SUMS
           predicate-type: https://github.com/LindersOSX/TetoTV-Beta/attestations/release-verification/v2
           predicate-path: ${{ runner.temp }}/tetotv-release/release-verification-predicate.json

--- a/test/release_repository_policy_test.dart
+++ b/test/release_repository_policy_test.dart
@@ -432,6 +432,16 @@ void main() {
     ).allMatches(subjectBlock!.group(1)!).length;
     expect(subjects, 3);
     expect(
+      RegExp(
+        r'\$\{\{ env\.RELEASE_TAG \}\}',
+      ).allMatches(subjectBlock.group(1)!).length,
+      2,
+    );
+    expect(
+      subjectBlock.group(1),
+      isNot(contains('github.event.release.tag_name')),
+    );
+    expect(
       subjectBlock.group(1),
       isNot(contains('unreviewed-beta-release-declaration')),
     );


### PR DESCRIPTION
## Summary
- use the workflow-level release tag for all three attestation subjects
- add a regression assertion so manual dispatch cannot silently drop the APK and source ZIP

## Verification
- flutter test test/release_repository_policy_test.dart
- git diff --check

The immutable v2.0.42 release itself is not modified.