### PR TITLE
TetoTV 2.0.45 Beta

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 
 <p align="center">
   <a href="https://github.com/LindersOSX/TetoTV-Beta/releases/latest"><strong>Download Beta</strong></a>
-  · <a href="docs/RELEASE_NOTES_2.0.44.md">What's new</a>
+  · <a href="docs/RELEASE_NOTES_2.0.45.md">What's new</a>
   · <a href="https://github.com/LindersOSX/TetoTV-Beta/issues/new">Report an issue</a>
   · <a href="https://discord.gg/juC6k7d4WY">Discord</a>
   · <a href="https://www.youtube.com/@TetoTVApp">YouTube</a>
@@ -82,10 +82,10 @@ TetoTV runs directly on the Android device with no companion server required for
 | Channel | Version | Best for |
 | --- | --- | --- |
 | Public | Not published | Source and release-readiness documents are available, but no Public APK is currently offered |
-| Beta | [2.0.44](docs/RELEASE_NOTES_2.0.44.md) | Testing current fixes and source-built native playback before a separately reviewed Public release |
+| Beta | [2.0.45](docs/RELEASE_NOTES_2.0.45.md) | Testing resilient skip timing, richer source diagnostics, and refined TV playback and catalog navigation before a separately reviewed Public release |
 
 > [!WARNING]
-> Beta 2.0.44 uses the repository's explicit unreviewed-Beta exception. Its native-library and corresponding-source material did not receive independent license review, and automated integrity checks are not a legal compliance determination. Read the [complete Beta disclosure](docs/RELEASE_NOTES_2.0.44.md). This exception does not apply to a future Public release.
+> Beta 2.0.45 uses the repository's explicit unreviewed-Beta exception. Its native-library and corresponding-source material did not receive independent license review, and automated integrity checks are not a legal compliance determination. Read the [complete Beta disclosure](docs/RELEASE_NOTES_2.0.45.md). This exception does not apply to a future Public release.
 
 The Public updater repository intentionally has no release while the Public build is held for review. Existing Beta installations continue to update from the Beta repository. Android never permits an in-place install of an APK with a lower build code; Developer Mode does not bypass that platform rule.
 

--- a/docs/BUILD_WINDOWS.md
+++ b/docs/BUILD_WINDOWS.md
@@ -220,39 +220,39 @@ APK containing both supported application ABIs.
 Public and Beta updates use anonymous GitHub requests. No Beta key, GitHub
 token, update-proxy URL, or update-specific Dart define is required. Every
 published APK uses the production signing identity. No Public APK is currently
-published. Beta 2.0.44 uses Android build code `410021`. Flutter reuses
+published. Beta 2.0.45 uses Android build code `410022`. Flutter reuses
 `app-release.apk`, so copy and rename the Beta artifact immediately after the
 build:
 
 ```powershell
-New-Item -ItemType Directory -Force .\build\fire-tv\v2.0.44 | Out-Null
+New-Item -ItemType Directory -Force .\build\fire-tv\v2.0.45 | Out-Null
 
-# Beta 2.0.44
+# Beta 2.0.45
 flutter build apk --release --target-platform android-arm,android-arm64 `
-  --build-name 2.0.44 --build-number 410021 --no-tree-shake-icons
+  --build-name 2.0.45 --build-number 410022 --no-tree-shake-icons
 Copy-Item .\build\app\outputs\flutter-apk\app-release.apk `
-  .\build\fire-tv\v2.0.44\TetoTV-v2.0.44-universal.apk
+  .\build\fire-tv\v2.0.45\TetoTV-v2.0.45-universal.apk
 
 .\tool\release\verify_release_apk.ps1 `
   -Channel Beta `
-  -ApkPath .\build\fire-tv\v2.0.44\TetoTV-v2.0.44-universal.apk
+  -ApkPath .\build\fire-tv\v2.0.45\TetoTV-v2.0.45-universal.apk
 
 .\tool\release\verify_native_redistribution.ps1 `
   -RequireResolvedBinaries `
   -ResolvedBinaryDirectory .\build\native-playback\outputs `
-  -StageBundle -ReleaseTag v2.0.44
+  -StageBundle -ReleaseTag v2.0.45
 
 .\tool\release\new_release_checksums.ps1 `
-  -ApkPath .\build\fire-tv\v2.0.44\TetoTV-v2.0.44-universal.apk `
-  -NativeSourcePath .\build\release-compliance\v2.0.44\TetoTV-v2.0.44-native-playback-sources.zip `
-  -OutputPath .\build\fire-tv\v2.0.44\SHA256SUMS
+  -ApkPath .\build\fire-tv\v2.0.45\TetoTV-v2.0.45-universal.apk `
+  -NativeSourcePath .\build\release-compliance\v2.0.45\TetoTV-v2.0.45-native-playback-sources.zip `
+  -OutputPath .\build\fire-tv\v2.0.45\SHA256SUMS
 
 .\tool\release\verify_release_payloads.ps1 `
   -Channel Beta `
-  -ApkPath .\build\fire-tv\v2.0.44\TetoTV-v2.0.44-universal.apk `
-  -NativeSourcePath .\build\release-compliance\v2.0.44\TetoTV-v2.0.44-native-playback-sources.zip `
-  -ChecksumsPath .\build\fire-tv\v2.0.44\SHA256SUMS `
-  -ReleaseNotesPath .\docs\RELEASE_NOTES_2.0.44.md
+  -ApkPath .\build\fire-tv\v2.0.45\TetoTV-v2.0.45-universal.apk `
+  -NativeSourcePath .\build\release-compliance\v2.0.45\TetoTV-v2.0.45-native-playback-sources.zip `
+  -ChecksumsPath .\build\fire-tv\v2.0.45\SHA256SUMS `
+  -ReleaseNotesPath .\docs\RELEASE_NOTES_2.0.45.md
 ```
 
 The final payload check requires all five exact, source-built native JARs

--- a/docs/RELEASE_NOTES_2.0.45.md
+++ b/docs/RELEASE_NOTES_2.0.45.md
@@ -1,0 +1,36 @@
+# TetoTV 2.0.45 Beta
+
+> [!WARNING]
+> No independent native-license review: This Beta has not received independent native-library licensing review. Automated checks verify the APK, native-source bundle, notices, pinned inputs, and checksums, but do not establish legal compliance or reproducible builds.
+
+This Beta makes skip timing more resilient, explains provider discovery more clearly, and refines the TV experience around featured titles, episode actions, scrubbing, Watch Parties, and franchise navigation.
+
+## What's changed
+
+- Skip-intro and skip-outro timing now retries temporary lookup failures after playback starts instead of permanently giving up after the first short retry window.
+- Clean no-match responses remain terminal, while unresolved transient failures receive bounded delayed retries without keeping unnecessary background work alive.
+- A skip marker is consumed only after the player confirms that playback reached the requested position. Failed automatic skips remain available for a manual retry.
+- Skip retries are tied to the active playback source so a delayed result cannot seek or suppress a marker after the user switches streams.
+- Diagnostic exports now distinguish installed, enabled, searchable, blocked, completed, and result-producing providers for each source search.
+- Provider diagnostics include bounded failure categories and raw-versus-visible provider/result counts with the active audio and quality filters, making it clearer when many choices came from only a few providers.
+- The expanded diagnostics remain privacy-safe: they do not record show titles, episode titles, search queries, stream URLs, request headers, credentials, or account tokens.
+- Diagnostic history retains enough structured provider and skip events to troubleshoot a playback session without exceeding the exporter's bounded event limit.
+- Featured titles on TV now use a consistent font size and roughly half of the banner width, wrapping long localized titles across additional lines instead of shrinking or cutting them off.
+- Watch trailer, Cast & crew, Related series, and Download season remain together in one compact row with all available actions visible and predictable left/right focus order.
+- The player seek-time bubble now floats above the progress bar without expanding or bouncing the HUD during touch or D-pad scrubbing.
+- Watch Party identities accept the public AniList and MyAnimeList avatar CDN aliases used by their APIs while continuing to reject untrusted avatar hosts and exclude private account data.
+- Related Series now presents a deterministic recommended watch order with numbered TV, movie, OVA, special, prequel, sequel, side-story, and spin-off labels while preserving the selected title language.
+
+## Release assets
+
+- `TetoTV-v2.0.45-universal.apk`
+- `TetoTV-v2.0.45-native-playback-sources.zip`
+- `SHA256SUMS`
+
+## Beta notes
+
+- This is a Beta-channel build with Android build code `410022`.
+- No Public APK is being published with this release.
+- Android does not permit an in-place install over an APK with a higher build code. A future Public counterpart must use build code `410022` or newer for data-preserving channel switching.
+
+<!-- tetotv-android-version-code: 410022 -->

