### PR TITLE
Prepare TetoTV 2.0.44 Beta

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,9 +42,9 @@ This repository contains the complete TetoTV source code as well as the Beta rel
 | Channel | Version | Best for |
 | --- | --- | --- |
 | Public | Not published | Source and release-readiness documents are available, but no Public APK is currently offered |
-| Beta | [2.0.43](docs/RELEASE_NOTES_2.0.43.md) | Testing current fixes and source-built native playback before a separately reviewed Public release |
+| Beta | [2.0.44](docs/RELEASE_NOTES_2.0.44.md) | Testing current fixes and source-built native playback before a separately reviewed Public release |
 
-Beta 2.0.43 uses the repository's explicit unreviewed-Beta exception: its
+Beta 2.0.44 uses the repository's explicit unreviewed-Beta exception: its
 native-library and corresponding-source material did not receive independent
 license review. Automated integrity and source-bundle checks are not a legal
 compliance determination. The release notes preserve the exact disclosure and

--- a/docs/BUILD_WINDOWS.md
+++ b/docs/BUILD_WINDOWS.md
@@ -220,39 +220,39 @@ APK containing both supported application ABIs.
 Public and Beta updates use anonymous GitHub requests. No Beta key, GitHub
 token, update-proxy URL, or update-specific Dart define is required. Every
 published APK uses the production signing identity. No Public APK is currently
-published. Beta 2.0.43 uses Android build code `410020`. Flutter reuses
+published. Beta 2.0.44 uses Android build code `410021`. Flutter reuses
 `app-release.apk`, so copy and rename the Beta artifact immediately after the
 build:
 
 ```powershell
-New-Item -ItemType Directory -Force .\build\fire-tv\v2.0.43 | Out-Null
+New-Item -ItemType Directory -Force .\build\fire-tv\v2.0.44 | Out-Null
 
-# Beta 2.0.43
+# Beta 2.0.44
 flutter build apk --release --target-platform android-arm,android-arm64 `
-  --build-name 2.0.43 --build-number 410020 --no-tree-shake-icons
+  --build-name 2.0.44 --build-number 410021 --no-tree-shake-icons
 Copy-Item .\build\app\outputs\flutter-apk\app-release.apk `
-  .\build\fire-tv\v2.0.43\TetoTV-v2.0.43-universal.apk
+  .\build\fire-tv\v2.0.44\TetoTV-v2.0.44-universal.apk
 
 .\tool\release\verify_release_apk.ps1 `
   -Channel Beta `
-  -ApkPath .\build\fire-tv\v2.0.43\TetoTV-v2.0.43-universal.apk
+  -ApkPath .\build\fire-tv\v2.0.44\TetoTV-v2.0.44-universal.apk
 
 .\tool\release\verify_native_redistribution.ps1 `
   -RequireResolvedBinaries `
   -ResolvedBinaryDirectory .\build\native-playback\outputs `
-  -StageBundle -ReleaseTag v2.0.43
+  -StageBundle -ReleaseTag v2.0.44
 
 .\tool\release\new_release_checksums.ps1 `
-  -ApkPath .\build\fire-tv\v2.0.43\TetoTV-v2.0.43-universal.apk `
-  -NativeSourcePath .\build\release-compliance\v2.0.43\TetoTV-v2.0.43-native-playback-sources.zip `
-  -OutputPath .\build\fire-tv\v2.0.43\SHA256SUMS
+  -ApkPath .\build\fire-tv\v2.0.44\TetoTV-v2.0.44-universal.apk `
+  -NativeSourcePath .\build\release-compliance\v2.0.44\TetoTV-v2.0.44-native-playback-sources.zip `
+  -OutputPath .\build\fire-tv\v2.0.44\SHA256SUMS
 
 .\tool\release\verify_release_payloads.ps1 `
   -Channel Beta `
-  -ApkPath .\build\fire-tv\v2.0.43\TetoTV-v2.0.43-universal.apk `
-  -NativeSourcePath .\build\release-compliance\v2.0.43\TetoTV-v2.0.43-native-playback-sources.zip `
-  -ChecksumsPath .\build\fire-tv\v2.0.43\SHA256SUMS `
-  -ReleaseNotesPath .\docs\RELEASE_NOTES_2.0.43.md
+  -ApkPath .\build\fire-tv\v2.0.44\TetoTV-v2.0.44-universal.apk `
+  -NativeSourcePath .\build\release-compliance\v2.0.44\TetoTV-v2.0.44-native-playback-sources.zip `
+  -ChecksumsPath .\build\fire-tv\v2.0.44\SHA256SUMS `
+  -ReleaseNotesPath .\docs\RELEASE_NOTES_2.0.44.md
 ```
 
 The final payload check requires all five exact, source-built native JARs

