### PR TITLE
TetoTV 2.0.46 Beta

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 
 <p align="center">
   <a href="https://github.com/LindersOSX/TetoTV-Beta/releases/latest"><strong>Download Beta</strong></a>
-  · <a href="docs/RELEASE_NOTES_2.0.45.md">What's new</a>
+  · <a href="docs/RELEASE_NOTES_2.0.46.md">What's new</a>
   · <a href="https://github.com/LindersOSX/TetoTV-Beta/issues/new">Report an issue</a>
   · <a href="https://discord.gg/juC6k7d4WY">Discord</a>
   · <a href="https://www.youtube.com/@TetoTVApp">YouTube</a>
@@ -82,10 +82,10 @@ TetoTV runs directly on the Android device with no companion server required for
 | Channel | Version | Best for |
 | --- | --- | --- |
 | Public | Not published | Source and release-readiness documents are available, but no Public APK is currently offered |
-| Beta | [2.0.45](docs/RELEASE_NOTES_2.0.45.md) | Testing resilient skip timing, richer source diagnostics, and refined TV playback and catalog navigation before a separately reviewed Public release |
+| Beta | [2.0.46](docs/RELEASE_NOTES_2.0.46.md) | Testing compact episode actions and a tighter, scrub-stable player HUD before a separately reviewed Public release |
 
 > [!WARNING]
-> Beta 2.0.45 uses the repository's explicit unreviewed-Beta exception. Its native-library and corresponding-source material did not receive independent license review, and automated integrity checks are not a legal compliance determination. Read the [complete Beta disclosure](docs/RELEASE_NOTES_2.0.45.md). This exception does not apply to a future Public release.
+> Beta 2.0.46 uses the repository's explicit unreviewed-Beta exception. Its native-library and corresponding-source material did not receive independent license review, and automated integrity checks are not a legal compliance determination. Read the [complete Beta disclosure](docs/RELEASE_NOTES_2.0.46.md). This exception does not apply to a future Public release.
 
 The Public updater repository intentionally has no release while the Public build is held for review. Existing Beta installations continue to update from the Beta repository. Android never permits an in-place install of an APK with a lower build code; Developer Mode does not bypass that platform rule.
 

--- a/docs/BUILD_WINDOWS.md
+++ b/docs/BUILD_WINDOWS.md
@@ -220,39 +220,39 @@ APK containing both supported application ABIs.
 Public and Beta updates use anonymous GitHub requests. No Beta key, GitHub
 token, update-proxy URL, or update-specific Dart define is required. Every
 published APK uses the production signing identity. No Public APK is currently
-published. Beta 2.0.45 uses Android build code `410022`. Flutter reuses
+published. Beta 2.0.46 uses Android build code `410023`. Flutter reuses
 `app-release.apk`, so copy and rename the Beta artifact immediately after the
 build:
 
 ```powershell
-New-Item -ItemType Directory -Force .\build\fire-tv\v2.0.45 | Out-Null
+New-Item -ItemType Directory -Force .\build\fire-tv\v2.0.46 | Out-Null
 
-# Beta 2.0.45
+# Beta 2.0.46
 flutter build apk --release --target-platform android-arm,android-arm64 `
-  --build-name 2.0.45 --build-number 410022 --no-tree-shake-icons
+  --build-name 2.0.46 --build-number 410023 --no-tree-shake-icons
 Copy-Item .\build\app\outputs\flutter-apk\app-release.apk `
-  .\build\fire-tv\v2.0.45\TetoTV-v2.0.45-universal.apk
+  .\build\fire-tv\v2.0.46\TetoTV-v2.0.46-universal.apk
 
 .\tool\release\verify_release_apk.ps1 `
   -Channel Beta `
-  -ApkPath .\build\fire-tv\v2.0.45\TetoTV-v2.0.45-universal.apk
+  -ApkPath .\build\fire-tv\v2.0.46\TetoTV-v2.0.46-universal.apk
 
 .\tool\release\verify_native_redistribution.ps1 `
   -RequireResolvedBinaries `
   -ResolvedBinaryDirectory .\build\native-playback\outputs `
-  -StageBundle -ReleaseTag v2.0.45
+  -StageBundle -ReleaseTag v2.0.46
 
 .\tool\release\new_release_checksums.ps1 `
-  -ApkPath .\build\fire-tv\v2.0.45\TetoTV-v2.0.45-universal.apk `
-  -NativeSourcePath .\build\release-compliance\v2.0.45\TetoTV-v2.0.45-native-playback-sources.zip `
-  -OutputPath .\build\fire-tv\v2.0.45\SHA256SUMS
+  -ApkPath .\build\fire-tv\v2.0.46\TetoTV-v2.0.46-universal.apk `
+  -NativeSourcePath .\build\release-compliance\v2.0.46\TetoTV-v2.0.46-native-playback-sources.zip `
+  -OutputPath .\build\fire-tv\v2.0.46\SHA256SUMS
 
 .\tool\release\verify_release_payloads.ps1 `
   -Channel Beta `
-  -ApkPath .\build\fire-tv\v2.0.45\TetoTV-v2.0.45-universal.apk `
-  -NativeSourcePath .\build\release-compliance\v2.0.45\TetoTV-v2.0.45-native-playback-sources.zip `
-  -ChecksumsPath .\build\fire-tv\v2.0.45\SHA256SUMS `
-  -ReleaseNotesPath .\docs\RELEASE_NOTES_2.0.45.md
+  -ApkPath .\build\fire-tv\v2.0.46\TetoTV-v2.0.46-universal.apk `
+  -NativeSourcePath .\build\release-compliance\v2.0.46\TetoTV-v2.0.46-native-playback-sources.zip `
+  -ChecksumsPath .\build\fire-tv\v2.0.46\SHA256SUMS `
+  -ReleaseNotesPath .\docs\RELEASE_NOTES_2.0.46.md
 ```
 
 The final payload check requires all five exact, source-built native JARs