--- a/lib/core/diagnostics/explicit_diagnostics_reporter.dart
+++ b/lib/core/diagnostics/explicit_diagnostics_reporter.dart
@@ -368,7 +368,7 @@ String buildRedactedDiagnosticsText({
   if (text.length <= maximumExplicitDiagnosticsCharacters) return text;
 
   // Preserve valid, parseable JSON if an unusual device produces an enormous
-  // capability list. The normal path above retains all 100 database events.
+  // capability list. The normal path above retains all 300 database events.
   // This fallback keeps representative data from every section and declares
   // the reduction instead of cutting through a JSON value.
   final compactTruncation = _SnapshotTruncation();

--- a/lib/core/storage/tetotv_database.dart
+++ b/lib/core/storage/tetotv_database.dart
@@ -9,7 +9,13 @@ import 'package:sqflite/sqflite.dart';
 /// The SQLite table survives process death; it is never uploaded unless the
 /// user presses the diagnostic-report share button.
 const diagnosticHistoryWindow = Duration(hours: 48);
-const maximumPersistedDiagnosticEvents = 240;
+// Provider searches and playback startup can each emit a burst of events.
+// Retain enough history for a complete search plus the playback which follows
+// it; 240 entries allowed title-artwork noise to evict the evidence needed to
+// correlate a source-picker result with an intermittent player failure. Keep
+// this aligned with the explicit report sanitizer's full-size list bound so a
+// chronological export never drops the newest events.
+const maximumPersistedDiagnosticEvents = 300;
 const diagnosticEventSchema = 'tetotv-diagnostic-events-v3';
 
 const _diagnosticDroppedAgeKey = 'dropped_age';
@@ -1764,6 +1770,9 @@ bool _isSafeDiagnosticContextKey(String key) {
     'embedded_marker_count',
     'community_marker_count',
     'community_status',
+    'community_status_class',
+    'community_failure_reason',
+    'community_transient_failure_count',
     'community_probe_count',
     'duration_fallback_used',
     'requested_duration_ms',
@@ -1772,6 +1781,8 @@ bool _isSafeDiagnosticContextKey(String key) {
     'marker_source',
     'automatic',
     'seek_succeeded',
+    'seek_verified',
+    'seek_attempts',
     'watch_party_active',
     'guest_controls_locked',
     'controls_visible',
@@ -1780,6 +1791,7 @@ bool _isSafeDiagnosticContextKey(String key) {
     'marker_start_ms',
     'marker_end_ms',
     'target_ms',
+    'post_seek_position_ms',
     'cached',
     'seekable',
     'frame',

--- a/lib/features/catalog/application/catalog_providers.dart
+++ b/lib/features/catalog/application/catalog_providers.dart
@@ -1,5 +1,6 @@
 import 'package:anime_tv/features/catalog/data/anilist_catalog_client.dart';
 import 'package:anime_tv/features/catalog/domain/anime_summary.dart';
+import 'package:anime_tv/features/catalog/domain/franchise_watch_order.dart';
 import 'package:anime_tv/features/downloads/application/offline_catalog_providers.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
@@ -40,9 +41,10 @@ final animeDetailsProvider = FutureProvider.family<AnimeSummary, int>((
   }
 });
 
-final franchiseProvider = FutureProvider.family<List<AnimeSummary>, int>(
-  (ref, id) => ref.watch(catalogClientProvider).franchise(id),
-);
+final franchiseProvider =
+    FutureProvider.family<List<FranchiseWatchOrderEntry>, int>(
+      (ref, id) => ref.watch(catalogClientProvider).franchiseWatchOrder(id),
+    );
 
 final studioAnimeProvider = FutureProvider.family<List<AnimeSummary>, int>(
   (ref, id) => ref.watch(catalogClientProvider).studioAnime(id),

--- a/lib/features/catalog/data/anilist_catalog_client.dart
+++ b/lib/features/catalog/data/anilist_catalog_client.dart
@@ -4,6 +4,7 @@ import 'package:anime_tv/core/storage/tetotv_database.dart';
 import 'package:anime_tv/features/catalog/data/kitsu_catalog_fallback.dart';
 import 'package:anime_tv/features/catalog/domain/anime_summary.dart';
 import 'package:anime_tv/features/catalog/domain/anime_trailer.dart';
+import 'package:anime_tv/features/catalog/domain/franchise_watch_order.dart';
 import 'package:dio/dio.dart';
 
 /// A catalog failure whose retryability is known without exposing the request
@@ -1436,38 +1437,56 @@ class AniListCatalogClient {
   }
 
   Future<List<AnimeSummary>> franchise(int mediaId) async {
+    final order = await franchiseWatchOrder(mediaId);
+    return List.unmodifiable(order.map((entry) => entry.anime));
+  }
+
+  Future<List<FranchiseWatchOrderEntry>> franchiseWatchOrder(
+    int mediaId,
+  ) async {
     final root = await details(mediaId);
-    final values = <int, AnimeSummary>{root.id: root};
-    for (final relation in root.relatedAnime) {
-      values[relation.anime.id] = relation.anime;
-    }
-    final directIds = root.relatedAnime
-        .where(
-          (item) =>
-              const ['SEQUEL', 'PREQUEL', 'PARENT'].contains(item.relationType),
-        )
-        .map((item) => item.anime.id)
-        .take(8);
-    final expanded = await Future.wait(directIds.map(details));
-    for (final anime in expanded) {
-      values[anime.id] = anime;
+    final expanded = <int, AnimeSummary>{root.id: root};
+    final pending = <int>{};
+
+    void queueContinuations(AnimeSummary anime) {
       for (final relation in anime.relatedAnime) {
-        if (const [
-          'SEQUEL',
-          'PREQUEL',
-          'PARENT',
-        ].contains(relation.relationType)) {
-          values[relation.anime.id] = relation.anime;
+        final type = relation.relationType.trim().toUpperCase().replaceAll(
+          '_',
+          ' ',
+        );
+        if (const {'SEQUEL', 'PREQUEL', 'PARENT'}.contains(type) &&
+            !expanded.containsKey(relation.anime.id)) {
+          pending.add(relation.anime.id);
         }
       }
     }
-    final result = values.values.toList();
-    result.sort((a, b) {
-      final year = (a.seasonYear ?? 9999).compareTo(b.seasonYear ?? 9999);
-      if (year != 0) return year;
-      return a.id.compareTo(b.id);
-    });
-    return result;
+
+    queueContinuations(root);
+    // Follow the primary continuation graph far enough to cover long-running
+    // franchises while keeping one Related Series visit bounded and fast.
+    const maximumDetailedTitles = 24;
+    while (pending.isNotEmpty && expanded.length < maximumDetailedTitles) {
+      final remainingCapacity = maximumDetailedTitles - expanded.length;
+      final batchIds = pending.take(remainingCapacity.clamp(1, 8)).toList();
+      pending.removeAll(batchIds);
+      final batch = await Future.wait(batchIds.map(details));
+      for (final anime in batch) {
+        expanded[anime.id] = anime;
+      }
+      // A reciprocal edge can point at another title from the same batch.
+      // Mark the whole batch complete before queuing its next continuation so
+      // that title is not fetched a second time on the following pass.
+      pending.removeAll(expanded.keys);
+      for (final anime in batch) {
+        queueContinuations(anime);
+      }
+      pending.removeAll(expanded.keys);
+    }
+
+    return buildRecommendedFranchiseWatchOrder(
+      rootId: root.id,
+      anime: expanded.values,
+    );
   }
 
   Future<List<AnimeSummary>> _mediaPage(

--- a/lib/features/catalog/domain/franchise_watch_order.dart
+++ b/lib/features/catalog/domain/franchise_watch_order.dart
@@ -1,0 +1,277 @@
+import 'package:anime_tv/features/catalog/domain/anime_summary.dart';
+
+enum FranchiseRelationRole {
+  current,
+  prequel,
+  sequel,
+  spinOff,
+  sideStory,
+  alternative,
+  summary,
+  adaptation,
+  other,
+}
+
+class FranchiseWatchOrderEntry {
+  const FranchiseWatchOrderEntry({
+    required this.anime,
+    required this.relationRole,
+  });
+
+  final AnimeSummary anime;
+  final FranchiseRelationRole relationRole;
+
+  String get relationLabel => switch (relationRole) {
+    FranchiseRelationRole.current => 'Current',
+    FranchiseRelationRole.prequel => 'Prequel',
+    FranchiseRelationRole.sequel => 'Sequel',
+    FranchiseRelationRole.spinOff => 'Spin-off',
+    FranchiseRelationRole.sideStory => 'Side story',
+    FranchiseRelationRole.alternative => 'Alternative',
+    FranchiseRelationRole.summary => 'Summary',
+    FranchiseRelationRole.adaptation => 'Adaptation',
+    FranchiseRelationRole.other => 'Related',
+  };
+
+  String get formatLabel => switch (_normalized(anime.format)) {
+    'MOVIE' => 'Movie',
+    'OVA' => 'OVA',
+    'SPECIAL' => 'Special',
+    'ONA' => 'ONA',
+    'TV SHORT' => 'TV short',
+    'TV' => 'TV',
+    final value when value.isNotEmpty => _titleCase(value),
+    _ => 'Anime',
+  };
+
+  String get watchOrderLabel => '$formatLabel · $relationLabel';
+}
+
+/// Builds a deterministic, cycle-safe watch order from AniList relations.
+///
+/// Continuation relations define the primary path. Side stories, spin-offs,
+/// summaries, and alternatives are placed after the title which references
+/// them. Release metadata is used only as a stable tie-breaker, so a sequel is
+/// never moved ahead of its known prequel merely because one date is missing.
+List<FranchiseWatchOrderEntry> buildRecommendedFranchiseWatchOrder({
+  required int rootId,
+  required Iterable<AnimeSummary> anime,
+}) {
+  final sources = anime.toList(growable: false);
+  final byId = <int, AnimeSummary>{};
+  for (final item in sources) {
+    _rememberBestSummary(byId, item);
+    for (final relation in item.relatedAnime) {
+      _rememberBestSummary(byId, relation.anime);
+    }
+  }
+  if (byId.isEmpty) return const [];
+
+  final orderEdges = <int, Set<int>>{for (final id in byId.keys) id: <int>{}};
+  final continuationEdges = <int, Set<int>>{
+    for (final id in byId.keys) id: <int>{},
+  };
+  final directRootRelations = <int, String>{};
+  final relationHints = <int, Set<String>>{};
+
+  void addEdge(Map<int, Set<int>> graph, int from, int to) {
+    if (from != to && graph.containsKey(from) && graph.containsKey(to)) {
+      graph[from]!.add(to);
+    }
+  }
+
+  for (final source in sources) {
+    if (!byId.containsKey(source.id)) continue;
+    for (final related in source.relatedAnime) {
+      final targetId = related.anime.id;
+      if (!byId.containsKey(targetId) || targetId == source.id) continue;
+      final relation = _normalized(related.relationType);
+      relationHints.putIfAbsent(targetId, () => <String>{}).add(relation);
+      if (source.id == rootId) directRootRelations[targetId] = relation;
+
+      switch (relation) {
+        case 'SEQUEL':
+          addEdge(orderEdges, source.id, targetId);
+          addEdge(continuationEdges, source.id, targetId);
+        case 'PREQUEL':
+        case 'PARENT':
+          addEdge(orderEdges, targetId, source.id);
+          addEdge(continuationEdges, targetId, source.id);
+        case 'SIDE STORY':
+        case 'SPIN OFF':
+        case 'SUMMARY':
+        case 'ALTERNATIVE':
+        case 'COMPILATION':
+        case 'CONTAINS':
+          addEdge(orderEdges, source.id, targetId);
+      }
+    }
+  }
+
+  final successors = _reachableFrom(rootId, continuationEdges);
+  final reverseContinuation = <int, Set<int>>{
+    for (final id in byId.keys) id: <int>{},
+  };
+  for (final entry in continuationEdges.entries) {
+    for (final target in entry.value) {
+      reverseContinuation[target]!.add(entry.key);
+    }
+  }
+  final predecessors = _reachableFrom(rootId, reverseContinuation);
+
+  FranchiseRelationRole roleFor(int id) {
+    if (id == rootId) return FranchiseRelationRole.current;
+    final direct = directRootRelations[id];
+    final directRole = _roleForDirectRelation(direct);
+    if (directRole != null && directRole != FranchiseRelationRole.other) {
+      return directRole;
+    }
+    if (predecessors.contains(id)) return FranchiseRelationRole.prequel;
+    if (successors.contains(id)) return FranchiseRelationRole.sequel;
+    final hints = relationHints[id] ?? const <String>{};
+    for (final relation in const [
+      'SPIN OFF',
+      'SIDE STORY',
+      'SUMMARY',
+      'ALTERNATIVE',
+      'ADAPTATION',
+      'SOURCE',
+    ]) {
+      if (hints.contains(relation)) {
+        return _roleForDirectRelation(relation) ?? FranchiseRelationRole.other;
+      }
+    }
+    return directRole ?? FranchiseRelationRole.other;
+  }
+
+  final roleById = <int, FranchiseRelationRole>{
+    for (final id in byId.keys) id: roleFor(id),
+  };
+  final orderedIds = _stableTopologicalOrder(
+    byId: byId,
+    edges: orderEdges,
+    roleById: roleById,
+  );
+  return List.unmodifiable([
+    for (final id in orderedIds)
+      FranchiseWatchOrderEntry(anime: byId[id]!, relationRole: roleById[id]!),
+  ]);
+}
+
+void _rememberBestSummary(Map<int, AnimeSummary> byId, AnimeSummary candidate) {
+  final current = byId[candidate.id];
+  if (current == null ||
+      (current.relatedAnime.isEmpty && candidate.relatedAnime.isNotEmpty)) {
+    byId[candidate.id] = candidate;
+  }
+}
+
+Set<int> _reachableFrom(int start, Map<int, Set<int>> graph) {
+  if (!graph.containsKey(start)) return const <int>{};
+  final reached = <int>{};
+  final pending = <int>[start];
+  while (pending.isNotEmpty) {
+    final current = pending.removeLast();
+    for (final target in graph[current] ?? const <int>{}) {
+      if (target != start && reached.add(target)) pending.add(target);
+    }
+  }
+  return reached;
+}
+
+List<int> _stableTopologicalOrder({
+  required Map<int, AnimeSummary> byId,
+  required Map<int, Set<int>> edges,
+  required Map<int, FranchiseRelationRole> roleById,
+}) {
+  final remaining = byId.keys.toSet();
+  final incoming = <int, int>{for (final id in remaining) id: 0};
+  for (final targets in edges.values) {
+    for (final target in targets) {
+      incoming[target] = (incoming[target] ?? 0) + 1;
+    }
+  }
+
+  int compareIds(int left, int right) {
+    final a = byId[left]!;
+    final b = byId[right]!;
+    final year = (a.seasonYear ?? 9999).compareTo(b.seasonYear ?? 9999);
+    if (year != 0) return year;
+    final season = _seasonRank(a.season).compareTo(_seasonRank(b.season));
+    if (season != 0) return season;
+    final role = _roleRank(
+      roleById[left]!,
+    ).compareTo(_roleRank(roleById[right]!));
+    if (role != 0) return role;
+    return left.compareTo(right);
+  }
+
+  final result = <int>[];
+  while (remaining.isNotEmpty) {
+    final ready = remaining.where((id) => incoming[id] == 0).toList()
+      ..sort(compareIds);
+    // AniList data can contain reciprocal or malformed relation cycles. Pick
+    // a deterministic release-order anchor and remove its incoming cycle
+    // edges rather than omitting the entire connected component.
+    final next = ready.isNotEmpty
+        ? ready.first
+        : (remaining.toList()..sort(compareIds)).first;
+    remaining.remove(next);
+    result.add(next);
+    for (final target in edges[next] ?? const <int>{}) {
+      if (remaining.contains(target)) {
+        incoming[target] = (incoming[target] ?? 1) - 1;
+      }
+    }
+  }
+  return result;
+}
+
+FranchiseRelationRole? _roleForDirectRelation(String? relation) =>
+    switch (relation) {
+      'PREQUEL' || 'PARENT' => FranchiseRelationRole.prequel,
+      'SEQUEL' => FranchiseRelationRole.sequel,
+      'SPIN OFF' => FranchiseRelationRole.spinOff,
+      'SIDE STORY' => FranchiseRelationRole.sideStory,
+      'ALTERNATIVE' => FranchiseRelationRole.alternative,
+      'SUMMARY' || 'COMPILATION' => FranchiseRelationRole.summary,
+      'ADAPTATION' || 'SOURCE' => FranchiseRelationRole.adaptation,
+      null => null,
+      _ => FranchiseRelationRole.other,
+    };
+
+int _seasonRank(String? season) => switch (_normalized(season)) {
+  'WINTER' => 0,
+  'SPRING' => 1,
+  'SUMMER' => 2,
+  'FALL' => 3,
+  _ => 4,
+};
+
+int _roleRank(FranchiseRelationRole role) => switch (role) {
+  FranchiseRelationRole.prequel => 0,
+  FranchiseRelationRole.current => 1,
+  FranchiseRelationRole.sequel => 2,
+  FranchiseRelationRole.sideStory => 3,
+  FranchiseRelationRole.spinOff => 4,
+  FranchiseRelationRole.summary => 5,
+  FranchiseRelationRole.alternative => 6,
+  FranchiseRelationRole.adaptation => 7,
+  FranchiseRelationRole.other => 8,
+};
+
+String _normalized(String? value) =>
+    value
+        ?.trim()
+        .toUpperCase()
+        .replaceAll('_', ' ')
+        .replaceAll('-', ' ')
+        .replaceAll(RegExp(r'\s+'), ' ') ??
+    '';
+
+String _titleCase(String value) => value
+    .toLowerCase()
+    .split(' ')
+    .where((part) => part.isNotEmpty)
+    .map((part) => '${part[0].toUpperCase()}${part.substring(1)}')
+    .join(' ');

--- a/lib/features/catalog/presentation/anime_details_screen.dart
+++ b/lib/features/catalog/presentation/anime_details_screen.dart
@@ -486,6 +486,9 @@ class _DetailsContentState extends ConsumerState<_DetailsContent> {
                                 onCredits: onCredits,
                                 onDownloadSeason: onDownloadSeason,
                                 downloadSeasonLabel: downloadSeasonLabel,
+                                television: isTelevision,
+                                large: isTelevision,
+                                availableWidth: constraints.maxWidth,
                               ),
                             ],
                           ],
@@ -526,6 +529,11 @@ class _DetailsContentState extends ConsumerState<_DetailsContent> {
               final posterWidth = targetPosterWidth
                   .clamp(minimumPosterWidth, maximumPosterWidth)
                   .toDouble();
+              final informationWidth =
+                  constraints.maxWidth -
+                  posterWidth -
+                  actionWidth -
+                  columnGap * 2;
               return Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
@@ -676,6 +684,8 @@ class _DetailsContentState extends ConsumerState<_DetailsContent> {
                                       onCredits: onCredits,
                                       onDownloadSeason: onDownloadSeason,
                                       downloadSeasonLabel: downloadSeasonLabel,
+                                      television: isTelevision,
+                                      availableWidth: informationWidth,
                                       // Android televisions do not all expose
                                       // the same logical canvas. Keep the
                                       // 10-foot action styling on TV even when
@@ -1239,6 +1249,8 @@ class _InformationActions extends StatelessWidget {
     required this.onCredits,
     required this.onDownloadSeason,
     required this.downloadSeasonLabel,
+    required this.television,
+    required this.availableWidth,
     this.large = false,
   });
 
@@ -1247,6 +1259,8 @@ class _InformationActions extends StatelessWidget {
   final VoidCallback? onCredits;
   final VoidCallback? onDownloadSeason;
   final String downloadSeasonLabel;
+  final bool television;
+  final double availableWidth;
   final bool large;
 
   @override
@@ -1317,7 +1331,7 @@ class _InformationActions extends StatelessWidget {
       (total, action) => total + action.preferredWidth,
     );
     final preferredStripWidth =
-        preferredButtonsWidth + (spacing * (actions.length - 1));
+        preferredButtonsWidth + spacing * (actions.length - 1);
 
     return FocusTraversalGroup(
       policy: ReadingOrderTraversalPolicy(),
@@ -1331,39 +1345,44 @@ class _InformationActions extends StatelessWidget {
         ),
         child: LayoutBuilder(
           builder: (context, constraints) {
-            // Keep the controls on one visual baseline like the TV reference.
-            // If a compact device cannot show their readable widths at once,
-            // the strip scrolls horizontally as focus (or touch) moves rather
-            // than wrapping or overflowing the screen.
-            final minimumReadableScale = .90;
-            final minimumStripWidth =
-                preferredStripWidth * minimumReadableScale;
-            // TV typography and icons must remain at their intended 10-foot
-            // size. A narrow TV column scrolls the fixed-width strip instead
-            // of quietly shrinking it into the phone treatment.
-            final stripWidth = large
-                ? preferredStripWidth
-                : constraints.maxWidth >= preferredStripWidth
-                ? preferredStripWidth
-                : constraints.maxWidth >= minimumStripWidth
+            // One row replaces the old two-row footprint. Never halve the
+            // control widths and then ask FittedBox to make 10-foot text fit:
+            // a constrained canvas keeps all actions visible by stacking each
+            // full-size icon above its (up to two-line) label instead.
+            final constraintWidth = constraints.hasBoundedWidth
                 ? constraints.maxWidth
-                : minimumStripWidth;
-            final widthScale = preferredStripWidth == 0
-                ? 1.0
-                : (stripWidth - (spacing * (actions.length - 1))) /
-                      preferredButtonsWidth;
-
-            return SingleChildScrollView(
-              scrollDirection: Axis.horizontal,
-              child: SizedBox(
-                width: stripWidth,
-                child: Row(
-                  crossAxisAlignment: CrossAxisAlignment.end,
-                  children: [
-                    for (var index = 0; index < actions.length; index++) ...[
-                      if (index > 0) SizedBox(width: spacing),
+                : preferredStripWidth;
+            final boundedWidth = (availableWidth - panelPadding.horizontal)
+                .clamp(0.0, constraintWidth)
+                .clamp(0.0, preferredStripWidth)
+                .toDouble();
+            final compact = boundedWidth < preferredStripWidth;
+            final compactSpacing = large || television ? 6.0 : 5.0;
+            final stripWidth = compact ? boundedWidth : preferredStripWidth;
+            return SizedBox(
+              width: stripWidth,
+              child: Row(
+                crossAxisAlignment: CrossAxisAlignment.center,
+                children: [
+                  for (var index = 0; index < actions.length; index++) ...[
+                    if (index > 0)
+                      SizedBox(width: compact ? compactSpacing : spacing),
+                    if (compact)
+                      Expanded(
+                        child: _InformationButton(
+                          key: actions[index].key,
+                          surfaceKey: actions[index].surfaceKey,
+                          label: actions[index].label,
+                          icon: actions[index].icon,
+                          onPressed: actions[index].onPressed,
+                          primary: actions[index].primary,
+                          large: large,
+                          stacked: true,
+                        ),
+                      )
+                    else
                       SizedBox(
-                        width: actions[index].preferredWidth * widthScale,
+                        width: actions[index].preferredWidth,
                         child: _InformationButton(
                           key: actions[index].key,
                           surfaceKey: actions[index].surfaceKey,
@@ -1374,9 +1393,8 @@ class _InformationActions extends StatelessWidget {
                           large: large,
                         ),
                       ),
-                    ],
                   ],
-                ),
+                ],
               ),
             );
           },
@@ -1395,6 +1413,7 @@ class _InformationButton extends StatelessWidget {
     required this.large,
     required this.surfaceKey,
     this.primary = false,
+    this.stacked = false,
   });
 
   final String label;
@@ -1402,6 +1421,7 @@ class _InformationButton extends StatelessWidget {
   final VoidCallback onPressed;
   final bool large;
   final bool primary;
+  final bool stacked;
   final Key? surfaceKey;
 
   @override
@@ -1424,32 +1444,57 @@ class _InformationButton extends StatelessWidget {
       },
       child: Container(
         key: surfaceKey,
-        height: large ? 58 : 42,
+        height: stacked ? (large ? 64 : 54) : (large ? 58 : 42),
         alignment: Alignment.center,
-        padding: EdgeInsets.symmetric(horizontal: large ? 14 : 11),
+        padding: EdgeInsets.symmetric(
+          horizontal: stacked ? (large ? 4 : 3) : (large ? 14 : 11),
+          vertical: stacked ? 2 : 0,
+        ),
         decoration: BoxDecoration(
           color: primary ? context.appPalette.accent : const Color(0xEE171717),
           borderRadius: BorderRadius.circular(10),
           border: Border.all(color: Colors.white.withValues(alpha: .15)),
         ),
-        child: FittedBox(
-          fit: BoxFit.scaleDown,
-          child: Row(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              Icon(icon, size: large ? 23 : 18),
-              SizedBox(width: large ? 9 : 7),
-              Text(
-                label,
-                maxLines: 1,
-                style: TextStyle(
-                  fontSize: large ? 16 : 12,
-                  fontWeight: FontWeight.w700,
-                ),
+        child: stacked
+            ? Column(
+                mainAxisSize: MainAxisSize.max,
+                children: [
+                  Icon(icon, size: large ? 23 : 18),
+                  const SizedBox(height: 1),
+                  Expanded(
+                    child: Center(
+                      child: Text(
+                        label,
+                        maxLines: 2,
+                        overflow: TextOverflow.ellipsis,
+                        textAlign: TextAlign.center,
+                        style: TextStyle(
+                          fontSize: large ? 16 : 12,
+                          height: 1,
+                          fontWeight: FontWeight.w700,
+                        ),
+                      ),
+                    ),
+                  ),
+                ],
+              )
+            : Row(
+                children: [
+                  Icon(icon, size: large ? 23 : 18),
+                  SizedBox(width: large ? 9 : 7),
+                  Expanded(
+                    child: Text(
+                      label,
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                      style: TextStyle(
+                        fontSize: large ? 16 : 12,
+                        fontWeight: FontWeight.w700,
+                      ),
+                    ),
+                  ),
+                ],
               ),
-            ],
-          ),
-        ),
       ),
     );
   }

--- a/lib/features/catalog/presentation/catalog_grid.dart
+++ b/lib/features/catalog/presentation/catalog_grid.dart
@@ -21,6 +21,7 @@ class CatalogGrid extends StatefulWidget {
     this.onNavigateLeftFromFirstColumn,
     this.onNavigateUpFromFirstRow,
     this.onLongPress,
+    this.itemBadgeText,
     super.key,
   });
 
@@ -31,6 +32,7 @@ class CatalogGrid extends StatefulWidget {
   final VoidCallback? onNavigateLeftFromFirstColumn;
   final VoidCallback? onNavigateUpFromFirstRow;
   final ValueChanged<AnimeSummary>? onLongPress;
+  final String? Function(AnimeSummary anime)? itemBadgeText;
 
   @override
   State<CatalogGrid> createState() => _CatalogGridState();
@@ -479,6 +481,7 @@ class _CatalogGridState extends State<CatalogGrid> {
           },
           itemBuilder: (context, index) {
             final anime = widget.items[index];
+            final itemBadgeText = widget.itemBadgeText?.call(anime);
             return TvFocusable(
               key: ValueKey(_itemIdentities[index]),
               focusNode: _focusNodeAt(index),
@@ -531,6 +534,26 @@ class _CatalogGridState extends State<CatalogGrid> {
                                   status: anime.status,
                                 ),
                               ),
+                            if (itemBadgeText != null &&
+                                itemBadgeText.trim().isNotEmpty)
+                              Positioned(
+                                right: 5,
+                                top:
+                                    animeAiringStatusLabel(anime.status) == null
+                                    ? 5
+                                    : 29,
+                                child: ConstrainedBox(
+                                  constraints: BoxConstraints(
+                                    maxWidth: cardCrossAxisExtent * .88,
+                                  ),
+                                  child: _CatalogItemContextBadge(
+                                    key: ValueKey(
+                                      'catalog-item-context-${anime.id}',
+                                    ),
+                                    label: itemBadgeText,
+                                  ),
+                                ),
+                              ),
                             Positioned(
                               left: 5,
                               right: 5,
@@ -571,6 +594,43 @@ class _CatalogGridState extends State<CatalogGrid> {
           },
         );
       },
+    );
+  }
+}
+
+class _CatalogItemContextBadge extends StatelessWidget {
+  const _CatalogItemContextBadge({required this.label, super.key});
+
+  final String label;
+
+  @override
+  Widget build(BuildContext context) {
+    return DecoratedBox(
+      decoration: BoxDecoration(
+        color: const Color(0xE8101010),
+        borderRadius: BorderRadius.circular(4),
+        border: Border.all(
+          color: context.appPalette.accentBright.withValues(alpha: .72),
+        ),
+      ),
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 4),
+        child: FittedBox(
+          fit: BoxFit.scaleDown,
+          alignment: Alignment.centerRight,
+          child: Text(
+            label,
+            maxLines: 1,
+            style: const TextStyle(
+              color: Colors.white,
+              fontSize: 8,
+              fontWeight: FontWeight.w900,
+              letterSpacing: .25,
+              height: 1,
+            ),
+          ),
+        ),
+      ),
     );
   }
 }

--- a/lib/features/catalog/presentation/franchise_screen.dart
+++ b/lib/features/catalog/presentation/franchise_screen.dart
@@ -36,13 +36,17 @@ class FranchiseScreen extends ConsumerWidget {
                 ),
                 const SizedBox(width: 14),
                 Text(
-                  'Franchise order',
+                  'Recommended watch order',
                   style: Theme.of(context).textTheme.headlineSmall,
                 ),
                 const SizedBox(width: 14),
-                Text(
-                  'Sequels, prequels, side stories, and connected titles',
-                  style: TextStyle(color: context.appPalette.mutedText),
+                Expanded(
+                  child: Text(
+                    'Prequels, sequels, movies, OVAs, specials, and spin-offs',
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                    style: TextStyle(color: context.appPalette.mutedText),
+                  ),
                 ),
               ],
             ),
@@ -56,11 +60,19 @@ class FranchiseScreen extends ConsumerWidget {
                 ),
                 error: (error, _) =>
                     Center(child: Text('Could not build franchise: $error')),
-                data: (items) => CatalogGrid(
-                  items: items,
-                  titlePreference: preference,
-                  autofocus: false,
-                ),
+                data: (entries) {
+                  final badgeByMediaId = <int, String>{
+                    for (var index = 0; index < entries.length; index++)
+                      entries[index].anime.id:
+                          '#${index + 1} · ${entries[index].watchOrderLabel}',
+                  };
+                  return CatalogGrid(
+                    items: [for (final entry in entries) entry.anime],
+                    titlePreference: preference,
+                    autofocus: false,
+                    itemBadgeText: (anime) => badgeByMediaId[anime.id],
+                  );
+                },
               ),
             ),
           ],

--- a/lib/features/home/presentation/home_screen.dart
+++ b/lib/features/home/presentation/home_screen.dart
@@ -1125,18 +1125,47 @@ class _HeroPanel extends StatelessWidget {
         // never lays out its title beyond the visible card.
         ? screenWidth - 62
         : isTelevision
-        // Keep the complete title within roughly the left half of the TV hero
-        // so even long localized titles can wrap without covering the subject
-        // artwork on the right.
-        ? (screenWidth * .48).clamp(360.0, 920.0)
+        // Give the title the left half of the TV hero. Do not cap this on
+        // larger canvases: using the available width keeps localized titles
+        // readable without shrinking their type or covering the artwork.
+        ? (screenWidth * .5).clamp(360.0, double.infinity)
         : screenWidth >= 1400
         ? 660.0
         : screenWidth >= 1100
         ? 570.0
         : 310.0;
-    final titleHeight = shortTvHero ? 68.0 : (cinematicTv ? 102.0 : 80.0);
     final displayTitle =
         anime?.displayTitle(titlePreference) ?? 'Frieren: Beyond Journey’s End';
+    final titleStyle = Theme.of(context).textTheme.displaySmall?.copyWith(
+      color: context.appPalette.primaryText,
+      fontSize: cinematicTv
+          ? (shortTvHero ? 33 : (dense ? 39 : 46))
+          : (compact ? 29 : 39),
+      height: .98,
+      fontWeight: FontWeight.w900,
+    );
+    final baseTitleHeight = isTelevision
+        ? 102.0
+        : (shortTvHero ? 68.0 : (cinematicTv ? 102.0 : 80.0));
+    final measuredTitleHeight = isTelevision
+        ? _measureHeroTitleHeight(
+            context,
+            title: displayTitle,
+            width: copyWidth,
+            style: titleStyle,
+          )
+        : baseTitleHeight;
+    final titleHeight = measuredTitleHeight > baseTitleHeight
+        ? measuredTitleHeight.ceilToDouble()
+        : baseTitleHeight;
+    final baseHeroHeight =
+        height ?? (compact ? (dense ? 360.0 : 410.0) : (dense ? 290.0 : 350.0));
+    // TV Home scrolls vertically, so an exceptional localized title can grow
+    // the banner instead of shrinking, clipping, or painting over the facts
+    // and actions below it. Normal titles keep the established hero height.
+    final resolvedHeroHeight = isTelevision
+        ? baseHeroHeight + titleHeight - baseTitleHeight
+        : baseHeroHeight;
     final facts = <String>[
       if (anime?.seasonYear case final year?) '$year',
       if (anime?.format case final format?) format.replaceAll('_', ' '),
@@ -1151,7 +1180,7 @@ class _HeroPanel extends StatelessWidget {
     ];
     return Container(
       key: const ValueKey('home-hero'),
-      height: height ?? (compact ? (dense ? 360 : 410) : (dense ? 290 : 350)),
+      height: resolvedHeroHeight,
       clipBehavior: Clip.hardEdge,
       decoration: BoxDecoration(color: context.appPalette.surface),
       child: Stack(
@@ -1211,7 +1240,7 @@ class _HeroPanel extends StatelessWidget {
           Padding(
             padding: EdgeInsets.fromLTRB(
               cinematicTv ? 34 : (compact ? 15 : 18),
-              shortTvHero ? 68 : (cinematicTv ? 78 : (compact ? 24 : 30)),
+              shortTvHero ? 60 : (cinematicTv ? 78 : (compact ? 24 : 30)),
               cinematicTv ? 28 : (compact ? 15 : 24),
               shortTvHero ? 18 : (cinematicTv ? 28 : (compact ? 18 : 22)),
             ),
@@ -1253,17 +1282,8 @@ class _HeroPanel extends StatelessWidget {
                       alignment: Alignment.centerLeft,
                       child: _HeroTitleText(
                         title: displayTitle,
-                        width: copyWidth,
                         fitEntireTitle: isTelevision,
-                        style: Theme.of(context).textTheme.displaySmall
-                            ?.copyWith(
-                              color: context.appPalette.primaryText,
-                              fontSize: cinematicTv
-                                  ? (shortTvHero ? 33 : (dense ? 39 : 46))
-                                  : (compact ? 29 : 39),
-                              height: .98,
-                              fontWeight: FontWeight.w900,
-                            ),
+                        style: titleStyle,
                       ),
                     ),
                   ),
@@ -1330,34 +1350,39 @@ class _HeroPanel extends StatelessWidget {
 class _HeroTitleText extends StatelessWidget {
   const _HeroTitleText({
     required this.title,
-    required this.width,
     required this.fitEntireTitle,
     required this.style,
   });
 
   final String title;
-  final double width;
   final bool fitEntireTitle;
   final TextStyle? style;
 
   @override
   Widget build(BuildContext context) {
-    final titleText = Text(
+    return Text(
       title,
       maxLines: fitEntireTitle ? null : 2,
       overflow: fitEntireTitle ? TextOverflow.visible : TextOverflow.ellipsis,
       softWrap: true,
       style: style,
     );
-    if (!fitEntireTitle) return titleText;
-
-    return FittedBox(
-      key: const ValueKey('home-hero-title-fit'),
-      fit: BoxFit.scaleDown,
-      alignment: Alignment.centerLeft,
-      child: SizedBox(width: width, child: titleText),
-    );
   }
+}
+
+double _measureHeroTitleHeight(
+  BuildContext context, {
+  required String title,
+  required double width,
+  required TextStyle? style,
+}) {
+  final painter = TextPainter(
+    text: TextSpan(text: title, style: style),
+    textDirection: Directionality.of(context),
+    textScaler: MediaQuery.textScalerOf(context),
+    locale: Localizations.maybeLocaleOf(context),
+  )..layout(maxWidth: width);
+  return painter.height;
 }
 
 class _HeroMetadataLine extends StatelessWidget {

--- a/lib/features/marketplace/application/web_stream_aggregator.dart
+++ b/lib/features/marketplace/application/web_stream_aggregator.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:math' as math;
 
 import 'package:anime_tv/core/storage/tetotv_database.dart';
 import 'package:anime_tv/features/marketplace/application/marketplace_controller.dart';
@@ -11,6 +12,22 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 const defaultWebProviderDeadline = Duration(seconds: 20);
 const defaultMaxConcurrentWebProviders = 2;
+
+var _webProviderSearchDiagnosticSequence = 0;
+final String _webProviderSearchDiagnosticBootNonce = (() {
+  final random = math.Random.secure();
+  return List<String>.generate(
+    3,
+    (_) => random.nextInt(0x10000).toRadixString(16).padLeft(4, '0'),
+    growable: false,
+  ).join();
+})();
+
+/// Returns a media-free correlation ID that remains unique across process
+/// restarts while the bounded diagnostic history is retained.
+String nextWebProviderSearchDiagnosticSessionId() =>
+    'provider-search-$_webProviderSearchDiagnosticBootNonce-'
+    '${++_webProviderSearchDiagnosticSequence}';
 
 /// Carries only audio capability a provider explicitly reported into the
 /// playback launch. A legacy unlabeled result remains unknown instead of
@@ -40,12 +57,14 @@ class WebStreamSearchProgress {
     this.completedProviders = 0,
     this.totalProviders = 0,
     this.pendingProviderNames = const [],
+    this.diagnosticSessionId = '',
   });
 
   final WebStreamAggregation aggregation;
   final int completedProviders;
   final int totalProviders;
   final List<String> pendingProviderNames;
+  final String diagnosticSessionId;
 
   bool get isComplete => completedProviders >= totalProviders;
 }
@@ -131,8 +150,10 @@ class WebStreamAggregator {
   Stream<WebStreamSearchProgress> searchIncrementally(
     EpisodeReference episode,
   ) async* {
+    final diagnosticSessionId = nextWebProviderSearchDiagnosticSessionId();
     final health = await _store.providerHealth();
-    final enabledAddons = (await _store.installedAddons())
+    final installedAddons = await _store.installedAddons();
+    final enabledAddons = installedAddons
         .where((addon) => addon.enabled)
         .toList(growable: false);
     final availabilityFailures = <WebProviderFailure>[];
@@ -151,6 +172,7 @@ class WebStreamAggregator {
       availabilityFailures.add(failure);
       _recordProviderSearchOutcome(
         provider,
+        diagnosticSessionId: diagnosticSessionId,
         status: failure.status.name,
         count: 0,
         stage: failure.stage ?? 'availability',
@@ -164,56 +186,78 @@ class WebStreamAggregator {
     }
     final addons = orderInstalledProvidersByHealth(searchable, health);
     final providers = addons.map(SeanimeJavascriptProvider.new).toList();
-    await for (final progress in aggregateWebStreamingProvidersIncrementally(
-      providers,
-      episode,
-      deadline: providerDeadline,
-      maxConcurrentProviders: maxConcurrentProviders,
-      onSuccess: (provider, streams) async {
-        final hasStreams = streams.isNotEmpty;
-        if (hasStreams) await _store.recordProviderSuccess(provider.id);
-        _recordProviderSearchOutcome(
-          provider,
-          status: hasStreams ? 'success' : 'no_match',
-          count: streams.length,
-          stage: 'complete',
-          reason: hasStreams ? 'streams_returned' : 'empty_result',
-        );
-      },
-      onFailure: (provider, error, noMatch) async {
-        final details = seanimeProviderFailureDetails(error);
-        final identityNoMatch = error is _EpisodeIdentityNoMatch;
-        final stage = identityNoMatch
-            ? 'episode_lookup'
-            : details?.stage ?? 'runtime';
-        final reason = identityNoMatch
-            ? 'episode_identity_mismatch'
-            : details?.reason ??
-                  (error is TimeoutException ? 'timeout' : 'provider_error');
-        if (!noMatch) {
-          final healthMessage = seanimeProviderFailureMessage(error);
-          await _store.recordProviderFailure(
-            provider.id,
-            healthMessage,
+    _recordProviderSearchSummary(
+      webProviderSearchSummaryDiagnosticDetails(
+        phase: 'start',
+        diagnosticSessionId: diagnosticSessionId,
+        installedProviders: installedAddons.length,
+        enabledProviders: enabledAddons.length,
+        searchableProviders: providers.length,
+        blockedProviders: blockedProviders,
+        completedProviders: blockedProviders,
+        returnedProviders: 0,
+        returnedResults: 0,
+      ),
+    );
+    var recordedInitialProgress = false;
+    var lastProgressMilestone = blockedProviders;
+    var terminalSummaryRecorded = false;
+    var lastCompletedProviders = blockedProviders;
+    var lastAggregation = WebStreamAggregation(
+      failures: List.unmodifiable(availabilityFailures),
+    );
+    try {
+      await for (final progress in aggregateWebStreamingProvidersIncrementally(
+        providers,
+        episode,
+        deadline: providerDeadline,
+        maxConcurrentProviders: maxConcurrentProviders,
+        onSuccess: (provider, streams) async {
+          final hasStreams = streams.isNotEmpty;
+          if (hasStreams) await _store.recordProviderSuccess(provider.id);
+          _recordProviderSearchOutcome(
+            provider,
+            diagnosticSessionId: diagnosticSessionId,
+            status: hasStreams ? 'success' : 'no_match',
+            count: streams.length,
+            stage: 'complete',
+            reason: hasStreams ? 'streams_returned' : 'empty_result',
+          );
+        },
+        onFailure: (provider, error, noMatch) async {
+          final details = seanimeProviderFailureDetails(error);
+          final identityNoMatch = error is _EpisodeIdentityNoMatch;
+          final stage = identityNoMatch
+              ? 'episode_lookup'
+              : details?.stage ?? 'runtime';
+          final reason = identityNoMatch
+              ? 'episode_identity_mismatch'
+              : details?.reason ??
+                    (error is TimeoutException ? 'timeout' : 'provider_error');
+          if (!noMatch) {
+            final healthMessage = seanimeProviderFailureMessage(error);
+            await _store.recordProviderFailure(
+              provider.id,
+              healthMessage,
+              stage: stage,
+              reason: reason,
+            );
+          }
+          _recordProviderSearchOutcome(
+            provider,
+            diagnosticSessionId: diagnosticSessionId,
+            status: noMatch ? 'no_match' : 'failed',
+            count: 0,
             stage: stage,
             reason: reason,
           );
-        }
-        _recordProviderSearchOutcome(
-          provider,
-          status: noMatch ? 'no_match' : 'failed',
-          count: 0,
-          stage: stage,
-          reason: reason,
-        );
-      },
-    )) {
-      final providersWithRuntimeStatus = {
-        for (final failure in progress.aggregation.failures)
-          if (failure.providerId case final id?) id.trim().toLowerCase(),
-      };
-      yield WebStreamSearchProgress(
-        aggregation: mergeWebProviderOutcomes([
+        },
+      )) {
+        final providersWithRuntimeStatus = {
+          for (final failure in progress.aggregation.failures)
+            if (failure.providerId case final id?) id.trim().toLowerCase(),
+        };
+        final aggregation = mergeWebProviderOutcomes([
           (streams: progress.aggregation.streams, failure: null),
           for (final failure in [
             ...availabilityFailures.where(
@@ -226,16 +270,122 @@ class WebStreamAggregator {
             ...progress.aggregation.failures,
           ])
             (streams: const <WebStreamResult>[], failure: failure),
-        ]),
-        completedProviders: progress.completedProviders + blockedProviders,
-        totalProviders: enabledAddons.length,
-        pendingProviderNames: progress.pendingProviderNames,
+        ]);
+        final completedProviders =
+            progress.completedProviders + blockedProviders;
+        final isComplete = completedProviders >= enabledAddons.length;
+        final returnedProviders = aggregation.streams
+            .map(webStreamProviderIdentity)
+            .toSet()
+            .length;
+        final shouldRecordProgress =
+            !isComplete &&
+            (!recordedInitialProgress ||
+                completedProviders - lastProgressMilestone >= 4);
+        if (shouldRecordProgress || isComplete) {
+          final phase = isComplete ? 'final' : 'progress';
+          _recordProviderSearchSummary(
+            webProviderSearchSummaryDiagnosticDetails(
+              phase: phase,
+              diagnosticSessionId: diagnosticSessionId,
+              installedProviders: installedAddons.length,
+              enabledProviders: enabledAddons.length,
+              searchableProviders: providers.length,
+              blockedProviders: blockedProviders,
+              completedProviders: completedProviders,
+              returnedProviders: returnedProviders,
+              returnedResults: aggregation.streams.length,
+              failureReasonCounts: webProviderFailureReasonCounts(
+                aggregation.failures,
+              ),
+            ),
+          );
+          if (!isComplete) {
+            recordedInitialProgress = true;
+            lastProgressMilestone = completedProviders;
+          } else {
+            terminalSummaryRecorded = true;
+          }
+        }
+        lastCompletedProviders = completedProviders;
+        lastAggregation = aggregation;
+        yield WebStreamSearchProgress(
+          aggregation: aggregation,
+          completedProviders: completedProviders,
+          totalProviders: enabledAddons.length,
+          pendingProviderNames: progress.pendingProviderNames,
+          diagnosticSessionId: diagnosticSessionId,
+        );
+      }
+    } catch (_) {
+      terminalSummaryRecorded = true;
+      _recordProviderSearchSummary(
+        webProviderSearchSummaryDiagnosticDetails(
+          phase: 'error',
+          diagnosticSessionId: diagnosticSessionId,
+          installedProviders: installedAddons.length,
+          enabledProviders: enabledAddons.length,
+          searchableProviders: providers.length,
+          blockedProviders: blockedProviders,
+          completedProviders: lastCompletedProviders,
+          returnedProviders: lastAggregation.streams
+              .map(webStreamProviderIdentity)
+              .toSet()
+              .length,
+          returnedResults: lastAggregation.streams.length,
+          failureReasonCounts: webProviderFailureReasonCounts(
+            lastAggregation.failures,
+          ),
+        ),
       );
+      rethrow;
+    } finally {
+      if (!terminalSummaryRecorded) {
+        _recordProviderSearchSummary(
+          webProviderSearchSummaryDiagnosticDetails(
+            phase: 'canceled',
+            diagnosticSessionId: diagnosticSessionId,
+            installedProviders: installedAddons.length,
+            enabledProviders: enabledAddons.length,
+            searchableProviders: providers.length,
+            blockedProviders: blockedProviders,
+            completedProviders: lastCompletedProviders,
+            returnedProviders: lastAggregation.streams
+                .map(webStreamProviderIdentity)
+                .toSet()
+                .length,
+            returnedResults: lastAggregation.streams.length,
+            failureReasonCounts: webProviderFailureReasonCounts(
+              lastAggregation.failures,
+            ),
+          ),
+        );
+      }
+    }
+  }
+
+  void _recordProviderSearchSummary(Map<String, Object?> details) {
+    unawaited(_persistProviderSearchSummary(details));
+  }
+
+  Future<void> _persistProviderSearchSummary(
+    Map<String, Object?> details,
+  ) async {
+    try {
+      await _store.database.recordDiagnosticEvent(
+        category: 'provider-search',
+        severity: 'info',
+        message: 'Web provider discovery summary',
+        details: details,
+      );
+    } catch (_) {
+      // Diagnostics are best-effort and must never affect provider discovery.
     }
   }
 
   void _recordProviderSearchOutcome(
     WebStreamingProvider provider, {
+    required String diagnosticSessionId,
     required String status,
     required int count,
     required String stage,
@@ -244,6 +394,7 @@ class WebStreamAggregator {
     unawaited(
       _persistProviderSearchOutcome(
         provider,
+        diagnosticSessionId: diagnosticSessionId,
         status: status,
         count: count,
         stage: stage,
@@ -254,6 +405,7 @@ class WebStreamAggregator {
 
   Future<void> _persistProviderSearchOutcome(
     WebStreamingProvider provider, {
+    required String diagnosticSessionId,
     required String status,
     required int count,
     required String stage,
@@ -262,6 +414,9 @@ class WebStreamAggregator {
     try {
       await _store.database.recordDiagnosticEvent(
         category: 'provider-search',
+        severity: status == 'failed' || status == 'unavailable'
+            ? 'warning'
+            : 'info',
         message: webProviderSearchDiagnosticMessage(
           provider,
           status: status,
@@ -269,6 +424,7 @@ class WebStreamAggregator {
           stage: stage,
           reason: reason,
         ),
+        details: webProviderSearchOutcomeDiagnosticDetails(diagnosticSessionId),
       );
     } catch (_) {
       // Diagnostics are best-effort and must never affect provider discovery.
@@ -480,6 +636,139 @@ WebProviderFailure? installedWebProviderAvailabilityFailure(
 /// Bounded provider-only provenance for the explicit diagnostic report. This
 /// never receives a catalog title, episode/query, result URL, or exception
 /// message; manifest URLs are reduced to their public host by the provider.
+Map<String, Object?> webProviderSearchSummaryDiagnosticDetails({
+  required String phase,
+  required String diagnosticSessionId,
+  required int installedProviders,
+  required int enabledProviders,
+  required int searchableProviders,
+  required int blockedProviders,
+  required int completedProviders,
+  required int returnedProviders,
+  required int returnedResults,
+  Map<String, int> failureReasonCounts = const {},
+}) {
+  final safeReasons = <String, int>{};
+  for (final entry in failureReasonCounts.entries) {
+    final reason = _safeWebProviderFailureReason(entry.key);
+    safeReasons.update(
+      reason,
+      (count) => count + entry.value.clamp(0, 9999),
+      ifAbsent: () => entry.value.clamp(0, 9999),
+    );
+  }
+  return {
+    'session_id': _safeWebProviderDiagnosticSessionId(diagnosticSessionId),
+    'phase': _safeWebProviderDiagnosticPhase(phase),
+    'state': <Map<String, Object>>[
+      {
+        'kind': 'installed_providers',
+        'count': installedProviders.clamp(0, 9999),
+      },
+      {'kind': 'enabled_providers', 'count': enabledProviders.clamp(0, 9999)},
+      {
+        'kind': 'searchable_providers',
+        'count': searchableProviders.clamp(0, 9999),
+      },
+      {'kind': 'blocked_providers', 'count': blockedProviders.clamp(0, 9999)},
+      {
+        'kind': 'completed_providers',
+        'count': completedProviders.clamp(0, 9999),
+      },
+      {'kind': 'returned_providers', 'count': returnedProviders.clamp(0, 9999)},
+      {'kind': 'returned_results', 'count': returnedResults.clamp(0, 99999)},
+    ],
+    if (safeReasons.isNotEmpty)
+      'reason': <Map<String, Object>>[
+        for (final entry in safeReasons.entries)
+          {'reason_code': entry.key, 'count': entry.value},
+      ],
+  };
+}
+
+Map<String, int> webProviderFailureReasonCounts(
+  Iterable<WebProviderFailure> failures,
+) {
+  final counts = <String, int>{};
+  for (final failure in failures) {
+    final reason = _safeWebProviderFailureReason(
+      failure.reason ?? 'unspecified',
+    );
+    counts.update(reason, (count) => count + 1, ifAbsent: () => 1);
+  }
+  return counts;
+}
+
+Map<String, Object?> webProviderVisibilityDiagnosticDetails({
+  required String phase,
+  required String diagnosticSessionId,
+  required int rawProviders,
+  required int rawResults,
+  required int visibleProviders,
+  required int visibleResults,
+  required String audioFilter,
+  required String qualityFilter,
+}) => {
+  'session_id': _safeWebProviderDiagnosticSessionId(diagnosticSessionId),
+  'phase': _safeWebProviderDiagnosticPhase(phase),
+  'state': <Map<String, Object>>[
+    {'kind': 'raw_providers', 'count': rawProviders.clamp(0, 9999)},
+    {'kind': 'raw_results', 'count': rawResults.clamp(0, 99999)},
+    {'kind': 'visible_providers', 'count': visibleProviders.clamp(0, 9999)},
+    {'kind': 'visible_results', 'count': visibleResults.clamp(0, 99999)},
+  ],
+  'audio_mode': const {'all', 'sub', 'dub'}.contains(audioFilter)
+      ? audioFilter
+      : 'unknown',
+  'quality': const {'any', 'p2160', 'p1080', 'p720'}.contains(qualityFilter)
+      ? qualityFilter
+      : 'unknown',
+};
+
+Map<String, Object?> webProviderSearchOutcomeDiagnosticDetails(
+  String diagnosticSessionId,
+) => {'session_id': _safeWebProviderDiagnosticSessionId(diagnosticSessionId)};
+
+String _safeWebProviderDiagnosticSessionId(String value) =>
+    RegExp(r'^provider-search-[0-9a-f]{12}-[0-9]+$').hasMatch(value)
+    ? value
+    : 'provider-search-unknown';
+
+String _safeWebProviderDiagnosticPhase(String value) =>
+    const {
+      'start',
+      'progress',
+      'final',
+      'filter_changed',
+      'canceled',
+      'error',
+    }.contains(value)
+    ? value
+    : 'unknown';
+
+String _safeWebProviderFailureReason(String value) {
+  if (RegExp(r'^http_[1-5][0-9]{2}$').hasMatch(value)) return value;
+  return const {
+        'timeout',
+        'empty_sources',
+        'unsafe_target',
+        'invalid_response',
+        'network',
+        'runtime_api',
+        'provider_error',
+        'empty_result',
+        'episode_identity_mismatch',
+        'health_quarantine',
+        'incompatible_runtime',
+        'reported_broken',
+        'deprecated',
+        'unavailable',
+        'unspecified',
+      }.contains(value)
+      ? value
+      : 'other';
+}
+
 String webProviderSearchDiagnosticMessage(
   WebStreamingProvider provider, {
   required String status,

--- a/lib/features/player/application/skip_segment_service.dart
+++ b/lib/features/player/application/skip_segment_service.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:math' as math;
 
 import 'package:dio/dio.dart';
@@ -31,12 +32,47 @@ bool skipSegmentLookupIsComplete({
   required bool externalFailed,
   required bool hasMarkers,
   required int attempts,
+  bool transientExternalFailure = false,
+  bool terminalExternalFailure = false,
   bool runtimeProbesExhausted = false,
 }) {
-  if (runtimeProbesExhausted) return true;
-  if (attempts >= 4) return true;
-  if (externalFailed) return false;
+  if (runtimeProbesExhausted || terminalExternalFailure) {
+    return true;
+  }
+  if (externalFailed) {
+    final limit = transientExternalFailure
+        ? skipSegmentTotalTransientLookupAttemptLimit
+        : skipSegmentImmediateLookupAttemptLimit;
+    return attempts >= limit;
+  }
+  if (attempts >= skipSegmentImmediateLookupAttemptLimit) return true;
   return hasMarkers || !isWebStream;
+}
+
+const skipSegmentImmediateLookupAttemptLimit = 4;
+const skipSegmentTotalTransientLookupAttemptLimit = 6;
+
+/// Returns a bounded retry delay for an incomplete marker lookup.
+///
+/// The first four attempts retain the short startup cadence. Transport and
+/// service failures then receive two slower recovery attempts because the
+/// timing service can recover while playback is still active. Clean, exhausted
+/// no-matches never enter this deferred path.
+Duration? skipSegmentLookupRetryDelay({
+  required bool lookupComplete,
+  required bool transientExternalFailure,
+  required int attempts,
+}) {
+  if (lookupComplete) return null;
+  if (attempts < skipSegmentImmediateLookupAttemptLimit) {
+    return const Duration(milliseconds: 1200);
+  }
+  if (!transientExternalFailure) return null;
+  return switch (attempts) {
+    4 => const Duration(seconds: 20),
+    5 => const Duration(seconds: 60),
+    _ => null,
+  };
 }
 
 enum SkipSegmentKind { opening, ending, recap }
@@ -80,6 +116,9 @@ class AniSkipLookupResult {
     required this.probeCount,
     required this.usedDurationFallback,
     required this.runtimeFallbackSearchComplete,
+    required this.status,
+    required this.transientFailureCount,
+    this.failureReason,
   });
 
   final List<SkipSegment> segments;
@@ -96,6 +135,64 @@ class AniSkipLookupResult {
   /// unresolved transport/server failure. Empty results may be finalized only
   /// in this state; otherwise the player can retry later.
   final bool runtimeFallbackSearchComplete;
+
+  final AniSkipLookupStatus status;
+  final int transientFailureCount;
+  final AniSkipFailureReason? failureReason;
+
+  bool get hasTransientFailure =>
+      status == AniSkipLookupStatus.transientFailure ||
+      status == AniSkipLookupStatus.partialTransientFailure;
+}
+
+enum AniSkipLookupStatus {
+  found,
+  noMatch,
+  partialTransientFailure,
+  transientFailure,
+  permanentFailure,
+}
+
+extension AniSkipLookupStatusDiagnostics on AniSkipLookupStatus {
+  String get diagnosticCode => switch (this) {
+    AniSkipLookupStatus.found => 'success',
+    AniSkipLookupStatus.noMatch => 'no_match',
+    AniSkipLookupStatus.partialTransientFailure => 'partial_transient_failure',
+    AniSkipLookupStatus.transientFailure => 'transient_failure',
+    AniSkipLookupStatus.permanentFailure => 'permanent_failure',
+  };
+}
+
+enum AniSkipFailureReason {
+  invalidRequest,
+  rateLimited,
+  serverError,
+  clientError,
+  connectionTimeout,
+  transformTimeout,
+  receiveTimeout,
+  sendTimeout,
+  connectionError,
+  certificateError,
+  canceled,
+  unknownTransport,
+}
+
+extension AniSkipFailureReasonDiagnostics on AniSkipFailureReason {
+  String get diagnosticCode => switch (this) {
+    AniSkipFailureReason.invalidRequest => 'invalid_request',
+    AniSkipFailureReason.rateLimited => 'rate_limited',
+    AniSkipFailureReason.serverError => 'server_error',
+    AniSkipFailureReason.clientError => 'client_error',
+    AniSkipFailureReason.connectionTimeout => 'connection_timeout',
+    AniSkipFailureReason.transformTimeout => 'transform_timeout',
+    AniSkipFailureReason.receiveTimeout => 'receive_timeout',
+    AniSkipFailureReason.sendTimeout => 'send_timeout',
+    AniSkipFailureReason.connectionError => 'connection_error',
+    AniSkipFailureReason.certificateError => 'certificate_error',
+    AniSkipFailureReason.canceled => 'canceled',
+    AniSkipFailureReason.unknownTransport => 'unknown_transport',
+  };
 }
 
 class AniSkipClient {
@@ -137,6 +234,9 @@ class AniSkipClient {
         probeCount: 0,
         usedDurationFallback: false,
         runtimeFallbackSearchComplete: false,
+        status: AniSkipLookupStatus.permanentFailure,
+        transientFailureCount: 0,
+        failureReason: AniSkipFailureReason.invalidRequest,
       );
     }
     final actualSeconds = episodeDuration.inMilliseconds / 1000;
@@ -144,8 +244,10 @@ class AniSkipClient {
         ? aniSkipRuntimeProbes(episodeDuration)
         : <double>[actualSeconds];
     Object? lastTransientFailure;
+    AniSkipFailureReason? lastFailureReason;
     var observedCleanNoMatch = false;
-    var hadTransientFailure = false;
+    var hadUnresolvedTransientFailure = false;
+    var transientFailureCount = 0;
     for (var probeIndex = 0; probeIndex < probeLengths.length; probeIndex++) {
       final probeLength = probeLengths[probeIndex];
       final uri = _aniSkipUri(
@@ -158,11 +260,13 @@ class AniSkipClient {
       // therefore execute once each to avoid hammering the community API.
       final requestAttempts = probeIndex == 0 ? 2 : 1;
       Map<String, dynamic>? body;
+      var receivedResponse = false;
       for (var attempt = 0; attempt < requestAttempts; attempt++) {
         try {
           final response = await _dio.getUri<Map<String, dynamic>>(uri);
           final status = response.statusCode ?? 200;
           if (status == 404) {
+            receivedResponse = true;
             observedCleanNoMatch = true;
             body = response.data;
             break;
@@ -174,24 +278,39 @@ class AniSkipClient {
               response: response,
             );
           }
+          receivedResponse = true;
           body = response.data;
           break;
         } on DioException catch (error) {
           final status = error.response?.statusCode;
           if (status == 404) {
+            receivedResponse = true;
             observedCleanNoMatch = true;
             final data = error.response?.data;
             if (data is Map<String, dynamic>) body = data;
             break;
           }
-          if (!_retryableAniSkipFailure(error)) rethrow;
+          final failureReason = _aniSkipFailureReason(error);
+          if (!_retryableAniSkipFailure(error)) {
+            return AniSkipLookupResult(
+              segments: const [],
+              probeCount: probeIndex + 1,
+              usedDurationFallback: false,
+              runtimeFallbackSearchComplete: false,
+              status: AniSkipLookupStatus.permanentFailure,
+              transientFailureCount: transientFailureCount,
+              failureReason: failureReason,
+            );
+          }
           lastTransientFailure = error;
-          hadTransientFailure = true;
+          lastFailureReason = failureReason;
+          transientFailureCount++;
           if (attempt + 1 < requestAttempts) {
             await Future<void>.delayed(retryDelay);
           }
         }
       }
+      if (!receivedResponse) hadUnresolvedTransientFailure = true;
       if (body == null || body['found'] != true || body['results'] is! List) {
         if (body != null) observedCleanNoMatch = true;
         continue;
@@ -206,17 +325,27 @@ class AniSkipClient {
         probeCount: probeIndex + 1,
         usedDurationFallback: probeIndex > 0,
         runtimeFallbackSearchComplete: false,
+        status: AniSkipLookupStatus.found,
+        transientFailureCount: transientFailureCount,
+        failureReason: lastFailureReason,
       );
     }
-    if (!observedCleanNoMatch && lastTransientFailure != null) {
-      throw lastTransientFailure;
-    }
+    // Retain this assertion in debug builds: a transient count must always
+    // carry the source exception that supplied its safe diagnostic class.
+    assert(transientFailureCount == 0 || lastTransientFailure != null);
     return AniSkipLookupResult(
       segments: const [],
       probeCount: probeLengths.length,
       usedDurationFallback: false,
       runtimeFallbackSearchComplete:
-          allowRuntimeFallback && !hadTransientFailure,
+          allowRuntimeFallback && !hadUnresolvedTransientFailure,
+      status: hadUnresolvedTransientFailure
+          ? observedCleanNoMatch
+                ? AniSkipLookupStatus.partialTransientFailure
+                : AniSkipLookupStatus.transientFailure
+          : AniSkipLookupStatus.noMatch,
+      transientFailureCount: transientFailureCount,
+      failureReason: lastFailureReason,
     );
   }
 
@@ -298,9 +427,124 @@ bool _retryableAniSkipFailure(DioException error) {
       (status != null && status >= 500) ||
       error.type == DioExceptionType.connectionError ||
       error.type == DioExceptionType.connectionTimeout ||
+      error.type == DioExceptionType.transformTimeout ||
       error.type == DioExceptionType.receiveTimeout ||
       error.type == DioExceptionType.sendTimeout ||
       error.type == DioExceptionType.unknown;
+}
+
+AniSkipFailureReason _aniSkipFailureReason(DioException error) {
+  final status = error.response?.statusCode;
+  if (status == 429) return AniSkipFailureReason.rateLimited;
+  if (status != null && status >= 500) return AniSkipFailureReason.serverError;
+  if (status != null && status >= 400) return AniSkipFailureReason.clientError;
+  return switch (error.type) {
+    DioExceptionType.connectionTimeout =>
+      AniSkipFailureReason.connectionTimeout,
+    DioExceptionType.transformTimeout => AniSkipFailureReason.transformTimeout,
+    DioExceptionType.receiveTimeout => AniSkipFailureReason.receiveTimeout,
+    DioExceptionType.sendTimeout => AniSkipFailureReason.sendTimeout,
+    DioExceptionType.connectionError => AniSkipFailureReason.connectionError,
+    DioExceptionType.badCertificate => AniSkipFailureReason.certificateError,
+    DioExceptionType.cancel => AniSkipFailureReason.canceled,
+    DioExceptionType.badResponse => AniSkipFailureReason.clientError,
+    DioExceptionType.unknown => AniSkipFailureReason.unknownTransport,
+  };
+}
+
+class VerifiedSkipSeekResult {
+  const VerifiedSkipSeekResult({
+    required this.verified,
+    required this.position,
+    required this.attempts,
+  });
+
+  final bool verified;
+  final Duration position;
+  final int attempts;
+}
+
+bool skipSeekTargetReached({
+  required Duration target,
+  required Duration actual,
+  Duration tolerance = const Duration(milliseconds: 250),
+  Duration maximumOvershoot = const Duration(seconds: 5),
+}) => actual + tolerance >= target && actual <= target + maximumOvershoot;
+
+/// Sends a skip seek and confirms the player actually moved before reporting
+/// success. Some HLS demuxers accept an early seek command without applying it.
+Future<VerifiedSkipSeekResult> performVerifiedSkipSeek({
+  required Duration target,
+  required Future<void> Function(Duration target) seek,
+  required Duration Function() currentPosition,
+  Future<void> Function(Duration delay)? wait,
+  bool Function()? isCanceled,
+  int maximumAttempts = 3,
+  Duration operationTimeout = const Duration(seconds: 2),
+  Duration settleDelay = const Duration(milliseconds: 700),
+}) async {
+  final boundedAttempts = maximumAttempts.clamp(1, 6).toInt();
+  final boundedOperationTimeout = operationTimeout <= Duration.zero
+      ? const Duration(milliseconds: 1)
+      : operationTimeout;
+  final waitFor = wait ?? Future<void>.delayed;
+  var actual = currentPosition();
+  for (var attempt = 1; attempt <= boundedAttempts; attempt++) {
+    if (isCanceled?.call() == true) {
+      return VerifiedSkipSeekResult(
+        verified: false,
+        position: actual,
+        attempts: attempt - 1,
+      );
+    }
+    var operationTimedOut = false;
+    try {
+      await seek(target).timeout(boundedOperationTimeout);
+    } on TimeoutException {
+      operationTimedOut = true;
+    } catch (_) {
+      // A demuxer can throw while still committing the seek. Verification is
+      // authoritative, so inspect the resulting position before retrying.
+    }
+    if (isCanceled?.call() == true) {
+      return VerifiedSkipSeekResult(
+        verified: false,
+        position: currentPosition(),
+        attempts: attempt,
+      );
+    }
+    await waitFor(settleDelay);
+    actual = currentPosition();
+    if (isCanceled?.call() == true) {
+      return VerifiedSkipSeekResult(
+        verified: false,
+        position: actual,
+        attempts: attempt,
+      );
+    }
+    if (skipSeekTargetReached(target: target, actual: actual)) {
+      return VerifiedSkipSeekResult(
+        verified: true,
+        position: actual,
+        attempts: attempt,
+      );
+    }
+    // Do not stack more seek commands behind an operation whose completion is
+    // unknown. A later source change is handled by the caller's cancellation
+    // guard, and the marker remains available for an explicit manual retry.
+    if (operationTimedOut) {
+      return VerifiedSkipSeekResult(
+        verified: false,
+        position: actual,
+        attempts: attempt,
+      );
+    }
+  }
+  return VerifiedSkipSeekResult(
+    verified: false,
+    position: actual,
+    attempts: boundedAttempts,
+  );
 }
 
 /// AniSkip selects submitted markers using the requested episode runtime.

--- a/lib/features/player/presentation/teto_player_chrome.dart
+++ b/lib/features/player/presentation/teto_player_chrome.dart
@@ -11,10 +11,11 @@ const double _playerControlFocusGutter = 20;
 const double _playerProgressFocusBorderWidth = 1.4;
 const double _compactPlayerSeekBubbleFontSize = 14;
 const double _regularPlayerSeekBubbleFontSize = 18;
-const double _compactPlayerSeekBubbleBaseReserve = 38;
-const double _regularPlayerSeekBubbleBaseReserve = 45;
-const double _compactPlayerChromeReservedHeight = 136;
-const double _regularPlayerChromeReservedHeight = 130;
+// These reserves include the always-present seek-bubble lane. Keeping the lane
+// in the resting HUD prevents either the chrome or the Skip action from moving
+// when scrubbing starts.
+const double _compactPlayerChromeReservedHeight = 169;
+const double _regularPlayerChromeReservedHeight = 173;
 const Color _defaultPlayerChromePanel = Color(0xD6080808);
 const Color _defaultPlayerChromeShadow = Color(0xA8000000);
 const Color _defaultPlayerControlSurface = Color(0x8F242429);
@@ -92,24 +93,12 @@ double playerSkipOverlayBottomInset({
   // viewports. Reserve that line so Skip Intro/Outro stays visibly detached
   // from the panel instead of landing on top of its badges or border.
   final expandedHeaderGrowth = expandedHeader ? 44.0 : 0.0;
-  // The seek timestamp is inserted above the progress track only while the
-  // viewer is scrubbing. Move Skip Intro/Outro by the same amount so it stays
-  // detached from both the bubble and the expanded HUD. The base reserve
-  // includes the bubble pointer and its gap above the track; the remaining
-  // term tracks the scaled timestamp glyph height.
-  final scrubbingGrowth = scrubbing
-      ? (compact
-                ? _compactPlayerSeekBubbleBaseReserve
-                : _regularPlayerSeekBubbleBaseReserve) +
-            (scale - 1) *
-                (compact
-                    ? _compactPlayerSeekBubbleFontSize * 1.05
-                    : _regularPlayerSeekBubbleFontSize * 1.05)
-      : 0.0;
+  // The bubble lane is part of the resting HUD, so beginning a scrub must not
+  // move either the chrome or the separate Skip action. [scrubbing] remains an
+  // explicit compatibility input but no longer changes geometry.
   return base +
       accessibleGrowth +
       expandedHeaderGrowth +
-      scrubbingGrowth +
       safeAreaBottom.clamp(0, 160);
 }
 
@@ -1066,21 +1055,32 @@ class _TetoPlayerProgressScrubberState
     final displayPosition = Duration(
       milliseconds: _displayMilliseconds.round(),
     );
+    final seekLabel = formatPlayerChromeDuration(displayPosition);
     return Column(
       mainAxisSize: MainAxisSize.min,
       children: [
-        if (_interacting) ...[
-          _PlayerSeekTimeBubble(
-            engineKey: widget.engineKey,
-            label: formatPlayerChromeDuration(displayPosition),
-            progress: durationAvailable
-                ? _displayMilliseconds / _scrubMaximumMilliseconds
-                : 0,
+        // Reserve the seek-bubble lane even while it is hidden. This keeps the
+        // HUD's outer geometry stable during scrubbing and prevents the bubble
+        // from painting back over the control strip above it.
+        SizedBox(
+          height: _PlayerSeekTimeBubble.heightFor(
+            context,
+            label: seekLabel,
             compact: widget.compact,
-            palette: widget.palette,
           ),
-          const SizedBox(height: 2),
-        ],
+          child: _interacting
+              ? _PlayerSeekTimeBubble(
+                  engineKey: widget.engineKey,
+                  label: seekLabel,
+                  progress: durationAvailable
+                      ? _displayMilliseconds / _scrubMaximumMilliseconds
+                      : 0,
+                  compact: widget.compact,
+                  palette: widget.palette,
+                )
+              : null,
+        ),
+        const SizedBox(height: 2),
         Semantics(
           hint: widget.showSupplementalRow ? null : widget.footerHint,
           child: Focus(
@@ -1222,6 +1222,31 @@ class _PlayerSeekTimeBubble extends StatelessWidget {
   final double progress;
   final bool compact;
   final AppThemePalette palette;
+
+  static double heightFor(
+    BuildContext context, {
+    required String label,
+    required bool compact,
+  }) {
+    final textPainter = TextPainter(
+      text: TextSpan(
+        text: label,
+        style: TextStyle(
+          fontSize: compact
+              ? _compactPlayerSeekBubbleFontSize
+              : _regularPlayerSeekBubbleFontSize,
+          height: 1.05,
+          fontWeight: FontWeight.w800,
+        ),
+      ),
+      maxLines: 1,
+      textDirection: Directionality.of(context),
+      textScaler: MediaQuery.textScalerOf(context),
+    )..layout();
+    final verticalPadding = compact ? 5.0 : 6.0;
+    final pointerHeight = compact ? 8.0 : 10.0;
+    return textPainter.height + verticalPadding * 2 + pointerHeight;
+  }
 
   @override
   Widget build(BuildContext context) {

--- a/lib/features/player/presentation/tv_player_screen.dart
+++ b/lib/features/player/presentation/tv_player_screen.dart
@@ -740,7 +740,7 @@ class _MpvTvPlayerScreenState extends ConsumerState<MpvTvPlayerScreen> {
   Completer<void>? _seekDrainCompleter;
   final Set<Future<void>> _trickplayOperations = <Future<void>>{};
   int _trickplayGeneration = 0;
-  Future<bool>? _skipSeekOperation;
+  Future<VerifiedSkipSeekResult>? _skipSeekOperation;
   bool _skipInProgress = false;
   int _seekBackSeconds = 10;
   int _seekForwardSeconds = 10;
@@ -748,6 +748,7 @@ class _MpvTvPlayerScreenState extends ConsumerState<MpvTvPlayerScreen> {
   Color _captionBackgroundColor = Colors.transparent;
   final PlayerSkipAutoFocusGate _skipAutoFocusGate = PlayerSkipAutoFocusGate();
   final Set<String> _consumedSkipSegments = {};
+  final Set<String> _suppressedAutomaticSkipSegments = {};
   final Set<String> _diagnosticActivatedSkipKeys = {};
   bool _allowExit = false;
   bool _confirmingExit = false;
@@ -1597,6 +1598,7 @@ class _MpvTvPlayerScreenState extends ConsumerState<MpvTvPlayerScreen> {
   }
 
   void _checkSkips(Duration position) {
+    if (_skipInProgress) return;
     final active = activeSkipSegmentAt(
       segments: _skips,
       position: position,
@@ -1640,7 +1642,9 @@ class _MpvTvPlayerScreenState extends ConsumerState<MpvTvPlayerScreen> {
           position: position,
         );
       }
-      if (autoSkip && !_skipInProgress && _consumedSkipSegments.add(key)) {
+      if (autoSkip &&
+          !_skipInProgress &&
+          !_suppressedAutomaticSkipSegments.contains(key)) {
         if (mounted) {
           final skipHadFocus = _skipControlFocus.hasFocus;
           setState(() {
@@ -1702,9 +1706,10 @@ class _MpvTvPlayerScreenState extends ConsumerState<MpvTvPlayerScreen> {
     if (_skipInProgress ||
         _engineHandoffInProgress ||
         _blockGuestLocalControl(notify: false)) {
-      _consumedSkipSegments.remove(segmentKey);
       return;
     }
+    final expectedStream = _currentStream;
+    final expectedSource = _source;
     _skipInProgress = true;
     final target = safeSkipSegmentTarget(
       requested: segment.end,
@@ -1717,11 +1722,13 @@ class _MpvTvPlayerScreenState extends ConsumerState<MpvTvPlayerScreen> {
       position: _player.state.position,
       target: target,
     );
+    VerifiedSkipSeekResult? seekResult;
     try {
       final duration = _player.state.duration;
       final wasPlaying = _player.state.playing;
-      final succeeded = await _seekForSkip(target);
-      if (!succeeded) throw StateError('skip seek failed');
+      seekResult = await _seekForSkip(target);
+      if (!seekResult.verified) throw StateError('skip seek failed');
+      _consumedSkipSegments.add(segmentKey);
       _recordSkipSegmentActionDiagnostic(
         status: 'seek_succeeded',
         segment: segment,
@@ -1729,6 +1736,9 @@ class _MpvTvPlayerScreenState extends ConsumerState<MpvTvPlayerScreen> {
         position: _player.state.position,
         target: target,
         seekSucceeded: true,
+        postSeekPosition: seekResult.position,
+        seekAttempts: seekResult.attempts,
+        seekVerified: true,
       );
       if (mounted && !_engineHandoffInProgress) {
         _showTrackMessage(
@@ -1746,17 +1756,29 @@ class _MpvTvPlayerScreenState extends ConsumerState<MpvTvPlayerScreen> {
         _handlePlaybackCompleted();
       }
     } catch (_) {
-      _recordSkipSegmentActionDiagnostic(
-        status: 'seek_failed',
-        segment: segment,
-        automatic: true,
-        position: _player.state.position,
-        target: target,
-        seekSucceeded: false,
-      );
-      _consumedSkipSegments.remove(segmentKey);
-      if (mounted && !_engineHandoffInProgress) {
-        _showTrackMessage('Could not skip this segment');
+      final sourceStillActive =
+          identical(_currentStream, expectedStream) &&
+          _source == expectedSource;
+      if (sourceStillActive) {
+        // The verified seek already makes a few bounded attempts. If all of
+        // them fail, keep the marker visible for a manual retry instead of
+        // immediately re-entering auto-skip on every position update.
+        _suppressedAutomaticSkipSegments.add(segmentKey);
+        _recordSkipSegmentActionDiagnostic(
+          status: 'seek_failed',
+          segment: segment,
+          automatic: true,
+          position: _player.state.position,
+          target: target,
+          seekSucceeded: false,
+          postSeekPosition: seekResult?.position ?? _player.state.position,
+          seekAttempts: seekResult?.attempts ?? 0,
+          seekVerified: false,
+        );
+        _consumedSkipSegments.remove(segmentKey);
+        if (mounted && !_engineHandoffInProgress) {
+          _showTrackMessage('Could not skip this segment');
+        }
       }
     } finally {
       _skipInProgress = false;
@@ -1791,7 +1813,10 @@ class _MpvTvPlayerScreenState extends ConsumerState<MpvTvPlayerScreen> {
     });
   }
 
-  void _scheduleSkipSegmentLoad(Duration duration) {
+  void _scheduleSkipSegmentLoad(
+    Duration duration, {
+    Duration delay = const Duration(milliseconds: 1200),
+  }) {
     if (!_skipSegmentFeaturesEnabled) return;
     if (_skipLoadInFlight ||
         _engineHandoffInProgress ||
@@ -1822,7 +1847,7 @@ class _MpvTvPlayerScreenState extends ConsumerState<MpvTvPlayerScreen> {
     }
     _skipLoadTimer?.cancel();
     final generation = _skipLoadGeneration;
-    _skipLoadTimer = Timer(const Duration(milliseconds: 1200), () {
+    _skipLoadTimer = Timer(delay, () {
       if (generation != _skipLoadGeneration) return;
       unawaited(_loadSkipSegments(duration, generation: generation));
     });
@@ -1860,12 +1885,19 @@ class _MpvTvPlayerScreenState extends ConsumerState<MpvTvPlayerScreen> {
     var externalProbeCount = 0;
     var externalDurationFallbackUsed = false;
     var externalRuntimeProbesExhausted = false;
+    var externalTransientFailure = false;
+    var externalTerminalFailure = false;
+    var externalStatusClass = 'not_requested';
+    String? externalFailureReason;
+    var externalTransientFailureCount = 0;
     try {
       final episode = _catalogEpisodeNumber ?? widget.launch.episode.episode;
       final malMediaId = await _resolveSkipMalMediaId();
       final Future<List<SkipSegment>> externalFuture;
       if (malMediaId == null || episode <= 0) {
         externalStatus = 'catalog_mapping_unavailable';
+        externalStatusClass = 'mapping_unavailable';
+        externalFailureReason = 'catalog_mapping_unavailable';
         externalFuture = Future<List<SkipSegment>>.value(const <SkipSegment>[]);
       } else {
         externalStatus = 'requested';
@@ -1877,6 +1909,15 @@ class _MpvTvPlayerScreenState extends ConsumerState<MpvTvPlayerScreen> {
               allowRuntimeFallback: _currentStream.isWebStream,
             )
             .then((result) {
+              externalStatusClass = result.status.diagnosticCode;
+              externalFailureReason = result.failureReason?.diagnosticCode;
+              externalTransientFailureCount = result.transientFailureCount;
+              externalTransientFailure =
+                  result.segments.isEmpty && result.hasTransientFailure;
+              externalTerminalFailure =
+                  result.segments.isEmpty &&
+                  result.status == AniSkipLookupStatus.permanentFailure;
+              externalFailed = externalTransientFailure;
               externalProbeCount = result.probeCount;
               externalDurationFallbackUsed = result.usedDurationFallback;
               externalRuntimeProbesExhausted =
@@ -1884,9 +1925,16 @@ class _MpvTvPlayerScreenState extends ConsumerState<MpvTvPlayerScreen> {
                   result.segments.isEmpty &&
                   result.runtimeFallbackSearchComplete;
               externalStatus = result.segments.isEmpty
-                  ? externalRuntimeProbesExhausted
-                        ? 'no_match_after_nearby_runtimes'
-                        : 'no_match'
+                  ? switch (result.status) {
+                      AniSkipLookupStatus.transientFailure ||
+                      AniSkipLookupStatus.partialTransientFailure =>
+                        'request_failed',
+                      AniSkipLookupStatus.permanentFailure =>
+                        'request_rejected',
+                      _ when externalRuntimeProbesExhausted =>
+                        'no_match_after_nearby_runtimes',
+                      _ => 'no_match',
+                    }
                   : result.usedDurationFallback
                   ? 'found_nearby_runtime'
                   : 'found';
@@ -1894,6 +1942,10 @@ class _MpvTvPlayerScreenState extends ConsumerState<MpvTvPlayerScreen> {
             })
             .catchError((_) {
               externalFailed = true;
+              externalTransientFailure = true;
+              externalStatusClass = 'unexpected_failure';
+              externalFailureReason = 'unexpected_error';
+              externalTransientFailureCount++;
               externalStatus = 'request_failed';
               return const <SkipSegment>[];
             });
@@ -1930,6 +1982,9 @@ class _MpvTvPlayerScreenState extends ConsumerState<MpvTvPlayerScreen> {
           currentDuration: currentDuration,
           communityProbeCount: externalProbeCount,
           durationFallbackUsed: externalDurationFallbackUsed,
+          communityStatusClass: externalStatusClass,
+          communityFailureReason: externalFailureReason,
+          communityTransientFailureCount: externalTransientFailureCount,
         );
         if (_skipDurationRestarts++ < 8) {
           _skipLoadAttempts = (_skipLoadAttempts - 1).clamp(0, 4);
@@ -1944,6 +1999,8 @@ class _MpvTvPlayerScreenState extends ConsumerState<MpvTvPlayerScreen> {
         externalFailed: externalFailed,
         hasMarkers: _skips.isNotEmpty,
         attempts: _skipLoadAttempts,
+        transientExternalFailure: externalTransientFailure,
+        terminalExternalFailure: externalTerminalFailure,
         runtimeProbesExhausted: externalRuntimeProbesExhausted,
       );
       _recordSkipSegmentDiagnostic(
@@ -1955,6 +2012,9 @@ class _MpvTvPlayerScreenState extends ConsumerState<MpvTvPlayerScreen> {
         currentDuration: currentDuration,
         communityProbeCount: externalProbeCount,
         durationFallbackUsed: externalDurationFallbackUsed,
+        communityStatusClass: externalStatusClass,
+        communityFailureReason: externalFailureReason,
+        communityTransientFailureCount: externalTransientFailureCount,
       );
     } catch (_) {
       if (generation != _skipLoadGeneration) return;
@@ -1967,12 +2027,20 @@ class _MpvTvPlayerScreenState extends ConsumerState<MpvTvPlayerScreen> {
         externalCount: 0,
         requestedDuration: duration,
         currentDuration: _player.state.duration,
+        communityStatusClass: externalStatusClass,
+        communityFailureReason: externalFailureReason,
+        communityTransientFailureCount: externalTransientFailureCount,
       );
     } finally {
       if (generation == _skipLoadGeneration) {
         _skipLoadInFlight = false;
-        if (mounted && !_skipLoadComplete && _skipLoadAttempts < 4) {
-          _scheduleSkipSegmentLoad(_player.state.duration);
+        final retryDelay = skipSegmentLookupRetryDelay(
+          lookupComplete: _skipLoadComplete,
+          transientExternalFailure: externalTransientFailure,
+          attempts: _skipLoadAttempts,
+        );
+        if (mounted && retryDelay != null) {
+          _scheduleSkipSegmentLoad(_player.state.duration, delay: retryDelay);
         }
       }
     }
@@ -1988,6 +2056,7 @@ class _MpvTvPlayerScreenState extends ConsumerState<MpvTvPlayerScreen> {
     _skipDurationRestarts = 0;
     _skipDurationCandidate = null;
     _consumedSkipSegments.clear();
+    _suppressedAutomaticSkipSegments.clear();
     _diagnosticActivatedSkipKeys.clear();
     _skipAutoFocusGate.reset();
     setState(() {
@@ -2010,6 +2079,9 @@ class _MpvTvPlayerScreenState extends ConsumerState<MpvTvPlayerScreen> {
     required Duration currentDuration,
     int communityProbeCount = 0,
     bool durationFallbackUsed = false,
+    String? communityStatusClass,
+    String? communityFailureReason,
+    int communityTransientFailureCount = 0,
   }) {
     unawaited(
       _database.recordDiagnosticEvent(
@@ -2024,6 +2096,9 @@ class _MpvTvPlayerScreenState extends ConsumerState<MpvTvPlayerScreen> {
           'embedded_marker_count': embeddedCount,
           'community_marker_count': externalCount,
           'community_status': externalStatus,
+          'community_status_class': ?communityStatusClass,
+          'community_failure_reason': ?communityFailureReason,
+          'community_transient_failure_count': communityTransientFailureCount,
           'community_probe_count': communityProbeCount,
           'duration_fallback_used': durationFallbackUsed,
           'requested_duration_ms': requestedDuration.inMilliseconds.clamp(
@@ -2046,6 +2121,9 @@ class _MpvTvPlayerScreenState extends ConsumerState<MpvTvPlayerScreen> {
     required Duration position,
     Duration? target,
     bool? seekSucceeded,
+    Duration? postSeekPosition,
+    int? seekAttempts,
+    bool? seekVerified,
   }) {
     unawaited(
       _database.recordDiagnosticEvent(
@@ -2058,6 +2136,8 @@ class _MpvTvPlayerScreenState extends ConsumerState<MpvTvPlayerScreen> {
           'marker_source': segment.source.name,
           'automatic': automatic,
           'seek_succeeded': ?seekSucceeded,
+          'seek_verified': ?seekVerified,
+          'seek_attempts': ?seekAttempts,
           'watch_party_active': _watchPartyActive,
           'guest_controls_locked': _guestControlsLocked,
           'controls_visible': _controlsVisible,
@@ -2079,6 +2159,10 @@ class _MpvTvPlayerScreenState extends ConsumerState<MpvTvPlayerScreen> {
             const Duration(hours: 24).inMilliseconds,
           ),
           'target_ms': ?target?.inMilliseconds.clamp(
+            0,
+            const Duration(hours: 24).inMilliseconds,
+          ),
+          'post_seek_position_ms': ?postSeekPosition?.inMilliseconds.clamp(
             0,
             const Duration(hours: 24).inMilliseconds,
           ),
@@ -2640,25 +2724,40 @@ class _MpvTvPlayerScreenState extends ConsumerState<MpvTvPlayerScreen> {
     }
   }
 
-  Future<bool> _seekForSkip(
+  Future<VerifiedSkipSeekResult> _seekForSkip(
     Duration target, {
     bool supersedeInheritedResume = false,
   }) {
     if (_engineHandoffInProgress || _blockGuestLocalControl(notify: false)) {
-      return Future<bool>.value(false);
+      return Future<VerifiedSkipSeekResult>.value(
+        VerifiedSkipSeekResult(
+          verified: false,
+          position: _player.state.position,
+          attempts: 0,
+        ),
+      );
     }
-    late final Future<bool> operation;
+    final expectedStream = _currentStream;
+    final expectedSource = _source;
+    late final Future<VerifiedSkipSeekResult> operation;
     operation =
         (() async {
-          try {
-            if (supersedeInheritedResume) _pendingInheritedResume = null;
-            _trickplayGeneration++;
-            await _player.seek(target);
+          if (supersedeInheritedResume) _pendingInheritedResume = null;
+          _trickplayGeneration++;
+          final result = await performVerifiedSkipSeek(
+            target: target,
+            seek: _player.seek,
+            currentPosition: () => _player.state.position,
+            isCanceled: () =>
+                _engineHandoffInProgress ||
+                _playerReleasedForHandoff ||
+                !identical(_currentStream, expectedStream) ||
+                _source != expectedSource,
+          );
+          if (result.verified) {
             _recordCommittedSeek(target);
-            return true;
-          } catch (_) {
-            return false;
           }
+          return result;
         })().whenComplete(() {
           if (identical(_skipSeekOperation, operation)) {
             _skipSeekOperation = null;
@@ -5103,13 +5202,14 @@ class _MpvTvPlayerScreenState extends ConsumerState<MpvTvPlayerScreen> {
     }
     final segment = _activeSkip;
     if (segment == null) return;
+    final expectedStream = _currentStream;
+    final expectedSource = _source;
     _skipInProgress = true;
     final target = safeSkipSegmentTarget(
       requested: segment.end,
       duration: _player.state.duration,
     );
     final segmentKey = skipSegmentKey(segment);
-    _consumedSkipSegments.add(segmentKey);
     _recordSkipSegmentActionDiagnostic(
       status: 'manual_action_started',
       segment: segment,
@@ -5125,14 +5225,13 @@ class _MpvTvPlayerScreenState extends ConsumerState<MpvTvPlayerScreen> {
       });
       _recoverFocusAfterSkipDismissed(skipHadFocus: skipHadFocus);
     }
+    VerifiedSkipSeekResult? seekResult;
     try {
       final duration = _player.state.duration;
       final wasPlaying = _player.state.playing;
-      final succeeded = await _seekForSkip(
-        target,
-        supersedeInheritedResume: true,
-      );
-      if (!succeeded) throw StateError('skip seek failed');
+      seekResult = await _seekForSkip(target, supersedeInheritedResume: true);
+      if (!seekResult.verified) throw StateError('skip seek failed');
+      _consumedSkipSegments.add(segmentKey);
       _recordSkipSegmentActionDiagnostic(
         status: 'seek_succeeded',
         segment: segment,
@@ -5140,6 +5239,9 @@ class _MpvTvPlayerScreenState extends ConsumerState<MpvTvPlayerScreen> {
         position: _player.state.position,
         target: target,
         seekSucceeded: true,
+        postSeekPosition: seekResult.position,
+        seekAttempts: seekResult.attempts,
+        seekVerified: true,
       );
       if (mounted && !_engineHandoffInProgress) {
         _showTrackMessage(segment.actionLabel.replaceFirst('Skip', 'Skipped'));
@@ -5153,17 +5255,25 @@ class _MpvTvPlayerScreenState extends ConsumerState<MpvTvPlayerScreen> {
         _handlePlaybackCompleted();
       }
     } catch (_) {
-      _recordSkipSegmentActionDiagnostic(
-        status: 'seek_failed',
-        segment: segment,
-        automatic: false,
-        position: _player.state.position,
-        target: target,
-        seekSucceeded: false,
-      );
-      _consumedSkipSegments.remove(segmentKey);
-      if (mounted && !_engineHandoffInProgress) {
-        _showTrackMessage('Could not skip this segment');
+      final sourceStillActive =
+          identical(_currentStream, expectedStream) &&
+          _source == expectedSource;
+      if (sourceStillActive) {
+        _recordSkipSegmentActionDiagnostic(
+          status: 'seek_failed',
+          segment: segment,
+          automatic: false,
+          position: _player.state.position,
+          target: target,
+          seekSucceeded: false,
+          postSeekPosition: seekResult?.position ?? _player.state.position,
+          seekAttempts: seekResult?.attempts ?? 0,
+          seekVerified: false,
+        );
+        _consumedSkipSegments.remove(segmentKey);
+        if (mounted && !_engineHandoffInProgress) {
+          _showTrackMessage('Could not skip this segment');
+        }
       }
     } finally {
       _skipInProgress = false;

--- a/lib/features/streaming/presentation/resolve_episode_screen.dart
+++ b/lib/features/streaming/presentation/resolve_episode_screen.dart
@@ -566,6 +566,8 @@ class _ResolveEpisodeScreenState extends ConsumerState<ResolveEpisodeScreen> {
   int _debridSourcesTotal = 0;
   int _webProvidersCompleted = 0;
   int _webProvidersTotal = 0;
+  String _webDiagnosticSessionId = '';
+  String _lastWebVisibilityDiagnosticSignature = '';
   List<String> _pendingDebridSources = const [];
   List<String> _pendingWebProviders = const [];
   int _releaseSearchGeneration = 0;
@@ -982,6 +984,8 @@ class _ResolveEpisodeScreenState extends ConsumerState<ResolveEpisodeScreen> {
       _debridSourcesTotal = 0;
       _webProvidersCompleted = 0;
       _webProvidersTotal = 0;
+      _webDiagnosticSessionId = '';
+      _lastWebVisibilityDiagnosticSignature = '';
       _pendingDebridSources = const [];
       _pendingWebProviders = const [];
       _debridSearchEnabled = shouldSearchDebrid;
@@ -1104,9 +1108,13 @@ class _ResolveEpisodeScreenState extends ConsumerState<ResolveEpisodeScreen> {
             _webFailures = progress.aggregation.failures;
             _webProvidersCompleted = progress.completedProviders;
             _webProvidersTotal = progress.totalProviders;
+            _webDiagnosticSessionId = progress.diagnosticSessionId;
             _pendingWebProviders = progress.pendingProviderNames;
             if (progress.isComplete) _webSearchFinished = true;
           });
+          if (progress.isComplete) {
+            _recordWebProviderVisibilityDiagnostic(phase: 'final');
+          }
           finishVisibleSearchIfReady();
           _tryStartAutoPlay(
             generation: generation,
@@ -2165,6 +2173,48 @@ class _ResolveEpisodeScreenState extends ConsumerState<ResolveEpisodeScreen> {
       ),
     );
     return _providerFairManualWebStreams(result);
+  }
+
+  void _recordWebProviderVisibilityDiagnostic({required String phase}) {
+    if (_webDiagnosticSessionId.isEmpty) return;
+    final visibleStreams = _filteredWebStreams(_webStreams);
+    final rawProviderCount = _webStreams
+        .map(webStreamProviderIdentity)
+        .toSet()
+        .length;
+    final visibleProviderCount = visibleStreams
+        .map(webStreamProviderIdentity)
+        .toSet()
+        .length;
+    final signature = [
+      phase,
+      _webDiagnosticSessionId,
+      rawProviderCount,
+      _webStreams.length,
+      visibleProviderCount,
+      visibleStreams.length,
+      _languageFilter.name,
+      _qualityFilter.name,
+    ].join(':');
+    if (signature == _lastWebVisibilityDiagnosticSignature) return;
+    _lastWebVisibilityDiagnosticSignature = signature;
+    unawaited(
+      TetoTvDatabase.instance.recordDiagnosticEvent(
+        category: 'provider-search',
+        message: 'Web provider results after filters',
+        severity: 'info',
+        details: webProviderVisibilityDiagnosticDetails(
+          phase: phase,
+          diagnosticSessionId: _webDiagnosticSessionId,
+          rawProviders: rawProviderCount,
+          rawResults: _webStreams.length,
+          visibleProviders: visibleProviderCount,
+          visibleResults: visibleStreams.length,
+          audioFilter: _languageFilter.name,
+          qualityFilter: _qualityFilter.name,
+        ),
+      ),
+    );
   }
 
   bool get _hasFailedWebProviders => _webFailures.any(
@@ -3390,7 +3440,13 @@ class _ResolveEpisodeScreenState extends ConsumerState<ResolveEpisodeScreen> {
   }
 
   void _updatePicker(VoidCallback update) {
+    final previousLanguage = _languageFilter;
+    final previousQuality = _qualityFilter;
     setState(update);
+    if (previousLanguage != _languageFilter ||
+        previousQuality != _qualityFilter) {
+      _recordWebProviderVisibilityDiagnostic(phase: 'filter_changed');
+    }
     unawaited(_rememberPickerPreferences());
   }
 

--- a/lib/features/watch_together/domain/watch_party_models.dart
+++ b/lib/features/watch_together/domain/watch_party_models.dart
@@ -10,7 +10,17 @@ const int maximumWatchPartyGuestCount = 20;
 const int maximumWatchPartyRosterSize = maximumWatchPartyGuestCount + 1;
 const int maximumWatchPartyEventCount = 16;
 
-const _watchPartyAvatarHosts = <String>{'s4.anilist.co', 'cdn.myanimelist.net'};
+// Tracker APIs can return either their established artwork host or a newer CDN
+// alias. Keep this list exact and provider-owned: a Watch Party shares only the
+// already-public avatar URL, never a tracker token, account ID, or lookup key.
+// Supporting both trackers' public CDN variants also makes the roster
+// independent of which tracker the receiving participant uses.
+const _watchPartyAvatarHosts = <String>{
+  's4.anilist.co',
+  'img.anili.st',
+  'cdn.myanimelist.net',
+  'api-cdn.myanimelist.net',
+};
 
 @immutable
 class WatchPartyPublicIdentity {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: 'none'
 # Public and Beta artifacts built from the same source use one monotonically
 # increasing Android versionCode. The project default carries the Beta display
 # version; the Public universal APK overrides the build name to the 1.x line.
-version: 2.0.44+410021
+version: 2.0.45+410022
 
 environment:
   sdk: ^3.12.2

--- a/test/anilist_catalog_client_test.dart
+++ b/test/anilist_catalog_client_test.dart
@@ -272,6 +272,121 @@ void main() {
   };
 
   group('AniListCatalogClient', () {
+    test(
+      'franchise watch order expands a continuation chain once per title',
+      () async {
+        final requestedIds = <int>[];
+        final dio = Dio(BaseOptions(baseUrl: 'https://graphql.anilist.co'));
+
+        Map<String, dynamic> media(
+          int id, {
+          required int year,
+          String format = 'TV',
+          List<(int, String)> relations = const [],
+        }) => {
+          'id': id,
+          'idMal': null,
+          'type': 'ANIME',
+          'title': {
+            'userPreferred': 'Title $id',
+            'english': 'English $id',
+            'romaji': 'Romaji $id',
+          },
+          'description': '',
+          'episodes': 12,
+          'averageScore': 80,
+          'genres': <String>[],
+          'coverImage': {'extraLarge': null},
+          'bannerImage': null,
+          'format': format,
+          'status': 'FINISHED',
+          'season': 'SPRING',
+          'seasonYear': year,
+          'duration': 24,
+          'synonyms': <String>[],
+          'nextAiringEpisode': null,
+          'relations': {
+            'edges': [
+              for (final relation in relations)
+                {
+                  'relationType': relation.$2,
+                  'node': {
+                    'id': relation.$1,
+                    'idMal': null,
+                    'type': 'ANIME',
+                    'title': {'userPreferred': 'Title ${relation.$1}'},
+                    'description': '',
+                    'episodes': relation.$1 == 9 ? 1 : 12,
+                    'averageScore': 80,
+                    'genres': <String>[],
+                    'coverImage': {'extraLarge': null},
+                    'bannerImage': null,
+                    'format': relation.$1 == 9 ? 'MOVIE' : 'TV',
+                    'status': 'FINISHED',
+                    'season': 'SPRING',
+                    'seasonYear': relation.$1 == 9 ? 2020 : 2019 + relation.$1,
+                    'duration': 24,
+                    'synonyms': <String>[],
+                    'nextAiringEpisode': null,
+                  },
+                },
+            ],
+          },
+        };
+
+        dio.interceptors.add(
+          InterceptorsWrapper(
+            onRequest: (options, handler) {
+              final variables =
+                  (options.data as Map<String, dynamic>)['variables']
+                      as Map<String, dynamic>;
+              final id = variables['id'] as int;
+              requestedIds.add(id);
+              final response = switch (id) {
+                1 => media(
+                  1,
+                  year: 2020,
+                  relations: const [(2, 'SEQUEL'), (9, 'SIDE_STORY')],
+                ),
+                2 => media(
+                  2,
+                  year: 2021,
+                  relations: const [(1, 'PREQUEL'), (3, 'SEQUEL')],
+                ),
+                3 => media(
+                  3,
+                  year: 2022,
+                  relations: const [(2, 'PREQUEL'), (4, 'SEQUEL')],
+                ),
+                4 => media(4, year: 2023, relations: const [(3, 'PREQUEL')]),
+                _ => throw StateError('Unexpected media request $id'),
+              };
+              handler.resolve(
+                Response<Map<String, dynamic>>(
+                  data: {
+                    'data': {'Media': response},
+                  },
+                  requestOptions: options,
+                  statusCode: 200,
+                ),
+              );
+            },
+          ),
+        );
+        final client = AniListCatalogClient(dio: dio);
+
+        final order = await client.franchiseWatchOrder(1);
+        final ids = order.map((entry) => entry.anime.id).toList();
+        final movie = order.singleWhere((entry) => entry.anime.id == 9);
+
+        expect(requestedIds, [1, 2, 3, 4]);
+        expect(ids.indexOf(1), lessThan(ids.indexOf(2)));
+        expect(ids.indexOf(2), lessThan(ids.indexOf(3)));
+        expect(ids.indexOf(3), lessThan(ids.indexOf(4)));
+        expect(movie.watchOrderLabel, 'Movie · Side story');
+      },
+    );
+
     test('strips HTML tags from descriptions', () async {
       final client = AniListCatalogClient(
         dio: interceptedDio({

--- a/test/anime_details_screen_test.dart
+++ b/test/anime_details_screen_test.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:anime_tv/core/layout/adaptive_layout.dart';
 import 'package:anime_tv/core/preferences/title_language_preference.dart';
 import 'package:anime_tv/core/theme/app_theme.dart';
 import 'package:anime_tv/features/catalog/application/anime_title_logo_provider.dart';
@@ -692,7 +693,7 @@ void main() {
     addTearDown(tester.view.resetPhysicalSize);
     addTearDown(tester.view.resetDevicePixelRatio);
 
-    const anime = AnimeSummary(
+    final anime = AnimeSummary(
       id: 1,
       title: 'The Example Hero and the Long Adventure Title',
       description:
@@ -704,7 +705,12 @@ void main() {
       format: 'TV',
       status: 'RELEASING',
       durationMinutes: 24,
-      relatedAnime: [
+      staff: const [AnimePerson(id: 10, name: 'Example Director')],
+      trailer: AnimeTrailer.tryCreate(
+        provider: 'youtube',
+        videoId: 'abcDEF_12-3',
+      ),
+      relatedAnime: const [
         RelatedAnime(
           relationType: 'SEQUEL',
           anime: AnimeSummary(
@@ -742,6 +748,8 @@ void main() {
     expect(find.text('Start watching'), findsOneWidget);
     expect(find.text('My List status'), findsOneWidget);
     expect(find.text('Episode 1 of 24'), findsOneWidget);
+    expect(find.text('Watch trailer'), findsOneWidget);
+    expect(find.text('Cast & crew'), findsOneWidget);
     expect(find.text('Related series'), findsOneWidget);
     expect(find.text('RELATED'), findsNothing);
     expect(find.text('The Example Hero Season 2'), findsNothing);
@@ -779,20 +787,83 @@ void main() {
     final compactTvInformationTray = tester.getRect(
       find.byKey(const ValueKey('anime-details-information-actions')),
     );
-    final compactTvRelatedAction = tester.getRect(
-      find.byKey(const ValueKey('anime-details-related-series')),
-    );
-    final compactTvDownloadAction = tester.getRect(
-      find.byKey(const ValueKey('anime-details-download-season')),
-    );
+    final compactInformationActionRects = <Rect>[
+      for (final key in const [
+        ValueKey('anime-details-watch-trailer-surface'),
+        ValueKey('anime-details-cast-crew-surface'),
+        ValueKey('anime-details-related-series-surface'),
+        ValueKey('anime-details-download-season-surface'),
+      ])
+        tester.getRect(find.byKey(key)),
+    ];
     expect(compactTvPoster.height / 540, closeTo(.60, .01));
     expect(compactTvPoster.right, lessThan(compactTvInfo.left));
     expect(compactTvInfo.right, lessThan(compactTvActions.left));
-    // A television keeps the same reference action sizing even when Android
-    // exposes a 960px logical canvas instead of a full-HD one.
-    expect(compactTvInformationTray.height, 80);
-    expect(compactTvRelatedAction.size, const Size(165, 58));
-    expect(compactTvDownloadAction.size, const Size(182, 58));
+    // A television keeps every available action in one compact visible row
+    // even when Android exposes a 960px logical canvas.
+    expect(compactTvInformationTray.height, 86);
+    for (var index = 0; index < compactInformationActionRects.length; index++) {
+      final rect = compactInformationActionRects[index];
+      expect(rect.width, closeTo(90, .01));
+      expect(rect.height, 64);
+      expect(rect.top, compactInformationActionRects.first.top);
+      expect(rect.left, greaterThanOrEqualTo(compactTvInformationTray.left));
+      expect(rect.right, lessThanOrEqualTo(compactTvInformationTray.right));
+      if (index > 0) {
+        expect(
+          rect.left - compactInformationActionRects[index - 1].right,
+          closeTo(6, .01),
+        );
+      }
+    }
+    final informationTray = find.byKey(
+      const ValueKey('anime-details-information-actions'),
+    );
+    expect(
+      find.descendant(of: informationTray, matching: find.byType(FittedBox)),
+      findsNothing,
+    );
+    expect(tester.widget<Text>(find.text('Watch trailer')).style?.fontSize, 16);
+    for (final icon in tester.widgetList<Icon>(
+      find.descendant(of: informationTray, matching: find.byType(Icon)),
+    )) {
+      expect(icon.size, 23);
+    }
+    final compactTrailerControl = tester.widget<FocusableActionDetector>(
+      find
+          .descendant(
+            of: find.byKey(const ValueKey('anime-details-watch-trailer')),
+            matching: find.byType(FocusableActionDetector),
+          )
+          .first,
+    );
+    compactTrailerControl.focusNode!.requestFocus();
+    await tester.pump();
+    await tester.sendKeyEvent(LogicalKeyboardKey.arrowRight);
+    await tester.pump();
+    final compactCastControl = tester.widget<FocusableActionDetector>(
+      find
+          .descendant(
+            of: find.byKey(const ValueKey('anime-details-cast-crew')),
+            matching: find.byType(FocusableActionDetector),
+          )
+          .first,
+    );
+    expect(compactCastControl.focusNode?.hasFocus, isTrue);
+    await tester.sendKeyEvent(LogicalKeyboardKey.arrowLeft);
+    await tester.pump();
+    expect(compactTrailerControl.focusNode?.hasFocus, isTrue);
+    expect(
+      find.descendant(
+        of: find.byKey(const ValueKey('anime-details-information-actions')),
+        matching: find.byWidgetPredicate(
+          (widget) =>
+              widget is SingleChildScrollView &&
+              widget.scrollDirection == Axis.horizontal,
+        ),
+      ),
+      findsNothing,
+    );
     await tester.tap(find.text('My List status'));
     await tester.pumpAndSettle();
     expect(find.text('Planning'), findsOneWidget);
@@ -871,16 +942,27 @@ void main() {
     expect(find.text('2026'), findsWidgets);
     expect(find.text('24m'), findsWidgets);
     expect(find.text('7.8 / 10'), findsOneWidget);
-    final castControl = tester.widget<FocusableActionDetector>(
+    final trailerControl = tester.widget<FocusableActionDetector>(
       find
-          .ancestor(
-            of: find.text('Cast & crew'),
+          .descendant(
+            of: find.byKey(const ValueKey('anime-details-watch-trailer')),
             matching: find.byType(FocusableActionDetector),
           )
           .first,
     );
-    castControl.focusNode!.requestFocus();
+    trailerControl.focusNode!.requestFocus();
     await tester.pump();
+    await tester.sendKeyEvent(LogicalKeyboardKey.arrowRight);
+    await tester.pump();
+    final castControl = tester.widget<FocusableActionDetector>(
+      find
+          .descendant(
+            of: find.byKey(const ValueKey('anime-details-cast-crew')),
+            matching: find.byType(FocusableActionDetector),
+          )
+          .first,
+    );
+    expect(castControl.focusNode?.hasFocus, isTrue);
     await tester.sendKeyEvent(LogicalKeyboardKey.arrowRight);
     await tester.pump();
     final relatedControl = tester.widget<FocusableActionDetector>(
@@ -922,22 +1004,18 @@ void main() {
         closeTo(informationActionRects.first.bottom, .01),
       );
       expect(
-        informationActionRects[index].left,
-        greaterThan(informationActionRects[index - 1].right),
-      );
-    }
-    expect(informationActionRects.first.height, 58);
-    expect(
-      informationActionRects.map((rect) => rect.width),
-      orderedEquals(const [154, 150, 165, 182]),
-    );
-    for (var index = 1; index < informationActionRects.length; index++) {
-      expect(
         informationActionRects[index].left -
             informationActionRects[index - 1].right,
         12,
       );
     }
+    for (final rect in informationActionRects) {
+      expect(rect.height, 58);
+    }
+    expect(
+      informationActionRects.map((rect) => rect.width),
+      orderedEquals(const [154, 150, 165, 182]),
+    );
     final informationTray = tester.widget<Container>(
       find.byKey(const ValueKey('anime-details-information-actions')),
     );
@@ -1087,6 +1165,7 @@ void main() {
         await tester.pumpWidget(
           ProviderScope(
             overrides: [
+              isTelevisionProvider.overrideWithValue(false),
               animeDetailsProvider.overrideWith((_, _) async => anime),
               trackingHomeProvider.overrideWith(
                 (_) async => const TrackingHomeData(
@@ -1200,6 +1279,7 @@ void main() {
         await tester.pumpWidget(
           ProviderScope(
             overrides: [
+              isTelevisionProvider.overrideWithValue(false),
               animeDetailsProvider.overrideWith((_, _) async => anime),
               trackingHomeProvider.overrideWith(
                 (_) async => const TrackingHomeData(
@@ -1222,18 +1302,50 @@ void main() {
         expect(find.text('Related series'), findsOneWidget);
         expect(find.text('Download season'), findsOneWidget);
         expect(find.text('EP 1 / 12'), findsOneWidget);
-        final informationActionTops = <double>[
+        final informationActionRects = <Rect>[
           for (final key in const [
             ValueKey('anime-details-watch-trailer'),
             ValueKey('anime-details-cast-crew'),
             ValueKey('anime-details-related-series'),
             ValueKey('anime-details-download-season'),
           ])
-            tester.getTopLeft(find.byKey(key)).dy,
+            tester.getRect(find.byKey(key)),
         ];
-        for (final top in informationActionTops.skip(1)) {
-          expect(top, closeTo(informationActionTops.first, .01));
+        for (var index = 1; index < informationActionRects.length; index++) {
+          expect(
+            informationActionRects[index].top,
+            closeTo(informationActionRects.first.top, .01),
+          );
+          expect(
+            informationActionRects[index].left,
+            greaterThan(informationActionRects[index - 1].right),
+          );
         }
+        expect(
+          find.descendant(
+            of: find.byKey(const ValueKey('anime-details-information-actions')),
+            matching: find.byWidgetPredicate(
+              (widget) =>
+                  widget is SingleChildScrollView &&
+                  widget.scrollDirection == Axis.horizontal,
+            ),
+          ),
+          findsNothing,
+        );
+        final mobileInformationTray = find.byKey(
+          const ValueKey('anime-details-information-actions'),
+        );
+        expect(
+          find.descendant(
+            of: mobileInformationTray,
+            matching: find.byType(FittedBox),
+          ),
+          findsNothing,
+        );
+        expect(
+          tester.widget<Text>(find.text('Watch trailer')).style?.fontSize,
+          12,
+        );
         final posterSize = tester.getSize(
           find.byKey(const ValueKey('anime-details-poster')),
         );

--- a/test/diagnostic_history_test.dart
+++ b/test/diagnostic_history_test.dart
@@ -198,12 +198,18 @@ void main() {
               'embedded_marker_count': 0,
               'community_marker_count': 2,
               'community_status': 'found_nearby_runtime',
+              'community_status_class': 'partial_transient_failure',
+              'community_failure_reason': 'connection_timeout',
+              'community_transient_failure_count': 1,
               'community_probe_count': 4,
               'duration_fallback_used': true,
               'segment_kind': 'opening',
               'automatic': true,
               'marker_start_ms': 90000,
               'marker_end_ms': 181013,
+              'seek_verified': true,
+              'seek_attempts': 2,
+              'post_seek_position_ms': 181100,
               'title': 'Private anime title',
               'url': 'https://private.example/video.m3u8',
             })!
@@ -211,12 +217,18 @@ void main() {
 
     expect(sanitized['community_status'], 'found_nearby_runtime');
     expect(sanitized['community_probe_count'], 4);
+    expect(sanitized['community_status_class'], 'partial_transient_failure');
+    expect(sanitized['community_failure_reason'], 'connection_timeout');
+    expect(sanitized['community_transient_failure_count'], 1);
     expect(sanitized['duration_fallback_used'], isTrue);
     expect(sanitized['community_marker_count'], 2);
     expect(sanitized['segment_kind'], 'opening');
     expect(sanitized['automatic'], isTrue);
     expect(sanitized['marker_start_ms'], 90000);
     expect(sanitized['marker_end_ms'], 181013);
+    expect(sanitized['seek_verified'], isTrue);
+    expect(sanitized['seek_attempts'], 2);
+    expect(sanitized['post_seek_position_ms'], 181100);
     expect(sanitized['title'], '[REDACTED]');
     expect(sanitized['url'], '[REDACTED]');
   });

--- a/test/franchise_screen_test.dart
+++ b/test/franchise_screen_test.dart
@@ -1,0 +1,110 @@
+import 'package:anime_tv/core/preferences/title_language_preference.dart';
+import 'package:anime_tv/features/catalog/application/catalog_providers.dart';
+import 'package:anime_tv/features/catalog/domain/anime_summary.dart';
+import 'package:anime_tv/features/catalog/domain/franchise_watch_order.dart';
+import 'package:anime_tv/features/catalog/presentation/franchise_screen.dart';
+import 'package:anime_tv/features/settings/application/display_preferences_controller.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('shows numbered relation badges and preferred-language titles', (
+    tester,
+  ) async {
+    tester.view.physicalSize = const Size(1280, 720);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    const entries = [
+      FranchiseWatchOrderEntry(
+        anime: AnimeSummary(
+          id: 1,
+          title: 'Fallback first',
+          titleEnglish: 'English first',
+          titleRomaji: 'Romaji first',
+          description: '',
+          episodes: 12,
+          score: 8,
+          format: 'TV',
+        ),
+        relationRole: FranchiseRelationRole.current,
+      ),
+      FranchiseWatchOrderEntry(
+        anime: AnimeSummary(
+          id: 2,
+          title: 'Fallback movie',
+          titleEnglish: 'English movie',
+          titleRomaji: 'Romaji movie',
+          description: '',
+          episodes: 1,
+          score: 8,
+          format: 'MOVIE',
+        ),
+        relationRole: FranchiseRelationRole.sequel,
+      ),
+      FranchiseWatchOrderEntry(
+        anime: AnimeSummary(
+          id: 3,
+          title: 'Fallback OVA',
+          titleEnglish: 'English OVA',
+          titleRomaji: 'Romaji OVA',
+          description: '',
+          episodes: 1,
+          score: 8,
+          format: 'OVA',
+        ),
+        relationRole: FranchiseRelationRole.sideStory,
+      ),
+      FranchiseWatchOrderEntry(
+        anime: AnimeSummary(
+          id: 4,
+          title: 'Fallback special',
+          titleEnglish: 'English special',
+          titleRomaji: 'Romaji special',
+          description: '',
+          episodes: 1,
+          score: 8,
+          format: 'SPECIAL',
+        ),
+        relationRole: FranchiseRelationRole.spinOff,
+      ),
+    ];
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          franchiseProvider(1).overrideWith((_) async => entries),
+          titleLanguagePreferenceProvider.overrideWith(
+            (_) =>
+                _StaticTitleLanguageController(TitleLanguagePreference.romaji),
+          ),
+        ],
+        child: const MaterialApp(home: FranchiseScreen(mediaId: 1)),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('Recommended watch order'), findsOneWidget);
+    expect(find.text('Romaji first'), findsOneWidget);
+    expect(find.text('Romaji movie'), findsOneWidget);
+    expect(find.text('English first'), findsNothing);
+    expect(find.text('#1 · TV · Current'), findsOneWidget);
+    expect(find.text('#2 · Movie · Sequel'), findsOneWidget);
+    expect(find.text('#3 · OVA · Side story'), findsOneWidget);
+    expect(find.text('#4 · Special · Spin-off'), findsOneWidget);
+    expect(tester.takeException(), isNull);
+  });
+}
+
+class _StaticTitleLanguageController extends TitleLanguagePreferenceController {
+  _StaticTitleLanguageController(TitleLanguagePreference initial)
+    : super(const FlutterSecureStorage()) {
+    state = initial;
+  }
+
+  @override
+  Future<void> load() async {}
+}

--- a/test/franchise_watch_order_test.dart
+++ b/test/franchise_watch_order_test.dart
@@ -1,0 +1,186 @@
+import 'package:anime_tv/features/catalog/domain/anime_summary.dart';
+import 'package:anime_tv/features/catalog/domain/franchise_watch_order.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('orders continuation graph and labels related formats and roles', () {
+    const prequel = AnimeSummary(
+      id: 1,
+      title: 'First story',
+      description: '',
+      episodes: 12,
+      score: 8,
+      format: 'TV',
+      seasonYear: 2018,
+    );
+    const sequel = AnimeSummary(
+      id: 3,
+      title: 'Third story',
+      description: '',
+      episodes: 12,
+      score: 8,
+      format: 'TV',
+      seasonYear: 2021,
+    );
+    const movie = AnimeSummary(
+      id: 4,
+      title: 'The movie',
+      description: '',
+      episodes: 1,
+      score: 8,
+      format: 'MOVIE',
+      seasonYear: 2020,
+    );
+    const ova = AnimeSummary(
+      id: 5,
+      title: 'Bonus OVA',
+      description: '',
+      episodes: 1,
+      score: 8,
+      format: 'OVA',
+      seasonYear: 2020,
+    );
+    const special = AnimeSummary(
+      id: 6,
+      title: 'Broadcast special',
+      description: '',
+      episodes: 1,
+      score: 8,
+      format: 'SPECIAL',
+      seasonYear: 2020,
+    );
+    const spinOff = AnimeSummary(
+      id: 7,
+      title: 'Different heroes',
+      description: '',
+      episodes: 12,
+      score: 8,
+      format: 'TV',
+      seasonYear: 2022,
+    );
+    const root = AnimeSummary(
+      id: 2,
+      title: 'Main story',
+      description: '',
+      episodes: 12,
+      score: 8,
+      format: 'TV',
+      seasonYear: 2020,
+      relatedAnime: [
+        RelatedAnime(anime: prequel, relationType: 'PREQUEL'),
+        RelatedAnime(anime: sequel, relationType: 'SEQUEL'),
+        RelatedAnime(anime: movie, relationType: 'SEQUEL'),
+        RelatedAnime(anime: ova, relationType: 'SIDE_STORY'),
+        RelatedAnime(anime: special, relationType: 'SIDE_STORY'),
+        RelatedAnime(anime: spinOff, relationType: 'SPIN_OFF'),
+      ],
+    );
+
+    final order = buildRecommendedFranchiseWatchOrder(
+      rootId: root.id,
+      anime: const [sequel, root, prequel],
+    );
+    final ids = order.map((entry) => entry.anime.id).toList();
+    final byId = {for (final entry in order) entry.anime.id: entry};
+
+    expect(ids.indexOf(1), lessThan(ids.indexOf(2)));
+    expect(ids.indexOf(2), lessThan(ids.indexOf(3)));
+    expect(ids.indexOf(2), lessThan(ids.indexOf(4)));
+    expect(byId[1]!.watchOrderLabel, 'TV · Prequel');
+    expect(byId[2]!.watchOrderLabel, 'TV · Current');
+    expect(byId[3]!.watchOrderLabel, 'TV · Sequel');
+    expect(byId[4]!.watchOrderLabel, 'Movie · Sequel');
+    expect(byId[5]!.watchOrderLabel, 'OVA · Side story');
+    expect(byId[6]!.watchOrderLabel, 'Special · Side story');
+    expect(byId[7]!.watchOrderLabel, 'TV · Spin-off');
+  });
+
+  test('classifies later continuation hops as sequels', () {
+    const fourth = AnimeSummary(
+      id: 4,
+      title: 'Part four',
+      description: '',
+      episodes: 12,
+      score: 8,
+      format: 'TV',
+      seasonYear: 2024,
+    );
+    const third = AnimeSummary(
+      id: 3,
+      title: 'Part three',
+      description: '',
+      episodes: 12,
+      score: 8,
+      format: 'TV',
+      seasonYear: 2023,
+      relatedAnime: [RelatedAnime(anime: fourth, relationType: 'SEQUEL')],
+    );
+    const root = AnimeSummary(
+      id: 2,
+      title: 'Part two',
+      description: '',
+      episodes: 12,
+      score: 8,
+      format: 'TV',
+      seasonYear: 2022,
+      relatedAnime: [RelatedAnime(anime: third, relationType: 'SEQUEL')],
+    );
+
+    final order = buildRecommendedFranchiseWatchOrder(
+      rootId: root.id,
+      anime: const [third, root],
+    );
+
+    expect(order.map((entry) => entry.anime.id), [2, 3, 4]);
+    expect(order.last.relationRole, FranchiseRelationRole.sequel);
+  });
+
+  test('malformed relationship cycles still produce a stable full order', () {
+    const firstStub = AnimeSummary(
+      id: 1,
+      title: 'First',
+      description: '',
+      episodes: 12,
+      score: 8,
+      format: 'TV',
+      seasonYear: 2020,
+    );
+    const secondStub = AnimeSummary(
+      id: 2,
+      title: 'Second',
+      description: '',
+      episodes: 12,
+      score: 8,
+      format: 'TV',
+      seasonYear: 2021,
+    );
+    const first = AnimeSummary(
+      id: 1,
+      title: 'First',
+      description: '',
+      episodes: 12,
+      score: 8,
+      format: 'TV',
+      seasonYear: 2020,
+      relatedAnime: [RelatedAnime(anime: secondStub, relationType: 'SEQUEL')],
+    );
+    const second = AnimeSummary(
+      id: 2,
+      title: 'Second',
+      description: '',
+      episodes: 12,
+      score: 8,
+      format: 'TV',
+      seasonYear: 2021,
+      relatedAnime: [RelatedAnime(anime: firstStub, relationType: 'SEQUEL')],
+    );
+
+    List<int> build() => buildRecommendedFranchiseWatchOrder(
+      rootId: 1,
+      anime: const [second, first],
+    ).map((entry) => entry.anime.id).toList();
+
+    expect(build(), [1, 2]);
+    expect(build(), build());
+  });
+}

--- a/test/home_tv_navigation_test.dart
+++ b/test/home_tv_navigation_test.dart
@@ -544,7 +544,7 @@ void main() {
     expect(find.text(hero.description), findsNothing);
     final titleRect = tester.getRect(titleFinder);
     final heroRect = tester.getRect(find.byKey(const ValueKey('home-hero')));
-    expect(titleRect.width, closeTo(1280 * .48, .01));
+    expect(titleRect.width, closeTo(1280 * .5, .01));
     expect(titleRect.right, lessThan(heroRect.left + heroRect.width * .58));
     expect(titleRect.height, lessThan(heroRect.height * .3));
     expect(heroRect.contains(titleRect.topLeft), isTrue);
@@ -556,11 +556,12 @@ void main() {
   });
 
   testWidgets(
-    'TV featured hero wraps and scales a long title without truncating it',
+    'TV featured hero wraps a long title at the same size without truncation',
     (tester) async {
       const longTitle =
           'The Legendary Hero Is Reborn as the Last Guardian of the Forgotten '
-          'Kingdom Beyond the End of the World';
+          'Kingdom Beyond the End of the World and Must Gather Every Ancient '
+          'Relic Before the Stars Disappear Forever from the Northern Sky';
       await _pumpFeaturedHomeHero(
         tester,
         viewport: const Size(960, 540),
@@ -590,17 +591,14 @@ void main() {
         of: currentTitle,
         matching: find.text(longTitle),
       );
-      final fittedTitle = find.descendant(
-        of: currentTitle,
-        matching: find.byKey(const ValueKey('home-hero-title-fit')),
-      );
-
       expect(titleText, findsOneWidget);
-      expect(fittedTitle, findsOneWidget);
+      expect(
+        find.descendant(of: currentTitle, matching: find.byType(FittedBox)),
+        findsNothing,
+      );
       final textWidget = tester.widget<Text>(titleText);
       expect(textWidget.maxLines, isNull);
       expect(textWidget.overflow, TextOverflow.visible);
-      expect(tester.widget<FittedBox>(fittedTitle).fit, BoxFit.scaleDown);
       expect(
         tester.renderObject<RenderParagraph>(titleText).didExceedMaxLines,
         isFalse,
@@ -609,8 +607,13 @@ void main() {
       final slotRect = tester.getRect(titleSlot);
       final renderedTextRect = tester.getRect(titleText);
       final heroRect = tester.getRect(find.byKey(const ValueKey('home-hero')));
-      expect(slotRect.height, 68);
-      expect(slotRect.width, closeTo(960 * .48, .01));
+      final metadataRect = tester.getRect(find.text('8.8'));
+      final labelRect = tester.getRect(find.text('Releasing'));
+      final actionRect = tester.getRect(
+        find.byKey(const ValueKey('home-hero-watch-now')),
+      );
+      expect(slotRect.height, greaterThan(102));
+      expect(slotRect.width, closeTo(960 * .5, .01));
       expect(slotRect.right, lessThan(heroRect.left + heroRect.width * .58));
       expect(find.byKey(const ValueKey('hero-art-1618')), findsOneWidget);
       expect(slotRect.contains(renderedTextRect.topLeft), isTrue);
@@ -618,6 +621,10 @@ void main() {
         slotRect.contains(renderedTextRect.bottomRight - const Offset(.1, .1)),
         isTrue,
       );
+      expect(renderedTextRect.bottom, lessThanOrEqualTo(metadataRect.top));
+      expect(metadataRect.bottom, lessThanOrEqualTo(labelRect.top));
+      expect(labelRect.bottom, lessThan(actionRect.top));
+      expect(heroRect.height, closeTo(300 + slotRect.height - 102, .01));
       for (final action in const [
         ValueKey('home-hero-watch-now'),
         ValueKey('home-hero-my-list'),
@@ -629,6 +636,50 @@ void main() {
           isTrue,
         );
       }
+      expect(tester.takeException(), isNull);
+
+      const shortTitle = 'Short TV Title';
+      await tester.pumpWidget(const SizedBox.shrink());
+      await tester.pump();
+      await _pumpFeaturedHomeHero(
+        tester,
+        viewport: const Size(960, 540),
+        isTelevision: true,
+        preferences: const SettingsPreferences(
+          interfaceMode: InterfaceMode.television,
+          showHero: true,
+          loaded: true,
+        ),
+        hero: const AnimeSummary(
+          id: 1619,
+          title: shortTitle,
+          description: 'A short-title comparison fixture.',
+          episodes: null,
+          score: null,
+        ),
+      );
+
+      final shortTitleText = find.text(shortTitle);
+      expect(shortTitleText, findsOneWidget);
+      expect(
+        tester.widget<Text>(shortTitleText).style?.fontSize,
+        textWidget.style?.fontSize,
+      );
+      expect(
+        tester.getSize(find.byKey(const ValueKey('hero-title-1619'))).height,
+        102,
+      );
+      expect(
+        tester.getSize(find.byKey(const ValueKey('home-hero'))).height,
+        300,
+      );
+      expect(
+        find.descendant(
+          of: find.byKey(const ValueKey('hero-title-text-1619')),
+          matching: find.byType(FittedBox),
+        ),
+        findsNothing,
+      );
       expect(tester.takeException(), isNull);
     },
   );

--- a/test/player_lifecycle_safety_test.dart
+++ b/test/player_lifecycle_safety_test.dart
@@ -240,7 +240,7 @@ void main() {
   test('library completion uses the awaited MPV handoff before route pop', () {
     final completion = method(
       'void _handlePlaybackCompleted()',
-      'Future<bool> _seekForSkip',
+      'Future<VerifiedSkipSeekResult> _seekForSkip',
     );
     expectInOrder(completion, [
       'libraryPlayback.markCompleted(',
@@ -248,6 +248,49 @@ void main() {
       'unawaited(_returnToStreamPicker())',
     ]);
     expect(completion, isNot(contains('context.pop()')));
+  });
+
+  test(
+    'failed automatic skip falls back to the manual action without looping',
+    () {
+      final skipCheck = method(
+        'void _checkSkips(Duration position)',
+        'void _focusSkipOnce',
+      );
+      expect(
+        skipCheck,
+        contains('!_suppressedAutomaticSkipSegments.contains(key)'),
+      );
+
+      final autoSkip = method(
+        'Future<void> _autoSkipSegment',
+        'void _focusSkipOnce',
+      );
+      expectInOrder(autoSkip, [
+        '} catch (_)',
+        'if (sourceStillActive)',
+        '_suppressedAutomaticSkipSegments.add(segmentKey)',
+        '} finally',
+        '_checkSkips(_player.state.position)',
+      ]);
+
+      final sourceReset = method(
+        'void _resetSkipSegmentsForSourceChange()',
+        'void _recordSkipSegmentDiagnostic',
+      );
+      expect(sourceReset, contains('_suppressedAutomaticSkipSegments.clear()'));
+    },
+  );
+
+  test('verified skip retries are bound to the active source', () {
+    final skipSeek = method(
+      'Future<VerifiedSkipSeekResult> _seekForSkip',
+      'Future<void> _waitForPlayerMutations',
+    );
+    expect(skipSeek, contains('final expectedStream = _currentStream'));
+    expect(skipSeek, contains('final expectedSource = _source'));
+    expect(skipSeek, contains('!identical(_currentStream, expectedStream)'));
+    expect(skipSeek, contains('_source != expectedSource'));
   });
 
   test(

--- a/test/player_premature_eof_test.dart
+++ b/test/player_premature_eof_test.dart
@@ -128,7 +128,7 @@ void main() {
     expect(
       source,
       contains(
-        'await _player.seek(target);\n            _recordCommittedSeek(target);',
+        'if (result.verified) {\n            _recordCommittedSeek(target);',
       ),
     );
     expect(

--- a/test/release_repository_policy_test.dart
+++ b/test/release_repository_policy_test.dart
@@ -206,7 +206,7 @@ void main() {
       '.github/workflows/verify-release-assets.yml',
     ).readAsStringSync();
     final releaseNotes = File(
-      'docs/RELEASE_NOTES_2.0.44.md',
+      'docs/RELEASE_NOTES_2.0.45.md',
     ).readAsStringSync();
 
     expect(

--- a/test/skip_segment_service_test.dart
+++ b/test/skip_segment_service_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:anime_tv/features/player/application/skip_segment_service.dart';
 import 'package:dio/dio.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -81,6 +83,87 @@ void main() {
         runtimeProbesExhausted: true,
       ),
       isTrue,
+    );
+  });
+
+  test('transient lookup failures receive only two deferred retries', () {
+    expect(
+      skipSegmentLookupIsComplete(
+        isWebStream: true,
+        externalFailed: true,
+        transientExternalFailure: true,
+        hasMarkers: false,
+        attempts: 4,
+      ),
+      isFalse,
+    );
+    expect(
+      skipSegmentLookupRetryDelay(
+        lookupComplete: false,
+        transientExternalFailure: true,
+        attempts: 4,
+      ),
+      const Duration(seconds: 20),
+    );
+    expect(
+      skipSegmentLookupRetryDelay(
+        lookupComplete: false,
+        transientExternalFailure: true,
+        attempts: 5,
+      ),
+      const Duration(seconds: 60),
+    );
+    expect(
+      skipSegmentLookupIsComplete(
+        isWebStream: true,
+        externalFailed: true,
+        transientExternalFailure: true,
+        hasMarkers: false,
+        attempts: 6,
+      ),
+      isTrue,
+    );
+    expect(
+      skipSegmentLookupRetryDelay(
+        lookupComplete: true,
+        transientExternalFailure: true,
+        attempts: 6,
+      ),
+      isNull,
+    );
+  });
+
+  test('embedded markers do not hide a transient community failure', () {
+    expect(
+      skipSegmentLookupIsComplete(
+        isWebStream: true,
+        externalFailed: true,
+        transientExternalFailure: true,
+        hasMarkers: true,
+        attempts: 4,
+      ),
+      isFalse,
+    );
+  });
+
+  test('clean exhausted no-match never enters deferred retry', () {
+    expect(
+      skipSegmentLookupIsComplete(
+        isWebStream: true,
+        externalFailed: false,
+        hasMarkers: false,
+        attempts: 1,
+        runtimeProbesExhausted: true,
+      ),
+      isTrue,
+    );
+    expect(
+      skipSegmentLookupRetryDelay(
+        lookupComplete: true,
+        transientExternalFailure: false,
+        attempts: 1,
+      ),
+      isNull,
     );
   });
 
@@ -463,5 +546,233 @@ void main() {
 
     expect(requests, 2);
     expect(segments.single.kind, SkipSegmentKind.opening);
+  });
+
+  test('AniSkip treats a recovered retry as a clean no-match', () async {
+    final dio = Dio();
+    var requests = 0;
+    dio.interceptors.add(
+      InterceptorsWrapper(
+        onRequest: (options, handler) {
+          requests++;
+          if (requests == 1) {
+            handler.reject(
+              DioException(
+                requestOptions: options,
+                type: DioExceptionType.connectionError,
+                message: 'temporary offline fixture',
+              ),
+            );
+            return;
+          }
+          handler.resolve(
+            Response<Map<String, dynamic>>(
+              requestOptions: options,
+              statusCode: 404,
+              data: const <String, dynamic>{'found': false, 'results': []},
+            ),
+          );
+        },
+      ),
+    );
+
+    final result = await AniSkipClient(dio: dio, retryDelay: Duration.zero)
+        .lookup(
+          malMediaId: 1887,
+          episode: 18,
+          episodeDuration: const Duration(minutes: 24),
+          allowRuntimeFallback: true,
+        );
+
+    expect(result.segments, isEmpty);
+    expect(result.status, AniSkipLookupStatus.noMatch);
+    expect(result.transientFailureCount, 1);
+    expect(result.failureReason, AniSkipFailureReason.connectionError);
+    expect(result.runtimeFallbackSearchComplete, isTrue);
+    expect(result.hasTransientFailure, isFalse);
+    expect(result.status.diagnosticCode, 'no_match');
+    expect(result.failureReason?.diagnosticCode, 'connection_error');
+  });
+
+  test(
+    'AniSkip keeps an exhausted probe retryable after later clean no-matches',
+    () async {
+      final dio = Dio();
+      var requests = 0;
+      dio.interceptors.add(
+        InterceptorsWrapper(
+          onRequest: (options, handler) {
+            requests++;
+            if (requests <= 2) {
+              handler.reject(
+                DioException(
+                  requestOptions: options,
+                  type: DioExceptionType.connectionError,
+                  message: 'temporary offline fixture',
+                ),
+              );
+              return;
+            }
+            handler.resolve(
+              Response<Map<String, dynamic>>(
+                requestOptions: options,
+                statusCode: 404,
+                data: const <String, dynamic>{'found': false, 'results': []},
+              ),
+            );
+          },
+        ),
+      );
+
+      final result = await AniSkipClient(dio: dio, retryDelay: Duration.zero)
+          .lookup(
+            malMediaId: 1887,
+            episode: 18,
+            episodeDuration: const Duration(minutes: 24),
+            allowRuntimeFallback: true,
+          );
+
+      expect(result.segments, isEmpty);
+      expect(result.status, AniSkipLookupStatus.partialTransientFailure);
+      expect(result.transientFailureCount, 2);
+      expect(result.runtimeFallbackSearchComplete, isFalse);
+      expect(result.hasTransientFailure, isTrue);
+    },
+  );
+
+  test('AniSkip keeps accepted server-error responses retryable', () async {
+    final dio = Dio(BaseOptions(validateStatus: (_) => true));
+    var requests = 0;
+    dio.interceptors.add(
+      InterceptorsWrapper(
+        onRequest: (options, handler) {
+          requests++;
+          handler.resolve(
+            Response<Map<String, dynamic>>(
+              requestOptions: options,
+              statusCode: 503,
+              data: const <String, dynamic>{'found': false, 'results': []},
+            ),
+          );
+        },
+      ),
+    );
+
+    final result = await AniSkipClient(dio: dio, retryDelay: Duration.zero)
+        .lookup(
+          malMediaId: 1887,
+          episode: 18,
+          episodeDuration: const Duration(minutes: 24),
+          allowRuntimeFallback: true,
+        );
+
+    expect(requests, greaterThan(1));
+    expect(result.segments, isEmpty);
+    expect(result.status, AniSkipLookupStatus.transientFailure);
+    expect(result.runtimeFallbackSearchComplete, isFalse);
+    expect(result.hasTransientFailure, isTrue);
+    expect(result.failureReason, AniSkipFailureReason.serverError);
+  });
+
+  test('verified skip seek retries a command the player ignored', () async {
+    var position = const Duration(seconds: 10);
+    var seekCalls = 0;
+
+    final result = await performVerifiedSkipSeek(
+      target: const Duration(seconds: 100),
+      seek: (target) async {
+        seekCalls++;
+        if (seekCalls == 2) position = target;
+      },
+      currentPosition: () => position,
+      wait: (_) async {},
+    );
+
+    expect(result.verified, isTrue);
+    expect(result.position, const Duration(seconds: 100));
+    expect(result.attempts, 2);
+    expect(seekCalls, 2);
+  });
+
+  test('verified skip seek stays failed after its bounded attempts', () async {
+    var seekCalls = 0;
+
+    final result = await performVerifiedSkipSeek(
+      target: const Duration(seconds: 100),
+      seek: (_) async => seekCalls++,
+      currentPosition: () => const Duration(seconds: 10),
+      wait: (_) async {},
+    );
+
+    expect(result.verified, isFalse);
+    expect(result.position, const Duration(seconds: 10));
+    expect(result.attempts, 3);
+    expect(seekCalls, 3);
+  });
+
+  test('verified skip seek stops retrying after its source changes', () async {
+    var sourceChanged = false;
+    var seekCalls = 0;
+    var position = const Duration(seconds: 10);
+
+    final result = await performVerifiedSkipSeek(
+      target: const Duration(seconds: 100),
+      seek: (_) async => seekCalls++,
+      currentPosition: () => position,
+      wait: (_) async {
+        sourceChanged = true;
+        position = const Duration(seconds: 100);
+      },
+      isCanceled: () => sourceChanged,
+    );
+
+    expect(result.verified, isFalse);
+    expect(result.attempts, 1);
+    expect(seekCalls, 1);
+  });
+
+  test('verified skip seek times out instead of waiting forever', () async {
+    final neverCompletes = Completer<void>();
+    var seekCalls = 0;
+
+    final result = await performVerifiedSkipSeek(
+      target: const Duration(seconds: 100),
+      seek: (_) {
+        seekCalls++;
+        return neverCompletes.future;
+      },
+      currentPosition: () => const Duration(seconds: 10),
+      wait: (_) async {},
+      operationTimeout: const Duration(milliseconds: 1),
+    );
+
+    expect(result.verified, isFalse);
+    expect(result.position, const Duration(seconds: 10));
+    expect(result.attempts, 1);
+    expect(seekCalls, 1);
+  });
+
+  test('seek verification does not accept a nearby ignored position', () {
+    expect(
+      skipSeekTargetReached(
+        target: const Duration(milliseconds: 191984),
+        actual: const Duration(milliseconds: 190000),
+      ),
+      isFalse,
+    );
+    expect(
+      skipSeekTargetReached(
+        target: const Duration(milliseconds: 191984),
+        actual: const Duration(milliseconds: 191800),
+      ),
+      isTrue,
+    );
+    expect(
+      skipSeekTargetReached(
+        target: const Duration(seconds: 100),
+        actual: const Duration(minutes: 24),
+      ),
+      isFalse,
+    );
   });
 }

--- a/test/teto_player_chrome_test.dart
+++ b/test/teto_player_chrome_test.dart
@@ -553,7 +553,7 @@ void main() {
         expect(timeRect.left, greaterThan(nextRect.right));
         expect(timeRect.right, lessThan(speedRect.left));
         expect(progressRect.top, greaterThan(playRect.bottom));
-        expect(panelRect.height, inInclusiveRange(96, 112));
+        expect(panelRect.height, inInclusiveRange(145, 153));
         expect(tester.takeException(), isNull);
       },
     );
@@ -1223,6 +1223,10 @@ void main() {
         ),
       );
 
+      final chrome = find.byKey(
+        const ValueKey('scrub-hold-bottom-player-chrome'),
+      );
+      final restingChromeRect = tester.getRect(chrome);
       final slider = find.byKey(
         const ValueKey('scrub-hold-player-progress-bar'),
       );
@@ -1236,9 +1240,31 @@ void main() {
         find.byKey(const ValueKey('scrub-hold-player-seek-time-bubble')),
         findsOneWidget,
       );
+      final bubbleRect = tester.getRect(
+        find.byKey(const ValueKey('scrub-hold-player-seek-time-bubble')),
+      );
+      final controlsRect = tester.getRect(
+        find.byKey(const ValueKey('scrub-hold-player-controls-spaced')),
+      );
+      final progressRect = tester.getRect(slider);
+      expect(
+        bubbleRect.top,
+        greaterThanOrEqualTo(controlsRect.bottom),
+        reason: 'the fixed seek-bubble lane must stay below the controls',
+      );
+      expect(
+        bubbleRect.bottom,
+        lessThan(progressRect.top),
+        reason: 'the seek bubble must remain directly above the progress bar',
+      );
       expect(
         find.byKey(const ValueKey('scrub-hold-player-seek-target-time')),
         findsNothing,
+      );
+      expect(
+        tester.getRect(chrome),
+        restingChromeRect,
+        reason: 'touch scrubbing must not resize or move the player HUD',
       );
 
       await gesture.up();
@@ -1256,6 +1282,7 @@ void main() {
       scheduleHide();
       progressFocus.requestFocus();
       await tester.pump();
+      final focusedChromeRect = tester.getRect(chrome);
       await tester.sendKeyDownEvent(LogicalKeyboardKey.arrowRight);
       for (var repeat = 0; repeat < 30; repeat++) {
         await tester.pump(const Duration(milliseconds: 200));
@@ -1266,6 +1293,11 @@ void main() {
       expect(
         find.byKey(const ValueKey('scrub-hold-player-seek-time-bubble')),
         findsOneWidget,
+      );
+      expect(
+        tester.getRect(chrome),
+        focusedChromeRect,
+        reason: 'D-pad scrubbing must not resize or move the player HUD',
       );
 
       await tester.sendKeyUpEvent(LogicalKeyboardKey.arrowRight);
@@ -1446,6 +1478,11 @@ void main() {
         ),
       );
 
+      final restingChromeRect = tester.getRect(
+        find.byKey(
+          const ValueKey('scrubbing-skip-spacing-bottom-player-chrome'),
+        ),
+      );
       progressFocus.requestFocus();
       await tester.pump();
       await tester.sendKeyDownEvent(LogicalKeyboardKey.arrowRight);
@@ -1468,6 +1505,11 @@ void main() {
       );
       expect(skipRect.bottom, lessThan(chromeRect.top));
       expect(chromeRect.top - skipRect.bottom, greaterThanOrEqualTo(12));
+      expect(
+        chromeRect,
+        restingChromeRect,
+        reason: 'the floating seek bubble must not expand the TV HUD',
+      );
 
       await tester.sendKeyUpEvent(LogicalKeyboardKey.arrowRight);
       await tester.pump();
@@ -1482,7 +1524,7 @@ void main() {
         viewport: const Size(1920, 1080),
         controlsVisible: true,
       ),
-      130,
+      173,
     );
     expect(
       playerSkipOverlayBottomInset(
@@ -1490,7 +1532,7 @@ void main() {
         controlsVisible: true,
         safeAreaBottom: 24,
       ),
-      160,
+      193,
     );
     expect(
       playerSkipOverlayBottomInset(
@@ -1499,7 +1541,7 @@ void main() {
         safeAreaBottom: 24,
         textScaleFactor: 2.5,
       ),
-      262,
+      295,
     );
     expect(
       playerSkipOverlayBottomInset(
@@ -1515,7 +1557,7 @@ void main() {
         controlsVisible: true,
         expandedHeader: true,
       ),
-      174,
+      217,
     );
     expect(
       playerSkipOverlayBottomInset(
@@ -1523,7 +1565,7 @@ void main() {
         controlsVisible: true,
         scrubbing: true,
       ),
-      175,
+      173,
     );
     expect(
       playerSkipOverlayBottomInset(
@@ -1532,7 +1574,7 @@ void main() {
         safeAreaBottom: 24,
         scrubbing: true,
       ),
-      198,
+      193,
     );
     expect(
       playerSkipOverlayBottomInset(
@@ -1542,7 +1584,7 @@ void main() {
         textScaleFactor: 2.5,
         scrubbing: true,
       ),
-      closeTo(322.05, .001),
+      295,
     );
   });
 

--- a/test/watch_party_public_roster_test.dart
+++ b/test/watch_party_public_roster_test.dart
@@ -1,5 +1,8 @@
 import 'dart:convert';
 
+import 'package:anime_tv/features/auth/domain/tracking_provider.dart';
+import 'package:anime_tv/features/settings/application/tracking_accounts_controller.dart';
+import 'package:anime_tv/features/watch_together/application/watch_party_public_identity_provider.dart';
 import 'package:anime_tv/features/watch_together/data/watch_party_client.dart';
 import 'package:anime_tv/features/watch_together/domain/watch_party_models.dart';
 import 'package:dio/dio.dart';
@@ -48,6 +51,75 @@ void main() {
       ),
       isNull,
     );
+  });
+
+  test('AniList host and MAL guest exchange public avatars', () {
+    final host = _trackerIdentity(
+      provider: TrackingProvider.anilist,
+      username: 'Ani Host',
+      avatarUrl: 'https://img.anili.st/user/123/avatar.png',
+    );
+    final guest = _trackerIdentity(
+      provider: TrackingProvider.myAnimeList,
+      username: 'MAL Guest',
+      avatarUrl:
+          'https://api-cdn.myanimelist.net/images/userimages/456/avatar.jpg',
+    );
+
+    final snapshot = _crossTrackerSnapshot(host: host, guest: guest);
+
+    expect(snapshot.participants, hasLength(2));
+    expect(snapshot.participants[0].displayName, 'Ani Host');
+    expect(
+      snapshot.participants[0].avatarUrl,
+      'https://img.anili.st/user/123/avatar.png',
+    );
+    expect(snapshot.participants[1].displayName, 'MAL Guest');
+    expect(
+      snapshot.participants[1].avatarUrl,
+      'https://api-cdn.myanimelist.net/images/userimages/456/avatar.jpg',
+    );
+  });
+
+  test('MAL host and AniList guest exchange public avatars', () {
+    final host = _trackerIdentity(
+      provider: TrackingProvider.myAnimeList,
+      username: 'MAL Host',
+      avatarUrl: 'https://cdn.myanimelist.net/images/userimages/789.jpg',
+    );
+    final guest = _trackerIdentity(
+      provider: TrackingProvider.anilist,
+      username: 'Ani Guest',
+      avatarUrl:
+          'https://s4.anilist.co/file/anilistcdn/user/avatar/large/b321.jpg',
+    );
+
+    final snapshot = _crossTrackerSnapshot(host: host, guest: guest);
+
+    expect(snapshot.participants, hasLength(2));
+    expect(snapshot.participants[0].displayName, 'MAL Host');
+    expect(
+      snapshot.participants[0].avatarUrl,
+      'https://cdn.myanimelist.net/images/userimages/789.jpg',
+    );
+    expect(snapshot.participants[1].displayName, 'Ani Guest');
+    expect(
+      snapshot.participants[1].avatarUrl,
+      'https://s4.anilist.co/file/anilistcdn/user/avatar/large/b321.jpg',
+    );
+  });
+
+  test('missing or untrusted tracker avatar keeps the initials fallback', () {
+    final identity = _trackerIdentity(
+      provider: TrackingProvider.anilist,
+      username: 'Fallback Viewer',
+      avatarUrl: 'https://tracker.example/private/avatar?token=secret',
+    );
+
+    expect(identity.toJson(), {'display_name': 'Fallback Viewer'});
+    final snapshot = _crossTrackerSnapshot(host: identity);
+    expect(snapshot.participants.single.displayName, 'Fallback Viewer');
+    expect(snapshot.participants.single.avatarUrl, isNull);
   });
 
   test('snapshot accepts a strict bounded public roster only', () {
@@ -211,3 +283,37 @@ Map<String, Object?> _snapshotJson() => {
   'participants': const <Object?>[],
   'expires_at': '2030-01-01T00:00:00Z',
 };
+
+WatchPartyPublicIdentity _trackerIdentity({
+  required TrackingProvider provider,
+  required String username,
+  required String avatarUrl,
+}) => watchPartyPublicIdentityForProfiles(
+  activeLocalProfile: null,
+  trackerProfiles: <TrackingProvider, TrackingAccountProfile>{
+    provider: TrackingAccountProfile(
+      provider: provider,
+      username: username,
+      avatarUrl: avatarUrl,
+    ),
+  },
+  preferredTracker: provider,
+)!;
+
+WatchPartySnapshot _crossTrackerSnapshot({
+  required WatchPartyPublicIdentity host,
+  WatchPartyPublicIdentity? guest,
+}) {
+  Map<String, Object?> participant(
+    WatchPartyPublicIdentity identity,
+    String role,
+  ) => <String, Object?>{...identity.toJson(), 'role': role, 'ready': true};
+
+  return WatchPartySnapshot.fromJson({
+    ..._snapshotJson(),
+    'participants': <Object?>[
+      participant(host, 'host'),
+      if (guest != null) participant(guest, 'guest'),
+    ],
+  });
+}

--- a/test/web_stream_aggregator_test.dart
+++ b/test/web_stream_aggregator_test.dart
@@ -698,6 +698,152 @@ void main() {
     },
   );
 
+  test('provider search correlation ids are boot-scoped and sequential', () {
+    final first = nextWebProviderSearchDiagnosticSessionId();
+    final second = nextWebProviderSearchDiagnosticSessionId();
+    final pattern = RegExp(r'^provider-search-[0-9a-f]{12}-[0-9]+$');
+
+    expect(first, matches(pattern));
+    expect(second, matches(pattern));
+    expect(second, isNot(first));
+    expect(
+      first.substring(0, first.lastIndexOf('-')),
+      second.substring(0, second.lastIndexOf('-')),
+    );
+  });
+
+  test('provider search summaries contain only aggregate safe fields', () {
+    final details = webProviderSearchSummaryDiagnosticDetails(
+      phase: 'final',
+      diagnosticSessionId:
+          'https://private.example/episode/7?token=do-not-record',
+      installedProviders: 14,
+      enabledProviders: 12,
+      searchableProviders: 10,
+      blockedProviders: 2,
+      completedProviders: 12,
+      returnedProviders: 3,
+      returnedResults: 20,
+      failureReasonCounts: const {
+        'timeout': 2,
+        'https://private.example/episode/7?token=do-not-record': 4,
+      },
+    );
+    final states = (details['state']! as List<Object?>)
+        .cast<Map<String, Object>>();
+    int countFor(String kind) =>
+        states.singleWhere((entry) => entry['kind'] == kind)['count']! as int;
+    final reasons = (details['reason']! as List<Object?>)
+        .cast<Map<String, Object>>();
+
+    expect(details['session_id'], 'provider-search-unknown');
+    expect(details['phase'], 'final');
+    expect(countFor('installed_providers'), 14);
+    expect(countFor('enabled_providers'), 12);
+    expect(countFor('searchable_providers'), 10);
+    expect(countFor('blocked_providers'), 2);
+    expect(countFor('completed_providers'), 12);
+    expect(countFor('returned_providers'), 3);
+    expect(countFor('returned_results'), 20);
+    expect(
+      reasons,
+      containsAll(<Map<String, Object>>[
+        {'reason_code': 'timeout', 'count': 2},
+        {'reason_code': 'other', 'count': 4},
+      ]),
+    );
+    expect(details.toString(), isNot(contains('private.example')));
+    expect(details.toString(), isNot(contains('episode/7')));
+    expect(details.toString(), isNot(contains('do-not-record')));
+    final sanitized = sanitizeDiagnosticContext(details)! as Map;
+    expect(sanitized['state'], hasLength(7));
+    expect(sanitized['reason'], hasLength(2));
+    expect(sanitized, isNot(contains('_redactedFieldCount')));
+  });
+
+  test('post-filter diagnostics expose counts and active safe filters', () {
+    final details = webProviderVisibilityDiagnosticDetails(
+      phase: 'filter_changed',
+      diagnosticSessionId: 'provider-search-a1b2c3d4e5f6-42',
+      rawProviders: 3,
+      rawResults: 20,
+      visibleProviders: 2,
+      visibleResults: 8,
+      audioFilter: 'dub',
+      qualityFilter: 'p1080',
+    );
+    final states = (details['state']! as List<Object?>)
+        .cast<Map<String, Object>>();
+    int countFor(String kind) =>
+        states.singleWhere((entry) => entry['kind'] == kind)['count']! as int;
+
+    expect(details['session_id'], 'provider-search-a1b2c3d4e5f6-42');
+    expect(details['phase'], 'filter_changed');
+    expect(details['audio_mode'], 'dub');
+    expect(details['quality'], 'p1080');
+    expect(countFor('raw_providers'), 3);
+    expect(countFor('raw_results'), 20);
+    expect(countFor('visible_providers'), 2);
+    expect(countFor('visible_results'), 8);
+    final sanitized = sanitizeDiagnosticContext(details)! as Map;
+    expect(sanitized['state'], hasLength(4));
+    expect(sanitized['audio_mode'], 'dub');
+    expect(sanitized['quality'], 'p1080');
+    expect(sanitized, isNot(contains('_redactedFieldCount')));
+
+    final unsafe = webProviderVisibilityDiagnosticDetails(
+      phase: 'https://private.example/title',
+      diagnosticSessionId: 'private-token',
+      rawProviders: 0,
+      rawResults: 0,
+      visibleProviders: 0,
+      visibleResults: 0,
+      audioFilter: 'episode-title',
+      qualityFilter: 'https://private.example/video.m3u8',
+    );
+    expect(unsafe['phase'], 'unknown');
+    expect(unsafe['session_id'], 'provider-search-unknown');
+    expect(unsafe['audio_mode'], 'unknown');
+    expect(unsafe['quality'], 'unknown');
+    expect(unsafe.toString(), isNot(contains('private.example')));
+    expect(unsafe.toString(), isNot(contains('episode-title')));
+  });
+
+  test(
+    'provider outcome diagnostics retain only their safe correlation id',
+    () {
+      expect(
+        webProviderSearchOutcomeDiagnosticDetails(
+          'provider-search-a1b2c3d4e5f6-42',
+        ),
+        {'session_id': 'provider-search-a1b2c3d4e5f6-42'},
+      );
+      final unsafe = webProviderSearchOutcomeDiagnosticDetails(
+        'https://private.example/episode/7?token=do-not-record',
+      );
+      expect(unsafe, {'session_id': 'provider-search-unknown'});
+      expect(unsafe.toString(), isNot(contains('private.example')));
+      expect(unsafe.toString(), isNot(contains('do-not-record')));
+
+      for (final phase in const ['canceled', 'error']) {
+        expect(
+          webProviderSearchSummaryDiagnosticDetails(
+            phase: phase,
+            diagnosticSessionId: 'provider-search-a1b2c3d4e5f6-42',
+            installedProviders: 14,
+            enabledProviders: 12,
+            searchableProviders: 10,
+            blockedProviders: 2,
+            completedProviders: 4,
+            returnedProviders: 1,
+            returnedResults: 3,
+          )['phase'],
+          phase,
+        );
+      }
+    },
+  );
+
   test('resolver and player share one episode discovery session', () async {
     final release = Completer<void>();
     final aggregator = _CountingSharedAggregator(release.future);

--- a/tool/release/native_playback_manifest.json
+++ b/tool/release/native_playback_manifest.json
@@ -375,16 +375,16 @@
     {
       "path": "lib/arm64-v8a/libapp.so",
       "size": 12125072,
-      "sha256": "70cd27e6a95a5b0a087685704b673f18fbd52c4092762c3163170568221d6254",
-      "origin": "TetoTV Flutter application AOT 2.0.44",
+      "sha256": "5c58616c7d6e5eaab0d4fc51aae72b796537c8a18e4f1996aca7e58b7eb262dc",
+      "origin": "TetoTV Flutter application AOT 2.0.45",
       "license": "MIT",
-      "sourceLocator": "Git tag v2.0.44",
+      "sourceLocator": "Git tag v2.0.45",
       "noticeLocator": "LICENSE"
     },
     {
       "path": "lib/arm64-v8a/libdartjni.so",
       "size": 131400,
-      "sha256": "c216dc4702aeb308818ef02e1989e406002573fe7855769d2caffcfec4528bc2",
+      "sha256": "a7b0e1248a14c5b9eb56f524175cf98dc79390088d02e8aad8c32b8a6d47bbed",
       "origin": "Dart jni 1.0.3",
       "license": "BSD-3-Clause",
       "sourceLocator": "pubspec.lock: jni 1.0.3",
@@ -402,7 +402,7 @@
     {
       "path": "lib/arm64-v8a/libfastdev_quickjs_runtime.so",
       "size": 1323616,
-      "sha256": "495c68f0a9816ef517fbb3851dd3d1867fe41a48e278c14acb5f031e3252bc25",
+      "sha256": "c4bdf6014bb337a588d11cdd4df4d3b483d696f9819cfdefdf4d15396d9692bd",
       "origin": "TetoTV vendored flutter_js 0.8.7+tetotv.1 and QuickJS Android runtime",
       "license": "MIT and bundled runtime component terms",
       "sourceLocator": "third_party/flutter_js/android/src/main",
@@ -423,7 +423,7 @@
       "sha256": "dc05f53278b2733094f12aeaed54c080329309762ce49e6de4118e4bfb0fff55",
       "origin": "TetoTV source build of media-kit Android helper at 42054e5d479f39ccbb0ae604862e2bcaf59b74c2",
       "license": "MIT",
-      "sourceLocator": "TetoTV-v2.0.44-native-playback-sources.zip: sources/media-kit-android-helper-42054e5d479f39ccbb0ae604862e2bcaf59b74c2.zip",
+      "sourceLocator": "TetoTV-v2.0.45-native-playback-sources.zip: sources/media-kit-android-helper-42054e5d479f39ccbb0ae604862e2bcaf59b74c2.zip",
       "noticeLocator": "assets/legal/native/MEDIA_KIT_ANDROID_HELPER_LICENSE.txt; assets/legal/native/NATIVE_PLAYBACK_NOTICE.txt"
     },
     {
@@ -432,13 +432,13 @@
       "sha256": "a7399d0be70844e5ee94cc5b1acc1516571113c50561fe0a5d05b49101c53ef2",
       "origin": "TetoTV source build of the pinned mpv and FFmpeg native playback stack",
       "license": "LGPL-3.0-or-later (conservative combined classification) plus component terms",
-      "sourceLocator": "TetoTV-v2.0.44-native-playback-sources.zip and tool/native/build_native_playback.sh",
+      "sourceLocator": "TetoTV-v2.0.45-native-playback-sources.zip and tool/native/build_native_playback.sh",
       "noticeLocator": "assets/legal/native/NATIVE_PLAYBACK_NOTICE.txt and its referenced exact license assets"
     },
     {
       "path": "lib/arm64-v8a/libtetotv_discord.so",
       "size": 752992,
-      "sha256": "7be1df79ed52b82a090fd0d6fe0b4f2b5b7a3cdd06c282a3543047a4031e10d2",
+      "sha256": "8d2caee054011b042dd16f2265b23c6a20c2609a17ad7d24302fd8dd44493bf6",
       "origin": "TetoTV Discord JNI wrapper",
       "license": "MIT for the TetoTV wrapper; Discord Social SDK Terms for the dynamically linked SDK",
       "sourceLocator": "android/app/src/main/cpp",
@@ -450,22 +450,22 @@
       "sha256": "263ba714570fb3acfc308cce52776b00506ec8809d225617e52352336144cfa2",
       "origin": "TetoTV source build of the pinned libtorrent4j and libtorrent-rasterbar stack",
       "license": "Mixed MIT, BSD, Boost-1.0, Apache-2.0, and MPL-2.0 component terms",
-      "sourceLocator": "TetoTV-v2.0.44-native-playback-sources.zip and tool/native/build_native_playback.sh",
+      "sourceLocator": "TetoTV-v2.0.45-native-playback-sources.zip and tool/native/build_native_playback.sh",
       "noticeLocator": "assets/legal/native/DIRECT_TORRENT_NATIVE_NOTICE.txt and its referenced exact license assets"
     },
     {
       "path": "lib/armeabi-v7a/libapp.so",
-      "size": 13238860,
-      "sha256": "9d98f44d1ecb36f254df7d7816443fa715aa653b5b44aa87f592581cc4023dc9",
-      "origin": "TetoTV Flutter application AOT 2.0.44",
+      "size": 13288012,
+      "sha256": "2f97493f6dd1dda4a22c68f37979aa221c1e7b18797b1e112a7b6f3e65e794f9",
+      "origin": "TetoTV Flutter application AOT 2.0.45",
       "license": "MIT",
-      "sourceLocator": "Git tag v2.0.44",
+      "sourceLocator": "Git tag v2.0.45",
       "noticeLocator": "LICENSE"
     },
     {
       "path": "lib/armeabi-v7a/libdartjni.so",
       "size": 81600,
-      "sha256": "7e406ee3708ea76576641b01770c540f318b17ddfdb9df5bb7f507089dff0a08",
+      "sha256": "8a4dbfe8637ea91dad72d15c1c91a162d8e86c368c6a5af97c9517b6c0127809",
       "origin": "Dart jni 1.0.3",
       "license": "BSD-3-Clause",
       "sourceLocator": "pubspec.lock: jni 1.0.3",
@@ -483,7 +483,7 @@
     {
       "path": "lib/armeabi-v7a/libfastdev_quickjs_runtime.so",
       "size": 921328,
-      "sha256": "8cd035f6fceb7b1c90ed89b71995b4f8084f5d2c5b408e728d630cfa778d39dc",
+      "sha256": "365bb9d78e66cd15a0d14ec6ab46978b4c3d82cc6428a54e119f11df89e0f36c",
       "origin": "TetoTV vendored flutter_js 0.8.7+tetotv.1 and QuickJS Android runtime",
       "license": "MIT and bundled runtime component terms",
       "sourceLocator": "third_party/flutter_js/android/src/main",
@@ -504,7 +504,7 @@
       "sha256": "8820a12e07bb3dc45f5b4286acf6918827fba4c265767e7f1cc8f07215c84b6a",
       "origin": "TetoTV source build of media-kit Android helper at 42054e5d479f39ccbb0ae604862e2bcaf59b74c2",
       "license": "MIT",
-      "sourceLocator": "TetoTV-v2.0.44-native-playback-sources.zip: sources/media-kit-android-helper-42054e5d479f39ccbb0ae604862e2bcaf59b74c2.zip",
+      "sourceLocator": "TetoTV-v2.0.45-native-playback-sources.zip: sources/media-kit-android-helper-42054e5d479f39ccbb0ae604862e2bcaf59b74c2.zip",
       "noticeLocator": "assets/legal/native/MEDIA_KIT_ANDROID_HELPER_LICENSE.txt; assets/legal/native/NATIVE_PLAYBACK_NOTICE.txt"
     },
     {
@@ -513,13 +513,13 @@
       "sha256": "d5a220fdf41edde10f161f86addc846ae9cb18137ea48e4db541cd703fec5092",
       "origin": "TetoTV source build of the pinned mpv and FFmpeg native playback stack",
       "license": "LGPL-3.0-or-later (conservative combined classification) plus component terms",
-      "sourceLocator": "TetoTV-v2.0.44-native-playback-sources.zip and tool/native/build_native_playback.sh",
+      "sourceLocator": "TetoTV-v2.0.45-native-playback-sources.zip and tool/native/build_native_playback.sh",
       "noticeLocator": "assets/legal/native/NATIVE_PLAYBACK_NOTICE.txt and its referenced exact license assets"
     },
     {
       "path": "lib/armeabi-v7a/libtetotv_discord.so",
       "size": 481224,
-      "sha256": "bdede1bf9fe6ded9001084e16318de3eb1a4a074a6374dd82bcb15b886899185",
+      "sha256": "a2c52aaedfeb41a457f717796bc7df6ea26c709ba2d59187d1365d559bcacd69",
       "origin": "TetoTV Discord JNI wrapper",
       "license": "MIT for the TetoTV wrapper; Discord Social SDK Terms for the dynamically linked SDK",
       "sourceLocator": "android/app/src/main/cpp",
@@ -531,7 +531,7 @@
       "sha256": "5e090380a7c1c26c16763d40c7f451bdb4fc2542bc5e1b8a410206f66dea4330",
       "origin": "TetoTV source build of the pinned libtorrent4j and libtorrent-rasterbar stack",
       "license": "Mixed MIT, BSD, Boost-1.0, Apache-2.0, and MPL-2.0 component terms",
-      "sourceLocator": "TetoTV-v2.0.44-native-playback-sources.zip and tool/native/build_native_playback.sh",
+      "sourceLocator": "TetoTV-v2.0.45-native-playback-sources.zip and tool/native/build_native_playback.sh",
       "noticeLocator": "assets/legal/native/DIRECT_TORRENT_NATIVE_NOTICE.txt and its referenced exact license assets"
     }
   ],


### PR DESCRIPTION
## Summary
- make skip-intro/outro lookup and seeking resilient and diagnosable
- add privacy-safe provider discovery diagnostics and recommended franchise watch order
- refine TV featured-title wrapping, compact episode actions, stable scrub HUD, and Watch Party avatars
- prepare signed Beta 2.0.45 release metadata and native-library manifest

## Validation
- flutter analyze (no issues)
- flutter test (1,880 passed; 14 skipped)
- signed release APK verification (18 exact native entries)
- native redistribution and release-policy checks