--- a/docs/RELEASE_NOTES_2.0.44.md
+++ b/docs/RELEASE_NOTES_2.0.44.md
@@ -1,0 +1,32 @@
+# TetoTV 2.0.44 Beta
+
+> [!WARNING]
+> No independent native-license review: This Beta has not received independent native-library licensing review. Automated checks verify the APK, native-source bundle, notices, pinned inputs, and checksums, but do not establish legal compliance or reproducible builds.
+
+This Beta replaces TetoTV's retired prebuilt playback inputs with native libraries compiled for TetoTV from pinned source. App behavior, update compatibility, playback, downloads, watch parties, and account connections remain on the existing Beta flow.
+
+## What's changed
+
+- The ARMv7 and ARM64 libmpv, media-kit Android helper, and libtorrent4j inputs are built from pinned source by TetoTV's documented Linux build script. Release builds have no fallback to the retired upstream prebuilt JARs.
+- The native source bundle now includes the exact build script, output provenance, immutable source snapshots, verified Boost and OpenSSL source archives, and complete checksums.
+- The compiled torrent source graph now explicitly includes `try_signal`, libtorrent's bundled ed25519 notice, the full libtorrent-rasterbar license, and the applicable Android NDK runtime and toolchain notices.
+- Native component notices for mpv, FFmpeg, libass, mbedTLS, dav1d, libxml2, FreeType, FriBidi, HarfBuzz, OpenSSL, Boost, libdatachannel, libjuice, usrsctp, plog, and the build-only gas-preprocessor tool are bundled and available in the app.
+- Source-bundle verification rejects Windows CRLF line endings in shell build scripts, preventing a checksum-valid bundle that cannot run on Linux.
+- Release verification inventories every final ARM native library in the signed APK and rejects missing, unexpected, or digest-mismatched entries.
+- The guarded publisher now preserves single-item GitHub Actions allowlists under PowerShell strict mode, preventing a verified release from stopping before draft creation.
+- This build is source-pinned and checksum-attested, but it has not been independently license reviewed or reproduced in a second isolated builder. Those limitations remain explicit in the manifest and this Beta warning.
+
+## Release assets
+
+- `TetoTV-v2.0.44-universal.apk`
+- `TetoTV-v2.0.44-native-playback-sources.zip`
+- `SHA256SUMS`
+
+## Beta notes
+
+- This is a Beta-channel build with Android build code `410021`.
+- No Public APK is being published with this release.
+- Android does not permit an in-place install over an APK with a higher build code. A future Public counterpart must use build code `410021` or newer for data-preserving channel switching.
+- `v2.0.43` was an unpublished candidate tag and was never offered as an app release.
+
+<!-- tetotv-android-version-code: 410021 -->

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: 'none'
 # Public and Beta artifacts built from the same source use one monotonically
 # increasing Android versionCode. The project default carries the Beta display
 # version; the Public universal APK overrides the build name to the 1.x line.
-version: 2.0.43+410020
+version: 2.0.44+410021
 
 environment:
   sdk: ^3.12.2