--- a/docs/RELEASE_NOTES_2.0.46.md
+++ b/docs/RELEASE_NOTES_2.0.46.md
@@ -1,0 +1,31 @@
+# TetoTV 2.0.46 Beta
+
+> [!WARNING]
+> No independent native-license review: This Beta has not received independent native-library licensing review. Automated checks verify the APK, native-source bundle, notices, pinned inputs, and checksums, but do not establish legal compliance or reproducible builds.
+
+This Beta compacts the episode-details actions and restores the player's tighter HUD spacing while keeping scrubbing stable and readable.
+
+## What's changed
+
+- Watch trailer, Cast & crew, Related series, and Download season now occupy about half of their former full-HD TV footprint.
+- All four actions remain together in one row with the same left-to-right D-pad focus order and focus styling.
+- Compact TV and phone layouts use proportioned button widths so every action remains visible without horizontal scrolling or scaled-down containers.
+- Labels can wrap onto two centered lines when space is constrained, and layout checks protect them from clipping across representative TV, phone, tablet, and landscape sizes.
+- The active season-download action uses the shorter `Cancel download` label so its state remains clear within the compact row.
+- The player HUD once again uses its tighter pre-2.0.45 padding instead of permanently reserving a tall empty lane for the scrub timestamp.
+- The scrub timestamp remains aligned to the seek thumb and may overlap the controls slightly without expanding, bouncing, or moving the HUD or Skip Intro/Outro action.
+- Real-Debrid's startup account check now exits safely if its settings controller is disposed while secure storage or account validation is still in flight.
+
+## Release assets
+
+- `TetoTV-v2.0.46-universal.apk`
+- `TetoTV-v2.0.46-native-playback-sources.zip`
+- `SHA256SUMS`
+
+## Beta notes
+
+- This is a Beta-channel build with Android build code `410023`.
+- No Public APK is being published with this release.
+- Android does not permit an in-place install over an APK with a higher build code. A future Public counterpart must use build code `410023` or newer for data-preserving channel switching.
+
+<!-- tetotv-android-version-code: 410023 -->

