### PR TITLE
Fix Beta publisher singleton allowlist handling

### DIFF
--- a/test/release_repository_policy_test.dart
+++ b/test/release_repository_policy_test.dart
@@ -87,6 +87,15 @@ void main() {
     expect(publisher, contains('immutable future releases must be enabled'));
     expect(publisher, contains('sha_pinning_required'));
     expect(publisher, contains('android-actions/setup-android@*'));
+    expect(
+      RegExp(
+        r'\$expectedExternalActionPatterns\s*=\s*@\(\s*@\([\s\S]*?"android-actions/setup-android@\*"[\s\S]*?\)\s*\|\s*Sort-Object\s*\)',
+      ).hasMatch(publisher),
+      isTrue,
+      reason:
+          'sorting a single expected action pattern must remain array-wrapped '
+          'under PowerShell strict mode',
+    );
     expect(publisher, isNot(contains('subosito/flutter-action@*')));
     expect(publisher, contains(r'$selectedActionsPolicy.verified_allowed'));
     expect(publisher, contains('default_workflow_permissions'));

--- a/tool/release/publish_release.ps1
+++ b/tool/release/publish_release.ps1
@@ -374,8 +374,10 @@ function Assert-GitHubReleaseAuthorityBoundary(
     }
     $selectedActionsPolicy = Get-GitHubApiJson "repos/$Repository/actions/permissions/selected-actions"
     $expectedExternalActionPatterns = @(
-        "android-actions/setup-android@*"
-    ) | Sort-Object
+        @(
+            "android-actions/setup-android@*"
+        ) | Sort-Object
+    )
     $actualExternalActionPatterns = @($selectedActionsPolicy.patterns_allowed | Sort-Object)
     if (
         -not [bool]$selectedActionsPolicy.github_owned_allowed -or


### PR DESCRIPTION
Summary: preserve the selected GitHub Actions allowlist as an array after sorting and add regression coverage for PowerShell strict mode. Validation: PowerShell AST parse, strict-mode singleton regression check, targeted Flutter policy tests (5/5), and git diff check.