--- a/test/release_repository_policy_test.dart
+++ b/test/release_repository_policy_test.dart
@@ -206,7 +206,7 @@ void main() {
       '.github/workflows/verify-release-assets.yml',
     ).readAsStringSync();
     final releaseNotes = File(
-      'docs/RELEASE_NOTES_2.0.43.md',
+      'docs/RELEASE_NOTES_2.0.44.md',
     ).readAsStringSync();
 
     expect(

--- a/tool/release/native_playback_manifest.json
+++ b/tool/release/native_playback_manifest.json
@@ -376,9 +376,9 @@
       "path": "lib/arm64-v8a/libapp.so",
       "size": 12125072,
       "sha256": "70cd27e6a95a5b0a087685704b673f18fbd52c4092762c3163170568221d6254",
-      "origin": "TetoTV Flutter application AOT 2.0.43",
+      "origin": "TetoTV Flutter application AOT 2.0.44",
       "license": "MIT",
-      "sourceLocator": "Git tag v2.0.43",
+      "sourceLocator": "Git tag v2.0.44",
       "noticeLocator": "LICENSE"
     },
     {
@@ -423,7 +423,7 @@
       "sha256": "dc05f53278b2733094f12aeaed54c080329309762ce49e6de4118e4bfb0fff55",
       "origin": "TetoTV source build of media-kit Android helper at 42054e5d479f39ccbb0ae604862e2bcaf59b74c2",
       "license": "MIT",
-      "sourceLocator": "TetoTV-v2.0.43-native-playback-sources.zip: sources/media-kit-android-helper-42054e5d479f39ccbb0ae604862e2bcaf59b74c2.zip",
+      "sourceLocator": "TetoTV-v2.0.44-native-playback-sources.zip: sources/media-kit-android-helper-42054e5d479f39ccbb0ae604862e2bcaf59b74c2.zip",
       "noticeLocator": "assets/legal/native/MEDIA_KIT_ANDROID_HELPER_LICENSE.txt; assets/legal/native/NATIVE_PLAYBACK_NOTICE.txt"
     },
     {
@@ -432,7 +432,7 @@
       "sha256": "a7399d0be70844e5ee94cc5b1acc1516571113c50561fe0a5d05b49101c53ef2",
       "origin": "TetoTV source build of the pinned mpv and FFmpeg native playback stack",
       "license": "LGPL-3.0-or-later (conservative combined classification) plus component terms",
-      "sourceLocator": "TetoTV-v2.0.43-native-playback-sources.zip and tool/native/build_native_playback.sh",
+      "sourceLocator": "TetoTV-v2.0.44-native-playback-sources.zip and tool/native/build_native_playback.sh",
       "noticeLocator": "assets/legal/native/NATIVE_PLAYBACK_NOTICE.txt and its referenced exact license assets"
     },
     {
@@ -450,16 +450,16 @@
       "sha256": "263ba714570fb3acfc308cce52776b00506ec8809d225617e52352336144cfa2",
       "origin": "TetoTV source build of the pinned libtorrent4j and libtorrent-rasterbar stack",
       "license": "Mixed MIT, BSD, Boost-1.0, Apache-2.0, and MPL-2.0 component terms",
-      "sourceLocator": "TetoTV-v2.0.43-native-playback-sources.zip and tool/native/build_native_playback.sh",
+      "sourceLocator": "TetoTV-v2.0.44-native-playback-sources.zip and tool/native/build_native_playback.sh",
       "noticeLocator": "assets/legal/native/DIRECT_TORRENT_NATIVE_NOTICE.txt and its referenced exact license assets"
     },
     {
       "path": "lib/armeabi-v7a/libapp.so",
       "size": 13238860,
       "sha256": "9d98f44d1ecb36f254df7d7816443fa715aa653b5b44aa87f592581cc4023dc9",
-      "origin": "TetoTV Flutter application AOT 2.0.43",
+      "origin": "TetoTV Flutter application AOT 2.0.44",
       "license": "MIT",
-      "sourceLocator": "Git tag v2.0.43",
+      "sourceLocator": "Git tag v2.0.44",
       "noticeLocator": "LICENSE"
     },
     {
@@ -504,7 +504,7 @@
       "sha256": "8820a12e07bb3dc45f5b4286acf6918827fba4c265767e7f1cc8f07215c84b6a",
       "origin": "TetoTV source build of media-kit Android helper at 42054e5d479f39ccbb0ae604862e2bcaf59b74c2",
       "license": "MIT",
-      "sourceLocator": "TetoTV-v2.0.43-native-playback-sources.zip: sources/media-kit-android-helper-42054e5d479f39ccbb0ae604862e2bcaf59b74c2.zip",
+      "sourceLocator": "TetoTV-v2.0.44-native-playback-sources.zip: sources/media-kit-android-helper-42054e5d479f39ccbb0ae604862e2bcaf59b74c2.zip",
       "noticeLocator": "assets/legal/native/MEDIA_KIT_ANDROID_HELPER_LICENSE.txt; assets/legal/native/NATIVE_PLAYBACK_NOTICE.txt"
     },
     {
@@ -513,7 +513,7 @@
       "sha256": "d5a220fdf41edde10f161f86addc846ae9cb18137ea48e4db541cd703fec5092",
       "origin": "TetoTV source build of the pinned mpv and FFmpeg native playback stack",
       "license": "LGPL-3.0-or-later (conservative combined classification) plus component terms",
-      "sourceLocator": "TetoTV-v2.0.43-native-playback-sources.zip and tool/native/build_native_playback.sh",
+      "sourceLocator": "TetoTV-v2.0.44-native-playback-sources.zip and tool/native/build_native_playback.sh",
       "noticeLocator": "assets/legal/native/NATIVE_PLAYBACK_NOTICE.txt and its referenced exact license assets"
     },
     {
@@ -531,7 +531,7 @@
       "sha256": "5e090380a7c1c26c16763d40c7f451bdb4fc2542bc5e1b8a410206f66dea4330",
       "origin": "TetoTV source build of the pinned libtorrent4j and libtorrent-rasterbar stack",
       "license": "Mixed MIT, BSD, Boost-1.0, Apache-2.0, and MPL-2.0 component terms",
-      "sourceLocator": "TetoTV-v2.0.43-native-playback-sources.zip and tool/native/build_native_playback.sh",
+      "sourceLocator": "TetoTV-v2.0.44-native-playback-sources.zip and tool/native/build_native_playback.sh",
       "noticeLocator": "assets/legal/native/DIRECT_TORRENT_NATIVE_NOTICE.txt and its referenced exact license assets"
     }
   ],


### PR DESCRIPTION
Prepare the corrected Beta candidate after the publisher strict-mode fix. Updates version/build metadata to 2.0.44+410021, refreshes the native source locators, documents v2.0.43 as an unpublished candidate tag, and adds exact release notes. Validation: production release APK build, full APK/native/source/checksum verification, flutter analyze, and full flutter test (1,855 passed; 14 skipped).