--- a/lib/features/catalog/presentation/anime_details_screen.dart
+++ b/lib/features/catalog/presentation/anime_details_screen.dart
@@ -1275,6 +1275,7 @@ class _InformationActions extends StatelessWidget {
             VoidCallback onPressed,
             bool primary,
             double preferredWidth,
+            double compactWidth,
           })
         >[
           if (onTrailer != null)
@@ -1285,7 +1286,8 @@ class _InformationActions extends StatelessWidget {
               icon: Icons.play_arrow_rounded,
               onPressed: onTrailer!,
               primary: true,
-              preferredWidth: large ? 154 : 112,
+              preferredWidth: large ? 132 : 110,
+              compactWidth: large || television ? 90 : 74,
             ),
           if (onCredits != null)
             (
@@ -1295,7 +1297,8 @@ class _InformationActions extends StatelessWidget {
               icon: Icons.groups_rounded,
               onPressed: onCredits!,
               primary: false,
-              preferredWidth: large ? 150 : 105,
+              preferredWidth: large ? 120 : 98,
+              compactWidth: large || television ? 78 : 62,
             ),
           if (onFranchise != null)
             (
@@ -1307,7 +1310,8 @@ class _InformationActions extends StatelessWidget {
               icon: Icons.account_tree_rounded,
               onPressed: onFranchise!,
               primary: false,
-              preferredWidth: large ? 165 : 119,
+              preferredWidth: large ? 130 : 112,
+              compactWidth: large || television ? 90 : 72,
             ),
           if (onDownloadSeason != null)
             (
@@ -1315,17 +1319,20 @@ class _InformationActions extends StatelessWidget {
               surfaceKey: const ValueKey(
                 'anime-details-download-season-surface',
               ),
-              label: downloadSeasonLabel,
+              label: downloadSeasonLabel == 'Cancel season download'
+                  ? 'Cancel download'
+                  : downloadSeasonLabel,
               icon: Icons.download_for_offline_rounded,
               onPressed: onDownloadSeason!,
               primary: false,
-              preferredWidth: large ? 182 : 145,
+              preferredWidth: large ? 148 : 132,
+              compactWidth: large || television ? 100 : 90,
             ),
         ];
-    final spacing = large ? 12.0 : 8.0;
+    final spacing = large ? 8.0 : 6.0;
     final panelPadding = large
-        ? const EdgeInsets.symmetric(horizontal: 8, vertical: 10)
-        : const EdgeInsets.all(6);
+        ? const EdgeInsets.all(5)
+        : const EdgeInsets.all(4);
     final preferredButtonsWidth = actions.fold<double>(
       0,
       (total, action) => total + action.preferredWidth,
@@ -1345,10 +1352,10 @@ class _InformationActions extends StatelessWidget {
         ),
         child: LayoutBuilder(
           builder: (context, constraints) {
-            // One row replaces the old two-row footprint. Never halve the
-            // control widths and then ask FittedBox to make 10-foot text fit:
-            // a constrained canvas keeps all actions visible by stacking each
-            // full-size icon above its (up to two-line) label instead.
+            // Keep the four controls near half of the former tray footprint
+            // without scaling their contents. A constrained canvas stacks each
+            // icon above its full, two-line label and gives every action the
+            // same readable width instead of clipping or scrolling the row.
             final constraintWidth = constraints.hasBoundedWidth
                 ? constraints.maxWidth
                 : preferredStripWidth;
@@ -1357,8 +1364,16 @@ class _InformationActions extends StatelessWidget {
                 .clamp(0.0, preferredStripWidth)
                 .toDouble();
             final compact = boundedWidth < preferredStripWidth;
-            final compactSpacing = large || television ? 6.0 : 5.0;
-            final stripWidth = compact ? boundedWidth : preferredStripWidth;
+            final compactSpacing = 4.0;
+            final compactButtonsWidth = actions.fold<double>(
+              0,
+              (total, action) => total + action.compactWidth,
+            );
+            final compactPreferredWidth =
+                compactButtonsWidth + compactSpacing * (actions.length - 1);
+            final stripWidth = compact
+                ? compactPreferredWidth.clamp(0.0, boundedWidth).toDouble()
+                : preferredStripWidth;
             return SizedBox(
               width: stripWidth,
               child: Row(
@@ -1369,6 +1384,7 @@ class _InformationActions extends StatelessWidget {
                       SizedBox(width: compact ? compactSpacing : spacing),
                     if (compact)
                       Expanded(
+                        flex: (actions[index].compactWidth * 10).round(),
                         child: _InformationButton(
                           key: actions[index].key,
                           surfaceKey: actions[index].surfaceKey,
@@ -1377,7 +1393,7 @@ class _InformationActions extends StatelessWidget {
                           onPressed: actions[index].onPressed,
                           primary: actions[index].primary,
                           large: large,
-                          stacked: true,
+                          compact: true,
                         ),
                       )
                     else
@@ -1413,7 +1429,7 @@ class _InformationButton extends StatelessWidget {
     required this.large,
     required this.surfaceKey,
     this.primary = false,
-    this.stacked = false,
+    this.compact = false,
   });
 
   final String label;
@@ -1421,7 +1437,7 @@ class _InformationButton extends StatelessWidget {
   final VoidCallback onPressed;
   final bool large;
   final bool primary;
-  final bool stacked;
+  final bool compact;
   final Key? surfaceKey;
 
   @override
@@ -1444,22 +1460,20 @@ class _InformationButton extends StatelessWidget {
       },
       child: Container(
         key: surfaceKey,
-        height: stacked ? (large ? 64 : 54) : (large ? 58 : 42),
+        height: compact ? (large ? 42 : 40) : (large ? 38 : 36),
         alignment: Alignment.center,
         padding: EdgeInsets.symmetric(
-          horizontal: stacked ? (large ? 4 : 3) : (large ? 14 : 11),
-          vertical: stacked ? 2 : 0,
+          horizontal: compact ? (large ? 4 : 3) : (large ? 10 : 8),
         ),
         decoration: BoxDecoration(
           color: primary ? context.appPalette.accent : const Color(0xEE171717),
           borderRadius: BorderRadius.circular(10),
           border: Border.all(color: Colors.white.withValues(alpha: .15)),
         ),
-        child: stacked
+        child: compact
             ? Column(
-                mainAxisSize: MainAxisSize.max,
                 children: [
-                  Icon(icon, size: large ? 23 : 18),
+                  Icon(icon, size: 15),
                   const SizedBox(height: 1),
                   Expanded(
                     child: Center(
@@ -1468,8 +1482,8 @@ class _InformationButton extends StatelessWidget {
                         maxLines: 2,
                         overflow: TextOverflow.ellipsis,
                         textAlign: TextAlign.center,
-                        style: TextStyle(
-                          fontSize: large ? 16 : 12,
+                        style: const TextStyle(
+                          fontSize: 11,
                           height: 1,
                           fontWeight: FontWeight.w700,
                         ),
@@ -1480,15 +1494,16 @@ class _InformationButton extends StatelessWidget {
               )
             : Row(
                 children: [
-                  Icon(icon, size: large ? 23 : 18),
-                  SizedBox(width: large ? 9 : 7),
+                  Icon(icon, size: large ? 17 : 16),
+                  const SizedBox(width: 5),
                   Expanded(
                     child: Text(
                       label,
-                      maxLines: 1,
+                      maxLines: 2,
                       overflow: TextOverflow.ellipsis,
                       style: TextStyle(
-                        fontSize: large ? 16 : 12,
+                        fontSize: 12,
+                        height: 1,
                         fontWeight: FontWeight.w700,
                       ),
                     ),

--- a/lib/features/player/presentation/teto_player_chrome.dart
+++ b/lib/features/player/presentation/teto_player_chrome.dart
@@ -11,11 +11,11 @@ const double _playerControlFocusGutter = 20;
 const double _playerProgressFocusBorderWidth = 1.4;
 const double _compactPlayerSeekBubbleFontSize = 14;
 const double _regularPlayerSeekBubbleFontSize = 18;
-// These reserves include the always-present seek-bubble lane. Keeping the lane
-// in the resting HUD prevents either the chrome or the Skip action from moving
-// when scrubbing starts.
-const double _compactPlayerChromeReservedHeight = 169;
-const double _regularPlayerChromeReservedHeight = 173;
+// Match the tighter pre-2.0.45 resting HUD. The seek bubble paints over the
+// lower control area instead of consuming layout height, so scrubbing does not
+// require a larger reserve or move the separate Skip action.
+const double _compactPlayerChromeReservedHeight = 136;
+const double _regularPlayerChromeReservedHeight = 130;
 const Color _defaultPlayerChromePanel = Color(0xD6080808);
 const Color _defaultPlayerChromeShadow = Color(0xA8000000);
 const Color _defaultPlayerControlSurface = Color(0x8F242429);
@@ -93,9 +93,9 @@ double playerSkipOverlayBottomInset({
   // viewports. Reserve that line so Skip Intro/Outro stays visibly detached
   // from the panel instead of landing on top of its badges or border.
   final expandedHeaderGrowth = expandedHeader ? 44.0 : 0.0;
-  // The bubble lane is part of the resting HUD, so beginning a scrub must not
-  // move either the chrome or the separate Skip action. [scrubbing] remains an
-  // explicit compatibility input but no longer changes geometry.
+  // The bubble overlays the fixed HUD, so beginning a scrub must not move the
+  // chrome or the separate Skip action. [scrubbing] remains an explicit
+  // compatibility input but no longer changes geometry.
   return base +
       accessibleGrowth +
       expandedHeaderGrowth +
@@ -1056,31 +1056,14 @@ class _TetoPlayerProgressScrubberState
       milliseconds: _displayMilliseconds.round(),
     );
     final seekLabel = formatPlayerChromeDuration(displayPosition);
-    return Column(
+    final seekBubbleHeight = _PlayerSeekTimeBubble.heightFor(
+      context,
+      label: seekLabel,
+      compact: widget.compact,
+    );
+    final progressContent = Column(
       mainAxisSize: MainAxisSize.min,
       children: [
-        // Reserve the seek-bubble lane even while it is hidden. This keeps the
-        // HUD's outer geometry stable during scrubbing and prevents the bubble
-        // from painting back over the control strip above it.
-        SizedBox(
-          height: _PlayerSeekTimeBubble.heightFor(
-            context,
-            label: seekLabel,
-            compact: widget.compact,
-          ),
-          child: _interacting
-              ? _PlayerSeekTimeBubble(
-                  engineKey: widget.engineKey,
-                  label: seekLabel,
-                  progress: durationAvailable
-                      ? _displayMilliseconds / _scrubMaximumMilliseconds
-                      : 0,
-                  compact: widget.compact,
-                  palette: widget.palette,
-                )
-              : null,
-        ),
-        const SizedBox(height: 2),
         Semantics(
           hint: widget.showSupplementalRow ? null : widget.footerHint,
           child: Focus(
@@ -1202,6 +1185,28 @@ class _TetoPlayerProgressScrubberState
                 ),
               ],
             ],
+          ),
+      ],
+    );
+    return Stack(
+      clipBehavior: Clip.none,
+      children: [
+        progressContent,
+        if (_interacting)
+          Positioned(
+            left: 0,
+            right: 0,
+            top: -seekBubbleHeight - 2,
+            height: seekBubbleHeight,
+            child: _PlayerSeekTimeBubble(
+              engineKey: widget.engineKey,
+              label: seekLabel,
+              progress: durationAvailable
+                  ? _displayMilliseconds / _scrubMaximumMilliseconds
+                  : 0,
+              compact: widget.compact,
+              palette: widget.palette,
+            ),
           ),
       ],
     );

--- a/lib/features/settings/application/real_debrid_settings_controller.dart
+++ b/lib/features/settings/application/real_debrid_settings_controller.dart
@@ -87,6 +87,7 @@ class RealDebridSettingsController
 
   Future<void> load() async {
     var token = await _storage.read(key: realDebridTokenStorageKey);
+    if (!mounted) return;
     if (token == null || token.isEmpty) {
       state = const RealDebridSettingsState();
       return;
@@ -98,8 +99,10 @@ class RealDebridSettingsController
     );
     try {
       token = await _refreshIfNeeded(token);
+      if (!mounted) return;
       await _validate(token, persist: false);
     } catch (error) {
+      if (!mounted) return;
       state = RealDebridSettingsState(
         hasSavedToken: true,
         errorMessage: error.toString(),
@@ -190,9 +193,11 @@ class RealDebridSettingsController
   }
 
   Future<bool> _validate(String token, {required bool persist}) async {
+    if (!mounted) return false;
     final hadSavedToken = state.hasSavedToken;
     try {
       final account = await _clientFactory(token).account();
+      if (!mounted) return false;
       if (!account.isPremium) {
         throw const RealDebridException(
           'Real-Debrid streaming requires an active Premium plan.',
@@ -213,10 +218,12 @@ class RealDebridSettingsController
             await _storage.write(key: realDebridTokenStorageKey, value: token);
           },
         );
+        if (!mounted) return false;
       }
       state = RealDebridSettingsState(hasSavedToken: true, account: account);
       return true;
     } catch (error) {
+      if (!mounted) return false;
       state = RealDebridSettingsState(
         hasSavedToken: hadSavedToken,
         errorMessage: error.toString(),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: 'none'
 # Public and Beta artifacts built from the same source use one monotonically
 # increasing Android versionCode. The project default carries the Beta display
 # version; the Public universal APK overrides the build name to the 1.x line.
-version: 2.0.45+410022
+version: 2.0.46+410023
 
 environment:
   sdk: ^3.12.2

--- a/test/anime_details_screen_test.dart
+++ b/test/anime_details_screen_test.dart
@@ -19,6 +19,7 @@ import 'package:anime_tv/features/tracking/application/my_list_controller.dart';
 import 'package:anime_tv/features/tracking/application/tracking_home_provider.dart';
 import 'package:anime_tv/features/tracking/domain/tracking_repository.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
@@ -801,18 +802,19 @@ void main() {
     expect(compactTvInfo.right, lessThan(compactTvActions.left));
     // A television keeps every available action in one compact visible row
     // even when Android exposes a 960px logical canvas.
-    expect(compactTvInformationTray.height, 86);
+    expect(compactTvInformationTray.size, const Size(382, 54));
+    const compactWidths = [90.0, 78.0, 90.0, 100.0];
     for (var index = 0; index < compactInformationActionRects.length; index++) {
       final rect = compactInformationActionRects[index];
-      expect(rect.width, closeTo(90, .01));
-      expect(rect.height, 64);
+      expect(rect.width, closeTo(compactWidths[index], .01));
+      expect(rect.height, 42);
       expect(rect.top, compactInformationActionRects.first.top);
       expect(rect.left, greaterThanOrEqualTo(compactTvInformationTray.left));
       expect(rect.right, lessThanOrEqualTo(compactTvInformationTray.right));
       if (index > 0) {
         expect(
           rect.left - compactInformationActionRects[index - 1].right,
-          closeTo(6, .01),
+          closeTo(4, .01),
         );
       }
     }
@@ -823,11 +825,31 @@ void main() {
       find.descendant(of: informationTray, matching: find.byType(FittedBox)),
       findsNothing,
     );
-    expect(tester.widget<Text>(find.text('Watch trailer')).style?.fontSize, 16);
+    expect(tester.widget<Text>(find.text('Watch trailer')).style?.fontSize, 11);
     for (final icon in tester.widgetList<Icon>(
       find.descendant(of: informationTray, matching: find.byType(Icon)),
     )) {
-      expect(icon.size, 23);
+      expect(icon.size, 15);
+    }
+    for (final label in const [
+      'Watch trailer',
+      'Cast & crew',
+      'Related series',
+      'Download season',
+    ]) {
+      final finder = find.text(label);
+      final text = tester.widget<Text>(finder);
+      final paragraph = tester.renderObject<RenderParagraph>(finder);
+      expect(text.maxLines, 2);
+      expect(text.style?.height, 1);
+      expect(
+        paragraph.didExceedMaxLines,
+        isFalse,
+        reason:
+            '$label must remain fully visible in the compact TV row '
+            '(size=${paragraph.size}, constraints=${paragraph.constraints}, '
+            'boxes=${paragraph.getBoxesForSelection(TextSelection(baseOffset: 0, extentOffset: label.length))})',
+      );
     }
     final compactTrailerControl = tester.widget<FocusableActionDetector>(
       find
@@ -1006,23 +1028,59 @@ void main() {
       expect(
         informationActionRects[index].left -
             informationActionRects[index - 1].right,
-        12,
+        8,
       );
     }
     for (final rect in informationActionRects) {
-      expect(rect.height, 58);
+      expect(rect.height, 38);
     }
     expect(
       informationActionRects.map((rect) => rect.width),
-      orderedEquals(const [154, 150, 165, 182]),
+      orderedEquals(const [132, 120, 130, 148]),
+    );
+    for (final label in const [
+      'Watch trailer',
+      'Cast & crew',
+      'Related series',
+      'Download season',
+    ]) {
+      final finder = find.text(label);
+      final text = tester.widget<Text>(finder);
+      final paragraph = tester.renderObject<RenderParagraph>(finder);
+      expect(text.maxLines, 2);
+      expect(text.style?.height, 1);
+      expect(
+        paragraph.didExceedMaxLines,
+        isFalse,
+        reason:
+            '$label must remain fully visible in the full-HD TV row '
+            '(size=${paragraph.size}, constraints=${paragraph.constraints}, '
+            'boxes=${paragraph.getBoxesForSelection(TextSelection(baseOffset: 0, extentOffset: label.length))})',
+      );
+    }
+    expect(tester.widget<Text>(find.text('Watch trailer')).style?.fontSize, 12);
+    for (final icon in tester.widgetList<Icon>(
+      find.descendant(
+        of: find.byKey(const ValueKey('anime-details-information-actions')),
+        matching: find.byType(Icon),
+      ),
+    )) {
+      expect(icon.size, 17);
+    }
+    final informationTrayRect = tester.getRect(
+      find.byKey(const ValueKey('anime-details-information-actions')),
+    );
+    expect(informationTrayRect.size, const Size(566, 50));
+    // The previous reference tray occupied 703 x 78 logical pixels. Preserve
+    // legible, unscaled content while reducing its total area to about half.
+    expect(
+      informationTrayRect.width * informationTrayRect.height,
+      lessThan(703 * 78 * .52),
     );
     final informationTray = tester.widget<Container>(
       find.byKey(const ValueKey('anime-details-information-actions')),
     );
-    expect(
-      informationTray.padding,
-      const EdgeInsets.symmetric(horizontal: 8, vertical: 10),
-    );
+    expect(informationTray.padding, const EdgeInsets.all(5));
     expect(
       (informationTray.decoration! as BoxDecoration).borderRadius,
       BorderRadius.circular(14),
@@ -1344,7 +1402,7 @@ void main() {
         );
         expect(
           tester.widget<Text>(find.text('Watch trailer')).style?.fontSize,
-          12,
+          size.width <= 412 ? 11 : 12,
         );
         final posterSize = tester.getSize(
           find.byKey(const ValueKey('anime-details-poster')),

--- a/test/real_debrid_settings_controller_test.dart
+++ b/test/real_debrid_settings_controller_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:anime_tv/features/auth/data/real_debrid_oauth_client.dart';
 import 'package:anime_tv/features/settings/application/real_debrid_settings_controller.dart';
 import 'package:anime_tv/features/streaming/data/real_debrid_client.dart';
@@ -160,6 +162,46 @@ void main() {
     expect(controller.state.account?.isPremium, isTrue);
     expect(controller.state.errorMessage, isNull);
   });
+
+  test('an in-flight account load is inert after disposal', () async {
+    FlutterSecureStorage.setMockInitialValues({
+      realDebridTokenStorageKey: 'saved-token',
+    });
+    final accountRequested = Completer<void>();
+    final accountResult = Completer<RealDebridAccount>();
+    final controller = RealDebridSettingsController(
+      storage,
+      (_) => _DeferredRealDebridClient(accountRequested, accountResult),
+    );
+
+    final load = controller.load();
+    await accountRequested.future;
+    controller.dispose();
+    accountResult.complete(
+      const RealDebridAccount(id: 3, username: 'late-user', type: 'premium'),
+    );
+
+    await expectLater(load, completes);
+  });
+
+  test('a failed in-flight account load is inert after disposal', () async {
+    FlutterSecureStorage.setMockInitialValues({
+      realDebridTokenStorageKey: 'saved-token',
+    });
+    final accountRequested = Completer<void>();
+    final accountResult = Completer<RealDebridAccount>();
+    final controller = RealDebridSettingsController(
+      storage,
+      (_) => _DeferredRealDebridClient(accountRequested, accountResult),
+    );
+
+    final load = controller.load();
+    await accountRequested.future;
+    controller.dispose();
+    accountResult.completeError(StateError('late account failure'));
+
+    await expectLater(load, completes);
+  });
 }
 
 class _ValidRealDebridClient extends RealDebridClient {
@@ -176,6 +218,19 @@ class _FreeRealDebridClient extends RealDebridClient {
   @override
   Future<RealDebridAccount> account() async =>
       const RealDebridAccount(id: 2, username: 'free-user', type: 'free');
+}
+
+class _DeferredRealDebridClient extends RealDebridClient {
+  _DeferredRealDebridClient(this.requested, this.result) : super(token: 'test');
+
+  final Completer<void> requested;
+  final Completer<RealDebridAccount> result;
+
+  @override
+  Future<RealDebridAccount> account() {
+    if (!requested.isCompleted) requested.complete();
+    return result.future;
+  }
 }
 
 class _FailingOAuthClient extends RealDebridOAuthClient {

--- a/test/teto_player_chrome_test.dart
+++ b/test/teto_player_chrome_test.dart
@@ -553,7 +553,9 @@ void main() {
         expect(timeRect.left, greaterThan(nextRect.right));
         expect(timeRect.right, lessThan(speedRect.left));
         expect(progressRect.top, greaterThan(playRect.bottom));
-        expect(panelRect.height, inInclusiveRange(145, 153));
+        // Match the tighter pre-2.0.45 HUD rather than reserving an empty
+        // timestamp lane whenever the viewer is not scrubbing.
+        expect(panelRect.height, inInclusiveRange(96, 112));
         expect(tester.takeException(), isNull);
       },
     );
@@ -1045,6 +1047,10 @@ void main() {
 
     progressFocus.requestFocus();
     await tester.pump();
+    final chromeFinder = find.byKey(
+      const ValueKey('compact-target-time-bottom-player-chrome'),
+    );
+    final restingChromeRect = tester.getRect(chromeFinder);
     await tester.sendKeyDownEvent(LogicalKeyboardKey.arrowRight);
     await tester.pump();
 
@@ -1068,6 +1074,11 @@ void main() {
       closeTo(expectedThumbCenter, .01),
     );
     expect(tester.getRect(seekFinder).bottom, lessThan(progressRect.top));
+    expect(
+      tester.getRect(chromeFinder),
+      restingChromeRect,
+      reason: 'compact D-pad scrubbing must not expand or move the HUD',
+    );
 
     await tester.sendKeyUpEvent(LogicalKeyboardKey.arrowRight);
     await tester.pump();
@@ -1247,10 +1258,18 @@ void main() {
         find.byKey(const ValueKey('scrub-hold-player-controls-spaced')),
       );
       final progressRect = tester.getRect(slider);
+      expect(bubbleRect.top, greaterThanOrEqualTo(controlsRect.top));
       expect(
         bubbleRect.top,
-        greaterThanOrEqualTo(controlsRect.bottom),
-        reason: 'the fixed seek-bubble lane must stay below the controls',
+        lessThan(controlsRect.bottom),
+        reason:
+            'the timestamp may overlay the lower control area to preserve '
+            'the tighter HUD',
+      );
+      expect(
+        bubbleRect.width,
+        lessThan(controlsRect.width * .2),
+        reason: 'the overlay should cover only a small part of the button row',
       );
       expect(
         bubbleRect.bottom,
@@ -1524,7 +1543,7 @@ void main() {
         viewport: const Size(1920, 1080),
         controlsVisible: true,
       ),
-      173,
+      130,
     );
     expect(
       playerSkipOverlayBottomInset(
@@ -1532,7 +1551,7 @@ void main() {
         controlsVisible: true,
         safeAreaBottom: 24,
       ),
-      193,
+      160,
     );
     expect(
       playerSkipOverlayBottomInset(
@@ -1541,7 +1560,7 @@ void main() {
         safeAreaBottom: 24,
         textScaleFactor: 2.5,
       ),
-      295,
+      262,
     );
     expect(
       playerSkipOverlayBottomInset(
@@ -1557,7 +1576,7 @@ void main() {
         controlsVisible: true,
         expandedHeader: true,
       ),
-      217,
+      174,
     );
     expect(
       playerSkipOverlayBottomInset(
@@ -1565,7 +1584,7 @@ void main() {
         controlsVisible: true,
         scrubbing: true,
       ),
-      173,
+      130,
     );
     expect(
       playerSkipOverlayBottomInset(
@@ -1574,7 +1593,7 @@ void main() {
         safeAreaBottom: 24,
         scrubbing: true,
       ),
-      193,
+      160,
     );
     expect(
       playerSkipOverlayBottomInset(
@@ -1584,7 +1603,7 @@ void main() {
         textScaleFactor: 2.5,
         scrubbing: true,
       ),
-      295,
+      262,
     );
   });
 

--- a/tool/release/native_playback_manifest.json
+++ b/tool/release/native_playback_manifest.json
@@ -375,10 +375,10 @@
     {
       "path": "lib/arm64-v8a/libapp.so",
       "size": 12125072,
-      "sha256": "5c58616c7d6e5eaab0d4fc51aae72b796537c8a18e4f1996aca7e58b7eb262dc",
-      "origin": "TetoTV Flutter application AOT 2.0.45",
+      "sha256": "83a8012eb21b43bb1f78d6a5e6ab2a4952618a45a2b204be21d3c70d752f87dd",
+      "origin": "TetoTV Flutter application AOT 2.0.46",
       "license": "MIT",
-      "sourceLocator": "Git tag v2.0.45",
+      "sourceLocator": "Git tag v2.0.46",
       "noticeLocator": "LICENSE"
     },
     {
@@ -423,7 +423,7 @@
       "sha256": "dc05f53278b2733094f12aeaed54c080329309762ce49e6de4118e4bfb0fff55",
       "origin": "TetoTV source build of media-kit Android helper at 42054e5d479f39ccbb0ae604862e2bcaf59b74c2",
       "license": "MIT",
-      "sourceLocator": "TetoTV-v2.0.45-native-playback-sources.zip: sources/media-kit-android-helper-42054e5d479f39ccbb0ae604862e2bcaf59b74c2.zip",
+      "sourceLocator": "TetoTV-v2.0.46-native-playback-sources.zip: sources/media-kit-android-helper-42054e5d479f39ccbb0ae604862e2bcaf59b74c2.zip",
       "noticeLocator": "assets/legal/native/MEDIA_KIT_ANDROID_HELPER_LICENSE.txt; assets/legal/native/NATIVE_PLAYBACK_NOTICE.txt"
     },
     {
@@ -432,7 +432,7 @@
       "sha256": "a7399d0be70844e5ee94cc5b1acc1516571113c50561fe0a5d05b49101c53ef2",
       "origin": "TetoTV source build of the pinned mpv and FFmpeg native playback stack",
       "license": "LGPL-3.0-or-later (conservative combined classification) plus component terms",
-      "sourceLocator": "TetoTV-v2.0.45-native-playback-sources.zip and tool/native/build_native_playback.sh",
+      "sourceLocator": "TetoTV-v2.0.46-native-playback-sources.zip and tool/native/build_native_playback.sh",
       "noticeLocator": "assets/legal/native/NATIVE_PLAYBACK_NOTICE.txt and its referenced exact license assets"
     },
     {
@@ -450,16 +450,16 @@
       "sha256": "263ba714570fb3acfc308cce52776b00506ec8809d225617e52352336144cfa2",
       "origin": "TetoTV source build of the pinned libtorrent4j and libtorrent-rasterbar stack",
       "license": "Mixed MIT, BSD, Boost-1.0, Apache-2.0, and MPL-2.0 component terms",
-      "sourceLocator": "TetoTV-v2.0.45-native-playback-sources.zip and tool/native/build_native_playback.sh",
+      "sourceLocator": "TetoTV-v2.0.46-native-playback-sources.zip and tool/native/build_native_playback.sh",
       "noticeLocator": "assets/legal/native/DIRECT_TORRENT_NATIVE_NOTICE.txt and its referenced exact license assets"
     },
     {
       "path": "lib/armeabi-v7a/libapp.so",
       "size": 13288012,
-      "sha256": "2f97493f6dd1dda4a22c68f37979aa221c1e7b18797b1e112a7b6f3e65e794f9",
-      "origin": "TetoTV Flutter application AOT 2.0.45",
+      "sha256": "2b163a1b9f4ad9a6e182a833235928bbd73387dd2298854e4a988af4daa2a60f",
+      "origin": "TetoTV Flutter application AOT 2.0.46",
       "license": "MIT",
-      "sourceLocator": "Git tag v2.0.45",
+      "sourceLocator": "Git tag v2.0.46",
       "noticeLocator": "LICENSE"
     },
     {
@@ -504,7 +504,7 @@
       "sha256": "8820a12e07bb3dc45f5b4286acf6918827fba4c265767e7f1cc8f07215c84b6a",
       "origin": "TetoTV source build of media-kit Android helper at 42054e5d479f39ccbb0ae604862e2bcaf59b74c2",
       "license": "MIT",
-      "sourceLocator": "TetoTV-v2.0.45-native-playback-sources.zip: sources/media-kit-android-helper-42054e5d479f39ccbb0ae604862e2bcaf59b74c2.zip",
+      "sourceLocator": "TetoTV-v2.0.46-native-playback-sources.zip: sources/media-kit-android-helper-42054e5d479f39ccbb0ae604862e2bcaf59b74c2.zip",
       "noticeLocator": "assets/legal/native/MEDIA_KIT_ANDROID_HELPER_LICENSE.txt; assets/legal/native/NATIVE_PLAYBACK_NOTICE.txt"
     },
     {
@@ -513,7 +513,7 @@
       "sha256": "d5a220fdf41edde10f161f86addc846ae9cb18137ea48e4db541cd703fec5092",
       "origin": "TetoTV source build of the pinned mpv and FFmpeg native playback stack",
       "license": "LGPL-3.0-or-later (conservative combined classification) plus component terms",
-      "sourceLocator": "TetoTV-v2.0.45-native-playback-sources.zip and tool/native/build_native_playback.sh",
+      "sourceLocator": "TetoTV-v2.0.46-native-playback-sources.zip and tool/native/build_native_playback.sh",
       "noticeLocator": "assets/legal/native/NATIVE_PLAYBACK_NOTICE.txt and its referenced exact license assets"
     },
     {
@@ -531,7 +531,7 @@
       "sha256": "5e090380a7c1c26c16763d40c7f451bdb4fc2542bc5e1b8a410206f66dea4330",
       "origin": "TetoTV source build of the pinned libtorrent4j and libtorrent-rasterbar stack",
       "license": "Mixed MIT, BSD, Boost-1.0, Apache-2.0, and MPL-2.0 component terms",
-      "sourceLocator": "TetoTV-v2.0.45-native-playback-sources.zip and tool/native/build_native_playback.sh",
+      "sourceLocator": "TetoTV-v2.0.46-native-playback-sources.zip and tool/native/build_native_playback.sh",
       "noticeLocator": "assets/legal/native/DIRECT_TORRENT_NATIVE_NOTICE.txt and its referenced exact license assets"
     }
   ],


### PR DESCRIPTION
## Summary
- reduce the four episode-details information actions to roughly half their former TV footprint while preserving one-row D-pad navigation
- restore the tighter pre-2.0.45 player HUD padding and overlay the scrub timestamp without HUD movement
- make an in-flight Real-Debrid startup load inert after controller disposal
- prepare signed Beta 2.0.46 (Android build 410023) release metadata and native BOM

## Verification
- flutter analyze
- flutter test --reporter compact (1,882 passed; 14 skipped)
- signed universal ARM APK verification (18 exact native entries)
- native redistribution bundle and release payload verification