### PR TITLE
TetoTV 2.0.48 Beta

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 
 <p align="center">
   <a href="https://github.com/LindersOSX/TetoTV-Beta/releases/latest"><strong>Download Beta</strong></a>
-  · <a href="docs/RELEASE_NOTES_2.0.47.md">What's new</a>
+  · <a href="docs/RELEASE_NOTES_2.0.48.md">What's new</a>
   · <a href="https://github.com/LindersOSX/TetoTV-Beta/issues/new">Report an issue</a>
   · <a href="https://discord.gg/juC6k7d4WY">Discord</a>
   · <a href="https://www.youtube.com/@TetoTVApp">YouTube</a>
@@ -27,6 +27,9 @@
 > TetoTV is a user-configured media client. It does not host, index, supply, recommend, or endorse media sources, provider extensions, marketplace catalogs, or credentials. No third-party catalog or provider is bundled or preconfigured. Viewers must be authorized to access, play, and download the media they connect.
 
 TetoTV runs directly on the Android device with no companion server required for normal browsing and playback. This repository contains the complete application source and the Beta release channel—not only APK downloads.
+
+> [!NOTE]
+> **AI-assisted development:** TetoTV uses AI tools to assist with code, design iteration, documentation, tests, and review. The maintainer directs project decisions and remains responsible for validating changes and approving releases. AI assistance is not an independent legal or security certification.
 
 ## See TetoTV in action
 
@@ -82,10 +85,10 @@ TetoTV runs directly on the Android device with no companion server required for
 | Channel | Version | Best for |
 | --- | --- | --- |
 | Public | Not published | Source and release-readiness documents are available, but no Public APK is currently offered |
-| Beta | [2.0.47](docs/RELEASE_NOTES_2.0.47.md) | Testing more reliable extension discovery, stream classification, and skip timing before a separately reviewed Public release |
+| Beta | [2.0.48](docs/RELEASE_NOTES_2.0.48.md) | Testing playback recovery, Discord stability, richer diagnostics, compact TV Settings, and safer release-history compatibility before a separately reviewed Public release |
 
 > [!WARNING]
-> Beta 2.0.47 uses the repository's explicit unreviewed-Beta exception. Its native-library and corresponding-source material did not receive independent license review, and automated integrity checks are not a legal compliance determination. Read the [complete Beta disclosure](docs/RELEASE_NOTES_2.0.47.md). This exception does not apply to a future Public release.
+> Beta 2.0.48 uses the repository's explicit unreviewed-Beta exception. Its native-library and corresponding-source material did not receive independent license review, and automated integrity checks are not a legal compliance determination. Read the [complete Beta disclosure](docs/RELEASE_NOTES_2.0.48.md). This exception does not apply to a future Public release.
 
 The Public updater repository intentionally has no release while the Public build is held for review. Existing Beta installations continue to update from the Beta repository. Android never permits an in-place install of an APK with a lower build code; Developer Mode does not bypass that platform rule.
 

--- a/android/app/src/main/cpp/CMakeLists.txt
+++ b/android/app/src/main/cpp/CMakeLists.txt
@@ -9,6 +9,18 @@ add_library(tetotv_discord SHARED discord_rich_presence.cpp)
 target_compile_features(tetotv_discord PRIVATE cxx_std_20)
 target_compile_options(tetotv_discord PRIVATE -Wall -Wextra -Werror=return-type)
 
+# NDK r28 already emits 16 KiB LOAD alignment for arm64-v8a, but its ARMv7
+# default remains 4 KiB. Raise only the ABI that needs it so the compliant
+# ARM64 layout is left unchanged.
+if(ANDROID_ABI STREQUAL "armeabi-v7a")
+    target_link_options(
+        tetotv_discord
+        PRIVATE
+        "-Wl,-z,common-page-size=16384"
+        "-Wl,-z,max-page-size=16384"
+    )
+endif()
+
 target_link_libraries(
     tetotv_discord
     PRIVATE

--- a/android/app/src/main/cpp/discord_rich_presence.cpp
+++ b/android/app/src/main/cpp/discord_rich_presence.cpp
@@ -35,6 +35,7 @@ std::thread g_worker;
 std::atomic<bool> g_running{false};
 std::atomic<bool> g_ready{false};
 std::atomic<std::uint64_t> g_auth_generation{0};
+std::atomic<std::uint64_t> g_connection_generation{0};
 std::unique_ptr<discordpp::Client> g_client;
 
 struct Presence {
@@ -47,6 +48,16 @@ struct Presence {
 };
 
 std::optional<Presence> g_pending_presence;
+std::optional<Presence> g_last_submitted_presence;
+std::chrono::steady_clock::time_point g_last_presence_submission{};
+bool g_presence_update_in_flight = false;
+bool g_clear_presence_pending = false;
+std::uint64_t g_presence_operation_generation = 0;
+bool g_connection_requested = false;
+bool g_manual_connect_after_token_update = false;
+std::uint64_t g_token_ready_connection_generation = 0;
+
+constexpr auto kPresenceTimelineTolerance = std::chrono::seconds(2);
 
 std::string from_jstring(JNIEnv* env, jstring value) {
     if (value == nullptr) return {};
@@ -183,9 +194,66 @@ void post(std::function<void()> command) {
     g_command_cv.notify_one();
 }
 
-void publish_presence(const Presence& value) {
-    if (!g_client || !g_ready.load()) {
-        g_pending_presence = value;
+bool connect_pending_if_disconnected() {
+    if (!g_client || !g_connection_requested ||
+        !g_manual_connect_after_token_update ||
+        g_token_ready_connection_generation != g_connection_generation.load() ||
+        g_client->GetStatus() != discordpp::Client::Status::Disconnected) {
+        return false;
+    }
+    // Consume the request before entering the SDK so a duplicate Disconnected
+    // callback cannot open a second websocket.
+    g_manual_connect_after_token_update = false;
+    g_token_ready_connection_generation = 0;
+    g_client->Connect();
+    return true;
+}
+
+bool same_presence_timeline(const Presence& previous,
+                            const Presence& next,
+                            std::chrono::steady_clock::time_point now) {
+    if (previous.title != next.title || previous.episode != next.episode ||
+        previous.playing != next.playing || previous.duration_ms != next.duration_ms ||
+        previous.artwork_url != next.artwork_url) {
+        return false;
+    }
+    if (!next.playing) return true;
+
+    const auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
+                             now - g_last_presence_submission)
+                             .count();
+    const auto expected_position = previous.position_ms + elapsed;
+    const auto delta = next.position_ms >= expected_position
+                           ? next.position_ms - expected_position
+                           : expected_position - next.position_ms;
+    return delta <=
+           std::chrono::duration_cast<std::chrono::milliseconds>(kPresenceTimelineTolerance)
+               .count();
+}
+
+void flush_pending_presence();
+
+void publish_presence(Presence value) {
+    // Flutter updates Android's media session every few seconds and emits
+    // back-to-back playing transitions while replacing a failed source. The
+    // Discord SDK completes presence writes asynchronously on its websocket.
+    // Retain only the newest desired state and never overlap those writes.
+    g_clear_presence_pending = false;
+    g_pending_presence = std::move(value);
+    flush_pending_presence();
+}
+
+void flush_pending_presence() {
+    if (!g_client || !g_ready.load() || g_presence_update_in_flight ||
+        !g_pending_presence.has_value()) {
+        return;
+    }
+
+    Presence value = std::move(*g_pending_presence);
+    g_pending_presence.reset();
+    const auto submitted_at = std::chrono::steady_clock::now();
+    if (g_last_submitted_presence.has_value() &&
+        same_presence_timeline(*g_last_submitted_presence, value, submitted_at)) {
         return;
     }
 
@@ -223,10 +291,36 @@ void publish_presence(const Presence& value) {
         activity.SetTimestamps(timestamps);
     }
 
+    g_presence_update_in_flight = true;
+    const auto presence_generation = ++g_presence_operation_generation;
     g_client->UpdateRichPresence(
-        std::move(activity), [](discordpp::ClientResult result) {
-            notify_simple("onPresenceResult", succeeded(result),
-                          succeeded(result) ? std::string{} : safe_error(result));
+        std::move(activity),
+        [value = std::move(value), submitted_at, presence_generation](
+            discordpp::ClientResult result) mutable {
+            const bool ok = succeeded(result);
+            std::string error = ok ? std::string{} : safe_error(result);
+            // Return from the SDK callback before starting another SDK
+            // operation. Some SDK callbacks may originate while its websocket
+            // state machine is still unwinding.
+            post([value = std::move(value),
+                  submitted_at,
+                  presence_generation,
+                  ok,
+                  error = std::move(error)]() mutable {
+                if (presence_generation != g_presence_operation_generation) return;
+                g_presence_update_in_flight = false;
+                if (ok) {
+                    g_last_submitted_presence = std::move(value);
+                    g_last_presence_submission = submitted_at;
+                }
+                notify_simple("onPresenceResult", ok, error);
+                if (g_clear_presence_pending) {
+                    g_clear_presence_pending = false;
+                    if (g_client && g_ready.load()) g_client->ClearRichPresence();
+                    return;
+                }
+                flush_pending_presence();
+            });
         });
 }
 
@@ -241,42 +335,66 @@ void start_worker() {
             [](discordpp::Client::Status status,
                discordpp::Client::Error error,
                std::int32_t error_detail) {
-                const bool ready = status == discordpp::Client::Status::Ready;
-                g_ready.store(ready);
-                switch (status) {
-                    case discordpp::Client::Status::Ready:
-                        notify_status("ready");
-                        if (g_pending_presence.has_value()) {
-                            Presence pending = std::move(*g_pending_presence);
-                            g_pending_presence.reset();
-                            publish_presence(pending);
-                        }
-                        break;
-                    case discordpp::Client::Status::Connecting:
-                    case discordpp::Client::Status::Connected:
-                        notify_status("connecting");
-                        break;
-                    case discordpp::Client::Status::Reconnecting:
-                    case discordpp::Client::Status::HttpWait:
-                        notify_status("reconnecting");
-                        break;
-                    case discordpp::Client::Status::Disconnecting:
-                        notify_status("disconnecting");
-                        break;
-                    case discordpp::Client::Status::Disconnected:
-                        notify_status(
-                            "disconnected",
-                            error == discordpp::Client::Error::None
-                                ? std::string{}
-                                : "Discord disconnected (" + std::to_string(error_detail) + ").");
-                        break;
-                }
+                post([status, error, error_detail] {
+                    const bool ready = status == discordpp::Client::Status::Ready;
+                    g_ready.store(ready);
+                    switch (status) {
+                        case discordpp::Client::Status::Ready:
+                            g_connection_requested = false;
+                            g_manual_connect_after_token_update = false;
+                            g_token_ready_connection_generation = 0;
+                            notify_status("ready");
+                            flush_pending_presence();
+                            break;
+                        case discordpp::Client::Status::Connecting:
+                        case discordpp::Client::Status::Connected:
+                            notify_status("connecting");
+                            break;
+                        case discordpp::Client::Status::Reconnecting:
+                        case discordpp::Client::Status::HttpWait:
+                            notify_status("reconnecting");
+                            break;
+                        case discordpp::Client::Status::Disconnecting:
+                            notify_status("disconnecting");
+                            break;
+                        case discordpp::Client::Status::Disconnected:
+                            // The SDK guarantees all socket teardown is done at
+                            // this status, so no prior presence write can still
+                            // block a later clean connection.
+                            ++g_presence_operation_generation;
+                            g_presence_update_in_flight = false;
+                            g_clear_presence_pending = false;
+                            // A fresh socket needs a fresh activity publish;
+                            // otherwise the timeline de-duplicator can mistake
+                            // the last pre-disconnect state for a live one.
+                            g_last_submitted_presence.reset();
+                            if (g_connection_requested) {
+                                if (!connect_pending_if_disconnected()) {
+                                    // UpdateToken owns reconnecting a client
+                                    // that was already connected. If teardown
+                                    // won the race, its token callback will
+                                    // return here once the new token is ready.
+                                    notify_status("connecting");
+                                }
+                                break;
+                            }
+                            notify_status(
+                                "disconnected",
+                                error == discordpp::Client::Error::None
+                                    ? std::string{}
+                                    : "Discord disconnected (" +
+                                          std::to_string(error_detail) + ").");
+                            break;
+                    }
+                });
             });
         g_client->SetTokenExpirationCallback([] {
-            with_bridge([](JNIEnv* env, jclass bridge) {
-                const jmethodID callback =
-                    env->GetStaticMethodID(bridge, "onTokenExpiring", "()V");
-                if (callback != nullptr) env->CallStaticVoidMethod(bridge, callback);
+            post([] {
+                with_bridge([](JNIEnv* env, jclass bridge) {
+                    const jmethodID callback =
+                        env->GetStaticMethodID(bridge, "onTokenExpiring", "()V");
+                    if (callback != nullptr) env->CallStaticVoidMethod(bridge, callback);
+                });
             });
         });
 
@@ -474,17 +592,48 @@ Java_dev_animetv_anime_1tv_DiscordRichPresenceBridge_nativeConnect(JNIEnv* env,
                                                                     jstring token,
                                                                     jint token_type) {
     const std::string access_token = from_jstring(env, token);
-    post([access_token, token_type] {
-        if (!g_client) return;
+    const auto connection_generation = g_connection_generation.fetch_add(1) + 1;
+    post([access_token, token_type, connection_generation] {
+        if (!g_client || connection_generation != g_connection_generation.load()) return;
+        g_connection_requested = true;
+        const auto initial_status = g_client->GetStatus();
+        g_manual_connect_after_token_update =
+            initial_status == discordpp::Client::Status::Disconnected ||
+            initial_status == discordpp::Client::Status::Disconnecting;
+        g_token_ready_connection_generation = 0;
         g_client->UpdateToken(
             static_cast<discordpp::AuthorizationTokenType>(token_type),
             access_token,
-            [](discordpp::ClientResult result) {
-                if (!succeeded(result)) {
-                    notify_status("error", safe_error(result));
-                    return;
-                }
-                g_client->Connect();
+            [connection_generation](discordpp::ClientResult result) {
+                const bool ok = succeeded(result);
+                std::string error = ok ? std::string{} : safe_error(result);
+                post([connection_generation, ok, error = std::move(error)] {
+                    if (!g_client ||
+                        connection_generation != g_connection_generation.load()) {
+                        return;
+                    }
+                    if (!ok) {
+                        g_connection_requested = false;
+                        g_manual_connect_after_token_update = false;
+                        g_token_ready_connection_generation = 0;
+                        notify_status("error", error);
+                        return;
+                    }
+                    g_token_ready_connection_generation = connection_generation;
+                    // UpdateToken may reconnect an already-connected client by
+                    // itself. Calling Connect unconditionally here creates a
+                    // second websocket transition. Manually connect only when
+                    // this request began with a fully disconnected client.
+                    if (connect_pending_if_disconnected()) return;
+                    const auto status = g_client->GetStatus();
+                    if (status == discordpp::Client::Status::Ready) {
+                        g_connection_requested = false;
+                        g_manual_connect_after_token_update = false;
+                        g_token_ready_connection_generation = 0;
+                        notify_status("ready");
+                        flush_pending_presence();
+                    }
+                });
             });
     });
 }
@@ -528,18 +677,37 @@ extern "C" JNIEXPORT void JNICALL
 Java_dev_animetv_anime_1tv_DiscordRichPresenceBridge_nativeClearPresence(JNIEnv*, jobject) {
     post([] {
         g_pending_presence.reset();
-        if (g_client && g_ready.load()) g_client->ClearRichPresence();
+        g_last_submitted_presence.reset();
+        if (!g_client || !g_ready.load()) return;
+        if (g_presence_update_in_flight) {
+            g_clear_presence_pending = true;
+            return;
+        }
+        g_client->ClearRichPresence();
     });
 }
 
 extern "C" JNIEXPORT void JNICALL
 Java_dev_animetv_anime_1tv_DiscordRichPresenceBridge_nativeDisconnect(JNIEnv*, jobject) {
+    // Invalidate an UpdateToken callback before its queued worker command can
+    // race this disconnect and open a replacement websocket afterward.
+    g_connection_generation.fetch_add(1);
     post([] {
         g_pending_presence.reset();
+        g_last_submitted_presence.reset();
+        g_clear_presence_pending = false;
+        const bool had_presence_update_in_flight = g_presence_update_in_flight;
+        ++g_presence_operation_generation;
+        g_presence_update_in_flight = false;
+        g_connection_requested = false;
+        g_manual_connect_after_token_update = false;
+        g_token_ready_connection_generation = 0;
         g_ready.store(false);
         if (g_client) {
-            g_client->AbortAuthorize();
-            g_client->ClearRichPresence();
+            // Do not overlap a synchronous clear with an asynchronous
+            // UpdateRichPresence write. Disconnect itself tears down the
+            // remote activity and the SDK's websocket.
+            if (!had_presence_update_in_flight) g_client->ClearRichPresence();
             g_client->Disconnect();
         }
     });

--- a/android/app/src/main/kotlin/dev/animetv/anime_tv/DirectTorrentPolicy.kt
+++ b/android/app/src/main/kotlin/dev/animetv/anime_tv/DirectTorrentPolicy.kt
@@ -5,12 +5,13 @@ import java.util.Locale
 internal const val DIRECT_TORRENT_MAX_FILE_BYTES = 6L * 1024L * 1024L * 1024L
 internal const val DIRECT_TORRENT_MIN_FREE_RESERVE_BYTES = 256L * 1024L * 1024L
 internal const val DIRECT_TORRENT_MAX_FILE_COUNT = 5_000
-internal const val DIRECT_TORRENT_ARM32_MAX_PAGE_SIZE_BYTES = 4_096L
+internal const val DIRECT_TORRENT_ARM32_MAX_PAGE_SIZE_BYTES = 16_384L
 internal const val DIRECT_TORRENT_MAX_SELECTED_BASENAME_CHARS = 512
 
 /**
- * The pinned ARM64 artifact is 16 KiB ELF-aligned. Its ARM32 companion is
- * only 4 KiB-aligned, so ARM32 must fail closed on a larger-page runtime.
+ * Both pinned ARM artifacts are 16 KiB ELF-aligned. Keep the explicit ARM32
+ * page-size guard so an unexpected future runtime cannot load an incompatible
+ * native torrent engine.
  */
 internal fun supportsDirectTorrentRuntime(
     processIs64Bit: Boolean,

--- a/android/app/src/test/kotlin/dev/animetv/anime_tv/DirectTorrentPolicyTest.kt
+++ b/android/app/src/test/kotlin/dev/animetv/anime_tv/DirectTorrentPolicyTest.kt
@@ -20,7 +20,7 @@ class DirectTorrentPolicyTest {
     }
 
     @Test
-    fun `runtime capability rejects arm32 on pages larger than 4 KiB`() {
+    fun `runtime capability accepts arm32 through 16 KiB pages`() {
         assertTrue(
             supportsDirectTorrentRuntime(
                 processIs64Bit = false,
@@ -28,11 +28,18 @@ class DirectTorrentPolicyTest {
                 pageSizeBytes = 4_096L,
             ),
         )
-        assertFalse(
+        assertTrue(
             supportsDirectTorrentRuntime(
                 processIs64Bit = false,
                 supportedAbis = listOf("armeabi-v7a"),
                 pageSizeBytes = 16_384L,
+            ),
+        )
+        assertFalse(
+            supportsDirectTorrentRuntime(
+                processIs64Bit = false,
+                supportedAbis = listOf("armeabi-v7a"),
+                pageSizeBytes = 65_536L,
             ),
         )
         assertFalse(

--- a/android/app/src/test/kotlin/dev/animetv/anime_tv/DiscordRichPresenceBridgeAbiTest.kt
+++ b/android/app/src/test/kotlin/dev/animetv/anime_tv/DiscordRichPresenceBridgeAbiTest.kt
@@ -122,4 +122,50 @@ class DiscordRichPresenceBridgeAbiTest {
             guardIndex >= 0 && nativeIndex > guardIndex,
         )
     }
+
+    @Test
+    fun `native bridge serializes presence writes and invalidates stale connects`() {
+        val relativeSource = "src/main/cpp/discord_rich_presence.cpp"
+        val workingDirectory = System.getProperty("user.dir") ?: "."
+        val sourceFile = generateSequence(File(workingDirectory)) { it.parentFile }
+            .take(6)
+            .flatMap { directory ->
+                sequenceOf(
+                    File(directory, relativeSource),
+                    File(directory, "app/$relativeSource"),
+                    File(directory, "android/app/$relativeSource"),
+                )
+            }
+            .firstOrNull(File::isFile)
+        assertTrue("Discord native source must be available to the contract test", sourceFile != null)
+        val source = sourceFile!!.readText()
+
+        assertTrue(
+            "presence updates must be held while an earlier SDK write is in flight",
+            source.contains("g_presence_update_in_flight") &&
+                source.contains("!g_pending_presence.has_value()"),
+        )
+        assertTrue(
+            "connect callbacks must be invalidated when a newer connect or disconnect wins",
+            source.contains("g_connection_generation") &&
+                source.contains("connection_generation != g_connection_generation.load()"),
+        )
+        assertTrue(
+            "UpdateToken must only open a websocket from the fully disconnected state",
+            source.contains("status == discordpp::Client::Status::Disconnected"),
+        )
+        assertTrue(
+            "a retry during teardown must wait for its token before connecting",
+            source.contains("initial_status == discordpp::Client::Status::Disconnecting") &&
+                source.contains("g_token_ready_connection_generation !=") &&
+                source.contains("connect_pending_if_disconnected()"),
+        )
+        val queuedConnect = source.substringAfter("bool connect_pending_if_disconnected()", "")
+            .substringBefore("bool same_presence_timeline", "")
+        assertTrue(
+            "the queued connect must be consumed before opening the websocket",
+            queuedConnect.indexOf("g_manual_connect_after_token_update = false") in
+                0 until queuedConnect.indexOf("g_client->Connect()"),
+        )
+    }
 }

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -161,8 +161,7 @@ for debug/emulator builds only. CPU marketing names are not sufficient: a
 device with a 64-bit CPU can still expose only a 32-bit app ABI.
 
 The optional direct-torrent engine is available only on `armeabi-v7a` and
-`arm64-v8a`. Its pinned upstream Android artifacts target API 24. ARM64 is
-16 KiB page-aligned; the upstream ARM32 binary is only 4 KiB-aligned, so its
-runtime capability fails closed on ARM32 devices with larger page sizes. The setting
-cannot be enabled on an unsupported ABI, and every release must re-check
-16-KiB APK/ELF page alignment before claiming Android 15/16 compatibility.
+`arm64-v8a`. Its pinned TetoTV source-built Android artifacts target API 24
+and are 16 KiB page-aligned for both ABIs. The setting cannot be enabled on an
+unsupported ABI, and every release must re-check 16-KiB APK/ELF page alignment
+before claiming Android 15/16 compatibility.

--- a/docs/BUILD_WINDOWS.md
+++ b/docs/BUILD_WINDOWS.md
@@ -220,39 +220,39 @@ APK containing both supported application ABIs.
 Public and Beta updates use anonymous GitHub requests. No Beta key, GitHub
 token, update-proxy URL, or update-specific Dart define is required. Every
 published APK uses the production signing identity. No Public APK is currently
-published. Beta 2.0.47 uses Android build code `410024`. Flutter reuses
+published. Beta 2.0.48 uses Android build code `410025`. Flutter reuses
 `app-release.apk`, so copy and rename the Beta artifact immediately after the
 build:
 
 ```powershell
-New-Item -ItemType Directory -Force .\build\fire-tv\v2.0.47 | Out-Null
+New-Item -ItemType Directory -Force .\build\fire-tv\v2.0.48 | Out-Null
 
-# Beta 2.0.47
+# Beta 2.0.48
 flutter build apk --release --target-platform android-arm,android-arm64 `
-  --build-name 2.0.47 --build-number 410024 --no-tree-shake-icons
+  --build-name 2.0.48 --build-number 410025 --no-tree-shake-icons
 Copy-Item .\build\app\outputs\flutter-apk\app-release.apk `
-  .\build\fire-tv\v2.0.47\TetoTV-v2.0.47-universal.apk
+  .\build\fire-tv\v2.0.48\TetoTV-v2.0.48-universal.apk
 
 .\tool\release\verify_release_apk.ps1 `
   -Channel Beta `
-  -ApkPath .\build\fire-tv\v2.0.47\TetoTV-v2.0.47-universal.apk
+  -ApkPath .\build\fire-tv\v2.0.48\TetoTV-v2.0.48-universal.apk
 
 .\tool\release\verify_native_redistribution.ps1 `
   -RequireResolvedBinaries `
   -ResolvedBinaryDirectory .\build\native-playback\outputs `
-  -StageBundle -ReleaseTag v2.0.47
+  -StageBundle -ReleaseTag v2.0.48
 
 .\tool\release\new_release_checksums.ps1 `
-  -ApkPath .\build\fire-tv\v2.0.47\TetoTV-v2.0.47-universal.apk `
-  -NativeSourcePath .\build\release-compliance\v2.0.47\TetoTV-v2.0.47-native-playback-sources.zip `
-  -OutputPath .\build\fire-tv\v2.0.47\SHA256SUMS
+  -ApkPath .\build\fire-tv\v2.0.48\TetoTV-v2.0.48-universal.apk `
+  -NativeSourcePath .\build\release-compliance\v2.0.48\TetoTV-v2.0.48-native-playback-sources.zip `
+  -OutputPath .\build\fire-tv\v2.0.48\SHA256SUMS
 
 .\tool\release\verify_release_payloads.ps1 `
   -Channel Beta `
-  -ApkPath .\build\fire-tv\v2.0.47\TetoTV-v2.0.47-universal.apk `
-  -NativeSourcePath .\build\release-compliance\v2.0.47\TetoTV-v2.0.47-native-playback-sources.zip `
-  -ChecksumsPath .\build\fire-tv\v2.0.47\SHA256SUMS `
-  -ReleaseNotesPath .\docs\RELEASE_NOTES_2.0.47.md
+  -ApkPath .\build\fire-tv\v2.0.48\TetoTV-v2.0.48-universal.apk `
+  -NativeSourcePath .\build\release-compliance\v2.0.48\TetoTV-v2.0.48-native-playback-sources.zip `
+  -ChecksumsPath .\build\fire-tv\v2.0.48\SHA256SUMS `
+  -ReleaseNotesPath .\docs\RELEASE_NOTES_2.0.48.md
 ```
 
 The final payload check requires all five exact, source-built native JARs

--- a/docs/DIRECT_TORRENT_STREAMING.md
+++ b/docs/DIRECT_TORRENT_STREAMING.md
@@ -35,9 +35,9 @@ and the MPL-covered source snapshots when redistributing the APK.
 
 ## Security and lifecycle boundary
 
-- ARM64 reports the capability on 4 KiB and 16 KiB page-size devices. The
-  pinned upstream ARM32 binary is 4 KiB-aligned, so ARM32 reports the
-  capability only on a 4 KiB runtime and fails closed on larger page sizes.
+- ARM64 and ARM32 report the capability on 4 KiB and 16 KiB page-size devices.
+  The TetoTV ARMv7 source build explicitly links 16 KiB maximum/common page
+  sizes because NDK r28's default ARMv7 layout is only 4 KiB-aligned.
 - The app accepts a magnet only through its internal platform call. It is not
   returned to Flutter, persisted, or logged.
 - MPV receives a `127.0.0.1` URL with a random 256-bit path. The bridge accepts

--- a/docs/RELEASE_NOTES_2.0.48.md
+++ b/docs/RELEASE_NOTES_2.0.48.md
@@ -1,0 +1,38 @@
+# TetoTV 2.0.48 Beta
+
+> [!WARNING]
+> No independent native-license review: This Beta has not received independent native-library licensing review. Automated checks verify the APK, native-source bundle, notices, pinned inputs, and checksums, but do not establish legal compliance or reproducible builds.
+
+This Beta focuses on dependable playback recovery, safer Discord Rich Presence lifecycle handling, more useful diagnostics, and a cleaner Settings experience across TVs and phones.
+
+## What's changed
+
+- Settings are reorganized into Appearance, Playback, Services, Accounts, and System so related controls are easier to find without removing existing functionality.
+- The Settings layout uses consistent dark cards, clear pink focus states, responsive two-column TV organization, and a single-column phone presentation.
+- TV Settings controls, cards, tabs, dialogs, and spacing are substantially more compact so more options fit on screen without changing the existing mobile layout.
+- Offline download controls now live with source and media services instead of occupying a separate Settings tab; the Download Manager and every existing download option remain available.
+- Developer release history now keeps lower-build releases visible but clearly disabled, preventing a failed download/install attempt when Android cannot perform an in-place downgrade.
+- Proxied HLS streams receive an appropriate first-frame readiness budget, preventing valid streams that need more than 12 seconds to start from being abandoned prematurely.
+- Automatic fallback advances cleanly past failed direct-stream validation and records each failed candidate once for more useful troubleshooting.
+- Optional HLS metadata inspection is deduplicated, bounded, and concurrent so compatible extensions return usable results sooner.
+- Explicit VOD playlists that omit `#EXT-X-ENDLIST` are safely finalized for playback, while live, event, low-latency, and otherwise mutable playlists remain blocked from an unsafe frozen rewrite.
+- Discord Rich Presence operations are serialized and stale callbacks are invalidated, preventing overlapping activity writes, disconnects, and reconnects from racing the native WebSocket lifecycle.
+- Immediate Discord reconnects now wait for both token readiness and complete socket teardown before opening exactly one replacement connection.
+- Diagnostics retain a larger bounded event window, aggregate repeated technical stream failures, classify interrupted playback sessions, and preserve whether the interruption was native, Java, Flutter, ANR, or another platform failure.
+- TetoTV still does not bundle, recommend, or endorse content providers. Users choose and configure their own lawful services and extensions, and the existing source-safety checks remain enforced.
+- Development disclosure: TetoTV includes code created and reviewed with AI-assisted development tools. Releases are tested and maintained by the project owner.
+
+## Release assets
+
+- `TetoTV-v2.0.48-universal.apk`
+- `TetoTV-v2.0.48-native-playback-sources.zip`
+- `SHA256SUMS`
+
+## Beta notes
+
+- This is a Beta-channel build with Android build code `410025`.
+- No Public APK is being published with this release.
+- Skip-button availability still depends on valid timing data from the configured metadata service or TetoTV's validated local cache; TetoTV does not guess unsafe skip points when that service is unavailable.
+- Android does not permit an in-place install over an APK with a higher build code. A future Public counterpart must use build code `410025` or newer for data-preserving channel switching.
+
+<!-- tetotv-android-version-code: 410025 -->

--- a/docs/UPDATE_CHANNELS.md
+++ b/docs/UPDATE_CHANNELS.md
@@ -35,11 +35,11 @@ Beta reads completed 2.x releases from:
 https://api.github.com/repos/LindersOSX/TetoTV-Beta/releases/latest
 ```
 
-The current Beta source build is `v2.0.42` with Android build code `410019`.
+The current Beta source build is `v2.0.48` with Android build code `410025`.
 Its release title is:
 
 ```text
-TetoTV 2.0.42 Beta - Android TV / Google TV / Fire TV
+TetoTV 2.0.48 Beta - Android TV / Google TV / Fire TV
 ```
 
 Publish it as a normal, non-draft, non-prerelease GitHub release so
@@ -72,7 +72,7 @@ proxy.
 Release notes must include the exact asset names and this build-code marker:
 
 ```html
-<!-- tetotv-android-version-code: 410019 -->
+<!-- tetotv-android-version-code: 410025 -->
 ```
 
 When build-code metadata is present, the updater rejects a known lower build
@@ -94,10 +94,10 @@ These rules apply equally on phones, Android TV, Google TV, and Fire TV.
 
 ## Switching and rollback
 
-The current Beta uses build code `410019`. No Public counterpart is available.
+The current Beta uses build code `410025`. No Public counterpart is available.
 An older Public install can move to this Beta when Android accepts the higher
 build code, but it cannot move back in place until a future Public build uses
-code `410019` or higher. Uninstalling first permits an older APK but deletes
+code `410025` or higher. Uninstalling first permits an older APK but deletes
 local application data. Developer Mode and in-app settings cannot override
 this Android rule.
 

--- a/lib/core/diagnostics/explicit_diagnostics_reporter.dart
+++ b/lib/core/diagnostics/explicit_diagnostics_reporter.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 import 'dart:math';
 
 import 'package:anime_tv/core/config/app_config.dart';
+import 'package:anime_tv/core/diagnostics/playback_session_diagnostics.dart';
 import 'package:anime_tv/core/platform/android_tv_bridge.dart';
 import 'package:anime_tv/core/storage/tetotv_database.dart';
 import 'package:dio/dio.dart';
@@ -64,8 +65,29 @@ Map<String, Object?> attachRecentCrashSummaries(
   final bounded = retained.length > maximumRecentCrashSummaries
       ? retained.sublist(retained.length - maximumRecentCrashSummaries)
       : retained;
+  final playbackDiagnostics = derivePlaybackSessionDiagnostics(
+    diagnostics['diagnosticEvents'],
+    interruptions: [
+      for (final crash in bounded)
+        if (_crashTimestamp(crash) case final DateTime timestamp)
+          PlaybackDiagnosticInterruption(
+            timestamp: timestamp,
+            reasonCode: switch (crash['kind']?.toString()) {
+              'native' => 'native_crash',
+              'java' => 'java_crash',
+              'anr' => 'anr',
+              'flutter' => 'flutter_crash',
+              _ => 'platform_crash',
+            },
+          ),
+    ],
+  );
   return {
     ...diagnostics,
+    // Re-derive persisted sessions with the platform crash timeline attached.
+    // A process death cannot write its own final playback event, so without
+    // this correlation the last failed session remains misleadingly active.
+    ...playbackDiagnostics,
     'recentCrashSummaryWindow': {
       'schema': 'tetotv-local-crash-summaries-v1',
       'hours': diagnosticHistoryWindow.inHours,
@@ -356,7 +378,7 @@ String buildRedactedDiagnosticsText({
     payload,
     depth: 0,
     stringMaximum: 4000,
-    listMaximum: 300,
+    listMaximum: maximumPersistedDiagnosticEvents,
     truncation: fullTruncation,
   );
   final fullPayload = _snapshotWithCompleteness(
@@ -368,7 +390,8 @@ String buildRedactedDiagnosticsText({
   if (text.length <= maximumExplicitDiagnosticsCharacters) return text;
 
   // Preserve valid, parseable JSON if an unusual device produces an enormous
-  // capability list. The normal path above retains all 300 database events.
+  // capability list. The normal path above retains the complete database
+  // event ring.
   // This fallback keeps representative data from every section and declares
   // the reduction instead of cutting through a JSON value.
   final compactTruncation = _SnapshotTruncation();

--- a/lib/core/diagnostics/playback_session_diagnostics.dart
+++ b/lib/core/diagnostics/playback_session_diagnostics.dart
@@ -108,10 +108,24 @@ enum PlaybackDiagnosticOutcome {
   final String wireValue;
 }
 
+class PlaybackDiagnosticInterruption {
+  const PlaybackDiagnosticInterruption({
+    required this.timestamp,
+    required this.reasonCode,
+  });
+
+  final DateTime timestamp;
+  final String reasonCode;
+}
+
 /// Builds privacy-safe playback timelines from the bounded diagnostic event
 /// ring. Only a strict vocabulary of technical fields is copied. Free-form
 /// messages and unknown context never enter a playback session summary.
-Map<String, Object?> derivePlaybackSessionDiagnostics(Object? rawEvents) {
+Map<String, Object?> derivePlaybackSessionDiagnostics(
+  Object? rawEvents, {
+  Iterable<PlaybackDiagnosticInterruption> interruptions =
+      const <PlaybackDiagnosticInterruption>[],
+}) {
   final grouped = <String, List<Map<String, Object?>>>{};
   if (rawEvents is Iterable) {
     for (final raw in rawEvents) {
@@ -304,6 +318,64 @@ Map<String, Object?> derivePlaybackSessionDiagnostics(Object? rawEvents) {
       'droppedTimelineEvents': timeline.length - boundedTimeline.length,
       'timeline': boundedTimeline,
     });
+  }
+  final safeInterruptions =
+      interruptions
+          .map(
+            (value) => PlaybackDiagnosticInterruption(
+              timestamp: value.timestamp.toUtc(),
+              reasonCode: value.reasonCode,
+            ),
+          )
+          .toList(growable: false)
+        ..sort((left, right) => left.timestamp.compareTo(right.timestamp));
+  final interruptionReasonsBySessionId = <Object?, String>{};
+  for (final interruption in safeInterruptions) {
+    final timestamp = interruption.timestamp;
+    Map<String, Object?>? nearest;
+    DateTime? nearestLastEvent;
+    for (final session in sessions) {
+      if (session['finalOutcome'] != 'in_progress') continue;
+      final lastEventAt = DateTime.tryParse(
+        session['lastEventAt']?.toString() ?? '',
+      )?.toUtc();
+      if (lastEventAt == null) continue;
+      final delay = timestamp.difference(lastEventAt);
+      if (delay.isNegative || delay > const Duration(minutes: 5)) continue;
+      if (nearestLastEvent == null || lastEventAt.isAfter(nearestLastEvent)) {
+        nearest = session;
+        nearestLastEvent = lastEventAt;
+      }
+    }
+    if (nearest != null) {
+      interruptionReasonsBySessionId[nearest['sessionId']] =
+          interruption.reasonCode;
+    }
+  }
+  for (final session in sessions) {
+    if (session['finalOutcome'] != 'in_progress') continue;
+    final lastEventAt = DateTime.tryParse(
+      session['lastEventAt']?.toString() ?? '',
+    )?.toUtc();
+    if (lastEventAt == null) continue;
+    final interruptionReason =
+        interruptionReasonsBySessionId[session['sessionId']];
+    if (interruptionReason != null) {
+      session['finalOutcome'] = 'failed';
+      session['finalReasonCode'] = interruptionReason;
+      continue;
+    }
+    final superseded = sessions.any((candidate) {
+      if (identical(candidate, session)) return false;
+      final candidateStart = DateTime.tryParse(
+        candidate['startedAt']?.toString() ?? '',
+      )?.toUtc();
+      return candidateStart != null && candidateStart.isAfter(lastEventAt);
+    });
+    if (superseded) {
+      session['finalOutcome'] = 'failed';
+      session['finalReasonCode'] = 'session_superseded';
+    }
   }
   sessions.sort(
     (left, right) => right['lastEventAt'].toString().compareTo(

--- a/lib/core/storage/tetotv_database.dart
+++ b/lib/core/storage/tetotv_database.dart
@@ -14,8 +14,10 @@ const diagnosticHistoryWindow = Duration(hours: 48);
 // it; 240 entries allowed title-artwork noise to evict the evidence needed to
 // correlate a source-picker result with an intermittent player failure. Keep
 // this aligned with the explicit report sanitizer's full-size list bound so a
-// chronological export never drops the newest events.
-const maximumPersistedDiagnosticEvents = 300;
+// chronological export never drops the newest events. Five hundred entries
+// cover several provider searches plus their playback fallbacks while still
+// fitting inside the explicit report's hard size limit in normal operation.
+const maximumPersistedDiagnosticEvents = 500;
 const diagnosticEventSchema = 'tetotv-diagnostic-events-v3';
 
 const _diagnosticDroppedAgeKey = 'dropped_age';
@@ -1276,18 +1278,26 @@ Future<Map<String, Object?>> loadRecentDiagnosticOperationalHistory(
   final end = (now ?? DateTime.now()).toUtc();
   final start = end.subtract(diagnosticHistoryWindow);
   final arguments = [start.millisecondsSinceEpoch, end.millisecondsSinceEpoch];
+  // A direct/Web fallback frequently changes its privacy-sensitive stream
+  // identity while preserving the same technical failure. Group by the safe
+  // reason at export time so a run of identical failures is visible as one
+  // useful counter instead of many indistinguishable `count: 1` rows.
   final failures = await database.rawQuery(
     '''
-      SELECT reason, failure_count, last_failed_at
+      SELECT COALESCE(reason, '') AS reason,
+             SUM(failure_count) AS failure_count,
+             COUNT(*) AS failure_record_count,
+             MAX(last_failed_at) AS last_failed_at
       FROM stream_failures
       WHERE last_failed_at >= ? AND last_failed_at <= ?
+      GROUP BY COALESCE(reason, '')
       ORDER BY last_failed_at DESC LIMIT ?
     ''',
     [...arguments, failureCapacity],
   );
   final failureCount = Sqflite.firstIntValue(
     await database.rawQuery('''
-        SELECT COUNT(*) FROM stream_failures
+        SELECT COUNT(DISTINCT COALESCE(reason, '')) FROM stream_failures
         WHERE last_failed_at >= ? AND last_failed_at <= ?
       ''', arguments),
   );
@@ -1326,6 +1336,8 @@ Future<Map<String, Object?>> loadRecentDiagnosticOperationalHistory(
           if (row['reason'] case final String reason)
             'reason': redactDiagnosticValue(reason),
           'lifetimeFailureCount': (row['failure_count'] as num?)?.toInt() ?? 0,
+          'failureRecordCount':
+              (row['failure_record_count'] as num?)?.toInt() ?? 0,
           'lastFailedAt': row['last_failed_at'],
         },
     ],

--- a/lib/features/marketplace/data/seanime_javascript_provider.dart
+++ b/lib/features/marketplace/data/seanime_javascript_provider.dart
@@ -675,18 +675,18 @@ Future<List<Map<String, dynamic>>> _expandHlsVariants(
   // the manifest still owns switchable English/Japanese audio renditions.
   // Inspect every bounded HLS candidate rather than only Auto/Adaptive labels;
   // otherwise those masters retain the provider's generic Sub label.
-  final hlsCandidates = raw.where(isHlsInspectionCandidate).take(6).toList();
-  for (var offset = 0; offset < hlsCandidates.length; offset += 2) {
-    cancellation?.throwIfCancelled();
-    final end = (offset + 2).clamp(0, hlsCandidates.length);
-    final groups = await Future.wait(
-      hlsCandidates
-          .sublist(offset, end)
-          .map((item) => _hlsVariantsForItem(item, cancellation)),
-    );
-    for (final variants in groups) {
-      result.addAll(variants);
-    }
+  // Enrichment is optional: the original streams remain usable even when a
+  // master cannot be inspected. Deduplicate mirrors before doing I/O and run
+  // the small bounded set together. The previous three sequential batches
+  // could consume nearly the provider's entire 20-second deadline after the
+  // provider had already returned valid streams.
+  final hlsCandidates = selectHlsInspectionCandidates(raw);
+  cancellation?.throwIfCancelled();
+  final groups = await Future.wait(
+    hlsCandidates.map((item) => _hlsVariantsForItem(item, cancellation)),
+  );
+  for (final variants in groups) {
+    result.addAll(variants);
   }
   return mergeDuplicateWebStreamItems(result).take(120).toList(growable: false);
 }
@@ -754,6 +754,25 @@ bool isHlsInspectionCandidate(Map<String, dynamic> item) {
   return url.contains('.m3u8') ||
       RegExp(r'(^|\s)(hls|m3u8)(\s|$)').hasMatch(normalizedType) ||
       normalizedType.contains('mpegurl');
+}
+
+/// Selects a small, unique set of safe HLS URLs for optional metadata
+/// inspection. Providers commonly repeat one master under several labels;
+/// inspecting those duplicates only delays the stream picker.
+List<Map<String, dynamic>> selectHlsInspectionCandidates(
+  Iterable<Map<String, dynamic>> items, {
+  int maximum = 4,
+}) {
+  if (maximum <= 0) return const [];
+  final selected = <String, Map<String, dynamic>>{};
+  for (final item in items) {
+    if (!isHlsInspectionCandidate(item)) continue;
+    final uri = safePublicHttpsUri(item['url']);
+    if (uri == null) continue;
+    selected.putIfAbsent(uri.toString(), () => item);
+    if (selected.length >= maximum) break;
+  }
+  return selected.values.toList(growable: false);
 }
 
 bool _isTransientHlsInspectionStatus(int status) =>
@@ -846,9 +865,9 @@ Future<List<Map<String, dynamic>>> _hlsVariantsForItem(
             'headers': item['headers'] is Map ? item['headers'] : const {},
           },
         },
-        connectTimeout: Duration(seconds: attempt == 0 ? 4 : 3),
-        receiveTimeout: Duration(seconds: attempt == 0 ? 4 : 3),
-        overallTimeout: Duration(seconds: attempt == 0 ? 6 : 4),
+        connectTimeout: Duration(seconds: attempt == 0 ? 3 : 2),
+        receiveTimeout: Duration(seconds: attempt == 0 ? 3 : 2),
+        overallTimeout: Duration(seconds: attempt == 0 ? 4 : 3),
         maximumResponseBytes: 512 * 1024,
         cancellation: cancellation,
       ),

--- a/lib/features/marketplace/data/web_playback_proxy.dart
+++ b/lib/features/marketplace/data/web_playback_proxy.dart
@@ -657,7 +657,16 @@ class WebPlaybackProxy {
             line.startsWith('#EXT-X-TARGETDURATION:') ||
             line.startsWith('#EXT-X-MEDIA-SEQUENCE:'),
       );
-      if (isMediaPlaylist && !trimmed.contains('#EXT-X-ENDLIST')) {
+      final hasEndList = trimmed.contains('#EXT-X-ENDLIST');
+      final explicitlyVod = trimmed.any(
+        (line) => line.toUpperCase() == '#EXT-X-PLAYLIST-TYPE:VOD',
+      );
+      // A malformed VOD manifest may omit ENDLIST despite explicitly declaring
+      // that it is finite. The proxy already caches an immutable rewrite, so
+      // that declared VOD can be closed safely. Never freeze an ordinary open
+      // media/event playlist: doing so would truncate a real live stream.
+      final closeDeclaredVod = isMediaPlaylist && !hasEndList && explicitlyVod;
+      if (isMediaPlaylist && !hasEndList && !explicitlyVod) {
         throw const FormatException(
           'Live or mutable HLS playlists are not allowed.',
         );
@@ -765,6 +774,7 @@ class WebPlaybackProxy {
           'The HLS manifest has no complete media references.',
         );
       }
+      if (closeDeclaredVod) rewritten.add('#EXT-X-ENDLIST');
       final bytes = utf8.encode(rewritten.join('\n'));
       if (bytes.length > limits.maximumManifestBytes) {
         throw const FormatException(

--- a/lib/features/player/presentation/player_failover_coordinator.dart
+++ b/lib/features/player/presentation/player_failover_coordinator.dart
@@ -100,6 +100,35 @@ class PlayerMediaReadinessException implements Exception {
       'No video frames were rendered after the stream was opened.';
 }
 
+/// Returns a readiness budget that accounts for app-owned HLS proxy startup.
+///
+/// A proxied HLS master can require one additional, DNS-pinned request to load
+/// the selected rendition before MPV receives its first media bytes. Ordinary
+/// candidates keep the original 12-second bound; HLS web streams get the same
+/// 20-second ceiling used by the proxy and native network layer. This prevents
+/// a healthy rendition that delivers its first bytes just after 12 seconds
+/// from being abandoned while still keeping dead candidates bounded.
+int playerMediaReadinessMaxPolls({
+  required bool isWebStream,
+  required String? mediaContentType,
+  Duration pollInterval = const Duration(milliseconds: 200),
+}) {
+  final normalizedType = mediaContentType
+      ?.toLowerCase()
+      .split(';')
+      .first
+      .trim();
+  final isHls =
+      normalizedType == 'application/vnd.apple.mpegurl' ||
+      normalizedType == 'application/x-mpegurl';
+  final timeout = isWebStream && isHls
+      ? const Duration(seconds: 20)
+      : const Duration(seconds: 12);
+  final intervalMicros = pollInterval.inMicroseconds;
+  if (intervalMicros <= 0) return 1;
+  return (timeout.inMicroseconds / intervalMicros).ceil().clamp(1, 1000);
+}
+
 /// Waits for the player to prove that a newly opened candidate can decode
 /// video. `Player.open` only confirms that MPV accepted the URL; it can return
 /// before a manifest, segment, or decoder has produced any media.

--- a/lib/features/player/presentation/tv_player_screen.dart
+++ b/lib/features/player/presentation/tv_player_screen.dart
@@ -2662,6 +2662,10 @@ class _MpvTvPlayerScreenState extends ConsumerState<MpvTvPlayerScreen> {
               mounted &&
               !_engineHandoffInProgress &&
               _mediaOpenRevision == readinessRevision,
+          maxPolls: playerMediaReadinessMaxPolls(
+            isWebStream: _currentStream.isWebStream,
+            mediaContentType: _currentStream.mediaContentType,
+          ),
         );
         if (!mediaReady) {
           // Route disposal and an intentional player handoff are cancellation,
@@ -3220,6 +3224,23 @@ class _MpvTvPlayerScreenState extends ConsumerState<MpvTvPlayerScreen> {
     return null;
   }
 
+  Future<void> _recordStreamFailureBestEffort({
+    required String deviceKey,
+    required String infoHash,
+    required Object reason,
+  }) async {
+    try {
+      await _database.recordStreamFailure(
+        deviceKey: deviceKey,
+        infoHash: infoHash,
+        reason: reason.toString(),
+      );
+    } catch (_) {
+      // Failure history is diagnostic state. A database write must never stop
+      // the player from trying the next candidate.
+    }
+  }
+
   Future<void> _tryNextStream(
     String reason, {
     bool notify = true,
@@ -3251,7 +3272,7 @@ class _MpvTvPlayerScreenState extends ConsumerState<MpvTvPlayerScreen> {
       );
       final profile = await AndroidTvBridge.instance.getDeviceProfile();
       if (!mounted || _engineHandoffInProgress) return;
-      await _database.recordStreamFailure(
+      await _recordStreamFailureBestEffort(
         deviceKey: profile.key,
         infoHash: _currentRelease.infoHash,
         reason: reason,
@@ -3283,7 +3304,14 @@ class _MpvTvPlayerScreenState extends ConsumerState<MpvTvPlayerScreen> {
               await resolvedStream?.playbackLease?.close();
               return false;
             }
-            if (ready == null) continue;
+            if (ready == null) {
+              await _recordStreamFailureBestEffort(
+                deviceKey: profile.key,
+                infoHash: candidate.infoHash,
+                reason: 'Fallback resolution returned no playable stream.',
+              );
+              continue;
+            }
             _source = ready.uri.toString();
             _currentRelease = candidate;
             _currentStream = ready;
@@ -3334,6 +3362,11 @@ class _MpvTvPlayerScreenState extends ConsumerState<MpvTvPlayerScreen> {
             _softwareFallbackUsed = previousSoftwareFallbackUsed;
             _decoderMode = previousDecoderMode;
             _videoFrameSeen = previousVideoFrameSeen;
+            await _recordStreamFailureBestEffort(
+              deviceKey: profile.key,
+              infoHash: candidate.infoHash,
+              reason: error,
+            );
             if (isTerminalDebridFailoverFailure(error)) {
               terminalFailure = error;
               return false;
@@ -3392,6 +3425,7 @@ class _MpvTvPlayerScreenState extends ConsumerState<MpvTvPlayerScreen> {
                 candidates: directCandidates,
                 failoverReason: reason,
                 notify: notify,
+                deviceKey: profile.key,
               ),
               PlayerFailoverClass.debrid =>
                 playerFailoverClassIsAvailable(
@@ -3438,6 +3472,7 @@ class _MpvTvPlayerScreenState extends ConsumerState<MpvTvPlayerScreen> {
     Iterable<PlaybackStreamOption>? candidates,
     Object? failoverReason,
     bool notify = true,
+    required String deviceKey,
   }) async {
     if (!mounted || _engineHandoffInProgress) {
       return false;
@@ -3522,7 +3557,7 @@ class _MpvTvPlayerScreenState extends ConsumerState<MpvTvPlayerScreen> {
             );
           }
           return true;
-        } catch (_) {
+        } catch (error) {
           await preparedOption?.stream.playbackLease?.close();
           if (!mounted || _engineHandoffInProgress) rethrow;
           _source = previousSource;
@@ -3534,6 +3569,11 @@ class _MpvTvPlayerScreenState extends ConsumerState<MpvTvPlayerScreen> {
           _softwareFallbackUsed = previousSoftwareFallbackUsed;
           _decoderMode = previousDecoderMode;
           _videoFrameSeen = previousVideoFrameSeen;
+          await _recordStreamFailureBestEffort(
+            deviceKey: deviceKey,
+            infoHash: candidate.release.infoHash,
+            reason: error,
+          );
           rethrow;
         }
       },
@@ -4462,6 +4502,7 @@ class _MpvTvPlayerScreenState extends ConsumerState<MpvTvPlayerScreen> {
           "${error.toString().replaceFirst('FormatException: ', '')}",
         );
       }
+      if (silent) rethrow;
       return null;
     }
   }

--- a/lib/features/settings/application/settings_preferences_controller.dart
+++ b/lib/features/settings/application/settings_preferences_controller.dart
@@ -1844,6 +1844,70 @@ class SettingsPreferencesController extends StateNotifier<SettingsPreferences> {
     });
   }
 
+  /// Restores visual and navigation preferences without changing playback.
+  ///
+  /// Unlike [resetAppearance], this deliberately leaves captions, seeking,
+  /// audio, player selection, filler labels, and external-player data alone.
+  Future<void> resetAppearanceAndNavigation() {
+    const defaults = SettingsPreferences();
+    const keys = [
+      _homeLayoutKey,
+      _showSearchKey,
+      _showHomeKey,
+      _showMyListKey,
+      _showDiscoverKey,
+      _showCalendarKey,
+      _showWatchTogetherKey,
+      _showDownloadsKey,
+      _showSettingsKey,
+      _topNavigationOrderKey,
+      _settingsEntryPlacementKey,
+      _navigationChromeSizeKey,
+      _showHeroKey,
+      _showPosterMetadataKey,
+      _showCardSubtitlesKey,
+      _navigationSoundsKey,
+      _clickSoundsKey,
+      _defaultLandingPageKey,
+      _thumbnailScaleKey,
+      _interfaceScaleKey,
+      _contentDensityKey,
+      _interfaceModeKey,
+      _showTitleStyleKey,
+    ];
+    _markMutated(keys);
+    state = state.copyWith(
+      homeLayout: defaults.homeLayout,
+      showSearch: defaults.showSearch,
+      showHome: defaults.showHome,
+      showMyList: defaults.showMyList,
+      showDiscover: defaults.showDiscover,
+      showCalendar: defaults.showCalendar,
+      showWatchTogether: defaults.showWatchTogether,
+      showDownloads: defaults.showDownloads,
+      showSettings: defaults.showSettings,
+      topNavigationOrder: defaults.topNavigationOrder,
+      settingsEntryPlacement: defaults.settingsEntryPlacement,
+      navigationChromeSize: defaults.navigationChromeSize,
+      showHero: defaults.showHero,
+      showPosterMetadata: defaults.showPosterMetadata,
+      showCardSubtitles: defaults.showCardSubtitles,
+      navigationSounds: defaults.navigationSounds,
+      clickSounds: defaults.clickSounds,
+      defaultLandingPage: defaults.defaultLandingPage,
+      thumbnailScale: defaults.thumbnailScale,
+      interfaceScale: defaults.interfaceScale,
+      contentDensity: defaults.contentDensity,
+      interfaceMode: defaults.interfaceMode,
+      showTitleStyle: defaults.showTitleStyle,
+    );
+    return _enqueueStorage(() async {
+      for (final key in keys) {
+        await _delete(key);
+      }
+    });
+  }
+
   Future<void> resetAppearance() {
     const defaults = SettingsPreferences();
     const keys = [

--- a/lib/features/settings/presentation/accounts_screen.dart
+++ b/lib/features/settings/presentation/accounts_screen.dart
@@ -44,7 +44,7 @@ final directTorrentSettingsCapabilityReaderProvider =
       return AndroidTvBridge.instance.getDirectTorrentCapability;
     });
 
-enum _SettingsArea { customize, streaming, tracking, system }
+enum _SettingsArea { appearance, playback, services, accounts, system }
 
 enum _CustomizationSection {
   homeShelves,
@@ -151,9 +151,6 @@ class _AccountsScreenState extends ConsumerState<AccountsScreen> {
   final _customizationFocus = FocusNode(
     debugLabel: 'accounts.customization.first',
   );
-  final _customizeSectionsToggleFocus = FocusNode(
-    debugLabel: 'accounts.customization.toggle-all',
-  );
   final _homeShelvesSectionFocus = FocusNode(
     debugLabel: 'accounts.section.home-shelves',
   );
@@ -165,6 +162,18 @@ class _AccountsScreenState extends ConsumerState<AccountsScreen> {
   );
   final _featuredHomeContentFocus = FocusNode(
     debugLabel: 'accounts.customization.home-content.featured',
+  );
+  final _posterMetadataFocus = FocusNode(
+    debugLabel: 'accounts.customization.home-content.poster-metadata',
+  );
+  final _continueWatchingFocus = FocusNode(
+    debugLabel: 'accounts.customization.home-content.continue-watching',
+  );
+  final _navigationSizeFocus = FocusNode(
+    debugLabel: 'accounts.customization.navigation-size',
+  );
+  final _menuOrderFocus = FocusNode(
+    debugLabel: 'accounts.customization.menu-order',
   );
   final _inputFeedbackSectionFocus = FocusNode(
     debugLabel: 'accounts.section.input-feedback',
@@ -238,6 +247,12 @@ class _AccountsScreenState extends ConsumerState<AccountsScreen> {
   final _resetAppFocus = FocusNode(debugLabel: 'accounts.system.reset-app');
   final _privacyFocus = FocusNode(debugLabel: 'accounts.system.privacy');
   final _legalFocus = FocusNode(debugLabel: 'accounts.system.legal');
+  final _anonymousCrashReportingFocus = FocusNode(
+    debugLabel: 'accounts.system.anonymous-crash-reports',
+  );
+  final _anonymousUsageCountFocus = FocusNode(
+    debugLabel: 'accounts.system.anonymous-live-count',
+  );
   final _areaFocusNodes = {
     for (final area in _SettingsArea.values)
       area: FocusNode(debugLabel: 'accounts.area.${area.name}'),
@@ -250,6 +265,12 @@ class _AccountsScreenState extends ConsumerState<AccountsScreen> {
     for (final destination in TopNavigationDestination.values)
       destination: FocusNode(
         debugLabel: 'accounts.customization.navigation.${destination.name}',
+      ),
+  };
+  final _menuOrderDialogFocusNodes = {
+    for (final destination in TopNavigationDestination.values)
+      destination: FocusNode(
+        debugLabel: 'accounts.customization.menu-order.${destination.name}',
       ),
   };
   final _directionalRepeatGate = TvDirectionalRepeatGate(
@@ -275,23 +296,6 @@ class _AccountsScreenState extends ConsumerState<AccountsScreen> {
       ),
   };
   int _systemActivationCount = 0;
-
-  bool get _allCustomizationSectionsExpanded =>
-      _expandedCustomizationSections.length ==
-      _CustomizationSection.values.length;
-
-  void _toggleAllCustomizationSections() {
-    final expand = !_allCustomizationSectionsExpanded;
-    setState(() {
-      if (!expand) {
-        _expandedCustomizationSections.clear();
-      } else {
-        _expandedCustomizationSections.addAll(_CustomizationSection.values);
-      }
-    });
-    _customizeSectionsToggleFocus.requestFocus();
-    _recordCustomizationSectionToggle(section: 'all', expanded: expand);
-  }
 
   void _setCustomizationSectionExpanded(
     _CustomizationSection section,
@@ -330,17 +334,6 @@ class _AccountsScreenState extends ConsumerState<AccountsScreen> {
     });
   }
 
-  void _scrollSettingsToEnd() {
-    if (!mounted || !_settingsScrollController.hasClients) return;
-    unawaited(
-      _settingsScrollController.animateTo(
-        _settingsScrollController.position.maxScrollExtent,
-        duration: const Duration(milliseconds: 140),
-        curve: Curves.easeOutCubic,
-      ),
-    );
-  }
-
   void _recordCustomizationSectionToggle({
     required String section,
     required bool expanded,
@@ -361,8 +354,8 @@ class _AccountsScreenState extends ConsumerState<AccountsScreen> {
   void initState() {
     super.initState();
     _activeArea = widget.openTracking
-        ? _SettingsArea.tracking
-        : _SettingsArea.customize;
+        ? _SettingsArea.accounts
+        : _SettingsArea.appearance;
   }
 
   Future<void> _setDirectTorrentEnabled(bool enabled) async {
@@ -468,11 +461,14 @@ class _AccountsScreenState extends ConsumerState<AccountsScreen> {
     _downloadManagerFocus.dispose();
     _watchTogetherFocus.dispose();
     _customizationFocus.dispose();
-    _customizeSectionsToggleFocus.dispose();
     _homeShelvesSectionFocus.dispose();
     _displaySectionFocus.dispose();
     _homeNavigationSectionFocus.dispose();
     _featuredHomeContentFocus.dispose();
+    _posterMetadataFocus.dispose();
+    _continueWatchingFocus.dispose();
+    _navigationSizeFocus.dispose();
+    _menuOrderFocus.dispose();
     _inputFeedbackSectionFocus.dispose();
     _closedCaptionsSectionFocus.dispose();
     _captionTextColorFocus.dispose();
@@ -513,6 +509,8 @@ class _AccountsScreenState extends ConsumerState<AccountsScreen> {
     _resetAppFocus.dispose();
     _privacyFocus.dispose();
     _legalFocus.dispose();
+    _anonymousCrashReportingFocus.dispose();
+    _anonymousUsageCountFocus.dispose();
     for (final node in _areaFocusNodes.values) {
       node.dispose();
     }
@@ -520,6 +518,9 @@ class _AccountsScreenState extends ConsumerState<AccountsScreen> {
       node.dispose();
     }
     for (final node in _topNavigationRowFocusNodes.values) {
+      node.dispose();
+    }
+    for (final node in _menuOrderDialogFocusNodes.values) {
       node.dispose();
     }
     for (final node in _autoPickSourceRowFocusNodes.values) {
@@ -618,7 +619,6 @@ class _AccountsScreenState extends ConsumerState<AccountsScreen> {
       _homeShelvesSectionFocus,
       _displaySectionFocus,
       _homeNavigationSectionFocus,
-      _featuredHomeContentFocus,
       ...topNavigationNodes,
       _inputFeedbackSectionFocus,
       _closedCaptionsSectionFocus,
@@ -629,8 +629,13 @@ class _AccountsScreenState extends ConsumerState<AccountsScreen> {
       _customizationFocus,
       _titleLanguageFocus,
       _showTitleStyleFocus,
+      _navigationSizeFocus,
+      _menuOrderFocus,
+      _customizationResetFocus,
       _debridProviderFocus,
       selectedDebridAction,
+      selectedDebridToken,
+      selectedDebridLast,
       _debridStreamsFocus,
       _marketplaceFocus,
       _debridSortFocus,
@@ -647,6 +652,10 @@ class _AccountsScreenState extends ConsumerState<AccountsScreen> {
       _watchTogetherFocus,
       _trackingProviderFocus,
       selectedTrackingAction,
+      _anilistTokenFocus,
+      _anilistSaveFocus,
+      _malTokenFocus,
+      _malSaveFocus,
       _localProfilesFocus,
       _trackingThresholdFocus,
       _subEpisodeNotificationsFocus,
@@ -661,7 +670,16 @@ class _AccountsScreenState extends ConsumerState<AccountsScreen> {
       _donateFocus,
       _clearCacheFocus,
       _privacyFocus,
+      _anonymousCrashReportingFocus,
+      _anonymousUsageCountFocus,
     };
+    if (key == LogicalKeyboardKey.arrowLeft &&
+        layout?.usesSideNavigation != true &&
+        leftEdgeNodes.contains(current) &&
+        focusNodeIsMounted(_backFocus)) {
+      _backFocus.requestFocus();
+      return KeyEventResult.handled;
+    }
     if (key == LogicalKeyboardKey.arrowLeft &&
         layout?.usesSideNavigation == true &&
         leftEdgeNodes.contains(current)) {
@@ -685,9 +703,10 @@ class _AccountsScreenState extends ConsumerState<AccountsScreen> {
       }
       if (key == LogicalKeyboardKey.arrowDown) {
         target = switch (_activeArea) {
-          _SettingsArea.customize => _customizeSectionsToggleFocus,
-          _SettingsArea.streaming => _debridProviderFocus,
-          _SettingsArea.tracking => _trackingProviderFocus,
+          _SettingsArea.appearance => _customizationFocus,
+          _SettingsArea.playback => _captionTextColorFocus,
+          _SettingsArea.services => _debridProviderFocus,
+          _SettingsArea.accounts => _trackingProviderFocus,
           _SettingsArea.system => _setupFocus,
         };
       }
@@ -695,20 +714,28 @@ class _AccountsScreenState extends ConsumerState<AccountsScreen> {
       if (key == LogicalKeyboardKey.arrowUp) {
         target = shelfIndex > 0
             ? shelfNodes[shelfIndex - 1]
-            : _homeShelvesSectionFocus;
+            : _continueWatchingFocus;
       }
       if (key == LogicalKeyboardKey.arrowDown) {
-        target = shelfIndex < shelfNodes.length - 1
-            ? shelfNodes[shelfIndex + 1]
-            : _displaySectionFocus;
+        if (shelfIndex < shelfNodes.length - 1) {
+          target = shelfNodes[shelfIndex + 1];
+        } else {
+          return KeyEventResult.handled;
+        }
       }
     }
 
     if (areaIndex >= 0 || shelfIndex >= 0) {
       // Settings-area and Home-shelf navigation were handled above.
     } else if (current == _featuredHomeContentFocus) {
+      if (key == LogicalKeyboardKey.arrowLeft) {
+        target = _customizationFocus;
+      }
+      if (key == LogicalKeyboardKey.arrowUp) {
+        target = _areaFocusNodes[_SettingsArea.appearance];
+      }
       if (key == LogicalKeyboardKey.arrowDown) {
-        target = topNavigationNodes.first;
+        target = _posterMetadataFocus;
       }
     } else if (topNavigationIndex >= 0) {
       if (key == LogicalKeyboardKey.arrowUp) {
@@ -721,19 +748,9 @@ class _AccountsScreenState extends ConsumerState<AccountsScreen> {
             ? _inputFeedbackSectionFocus
             : topNavigationNodes[topNavigationIndex + 1];
       }
-    } else if (current == _customizeSectionsToggleFocus) {
-      if (key == LogicalKeyboardKey.arrowLeft) {
-        target = _areaFocusNodes[_SettingsArea.system];
-      }
-      if (key == LogicalKeyboardKey.arrowUp) {
-        target = _areaFocusNodes[_SettingsArea.customize];
-      }
-      if (key == LogicalKeyboardKey.arrowDown) {
-        target = _homeShelvesSectionFocus;
-      }
     } else if (current == _homeShelvesSectionFocus) {
       if (key == LogicalKeyboardKey.arrowUp) {
-        target = _customizeSectionsToggleFocus;
+        target = _areaFocusNodes[_SettingsArea.appearance];
       }
       if (key == LogicalKeyboardKey.arrowDown) {
         target = focusNodeIsMounted(shelfNodes.first)
@@ -741,22 +758,46 @@ class _AccountsScreenState extends ConsumerState<AccountsScreen> {
             : _displaySectionFocus;
       }
     } else if (current == _displaySectionFocus) {
-      if (key == LogicalKeyboardKey.arrowUp) {
-        target = focusNodeIsMounted(shelfNodes.last)
-            ? shelfNodes.last
-            : _homeShelvesSectionFocus;
-      }
-      if (key == LogicalKeyboardKey.arrowDown) {
-        target = focusNodeIsMounted(_customizationFocus)
-            ? _customizationFocus
-            : _homeNavigationSectionFocus;
+      if (_activeArea == _SettingsArea.appearance) {
+        if (key == LogicalKeyboardKey.arrowUp) {
+          target = _customizationResetFocus;
+        }
+      } else {
+        if (key == LogicalKeyboardKey.arrowUp) {
+          target = focusNodeIsMounted(shelfNodes.last)
+              ? shelfNodes.last
+              : _homeShelvesSectionFocus;
+        }
+        if (key == LogicalKeyboardKey.arrowDown) {
+          target = focusNodeIsMounted(_customizationFocus)
+              ? _customizationFocus
+              : _homeNavigationSectionFocus;
+        }
       }
     } else if (current == _backFocus) {
       if (key == LogicalKeyboardKey.arrowRight ||
           key == LogicalKeyboardKey.arrowDown) {
-        target = _areaFocusNodes[_activeArea];
+        target = _activeArea == _SettingsArea.appearance
+            ? _customizationFocus
+            : _areaFocusNodes[_activeArea];
+      }
+    } else if (current == _customizationFocus) {
+      if (key == LogicalKeyboardKey.arrowUp) {
+        target = _areaFocusNodes[_SettingsArea.appearance];
+      }
+      if (key == LogicalKeyboardKey.arrowRight) {
+        target = _featuredHomeContentFocus;
+      }
+      if (key == LogicalKeyboardKey.arrowDown) {
+        target = _titleLanguageFocus;
       }
     } else if (current == _titleLanguageFocus) {
+      if (key == LogicalKeyboardKey.arrowUp) {
+        target = _customizationFocus;
+      }
+      if (key == LogicalKeyboardKey.arrowRight) {
+        target = _posterMetadataFocus;
+      }
       if (key == LogicalKeyboardKey.arrowDown) {
         target = _showTitleStyleFocus;
       }
@@ -764,8 +805,51 @@ class _AccountsScreenState extends ConsumerState<AccountsScreen> {
       if (key == LogicalKeyboardKey.arrowUp) {
         target = _titleLanguageFocus;
       }
+      if (key == LogicalKeyboardKey.arrowRight) {
+        target = _continueWatchingFocus;
+      }
       if (key == LogicalKeyboardKey.arrowDown) {
-        target = _homeNavigationSectionFocus;
+        target = _navigationSizeFocus;
+      }
+    } else if (current == _navigationSizeFocus) {
+      if (key == LogicalKeyboardKey.arrowUp) {
+        target = _showTitleStyleFocus;
+      }
+      if (key == LogicalKeyboardKey.arrowRight) {
+        target = _continueWatchingFocus;
+      }
+      if (key == LogicalKeyboardKey.arrowDown) {
+        target = _menuOrderFocus;
+      }
+    } else if (current == _menuOrderFocus) {
+      if (key == LogicalKeyboardKey.arrowUp) {
+        target = _navigationSizeFocus;
+      }
+      if (key == LogicalKeyboardKey.arrowRight) {
+        target = _continueWatchingFocus;
+      }
+      if (key == LogicalKeyboardKey.arrowDown) {
+        target = _customizationResetFocus;
+      }
+    } else if (current == _posterMetadataFocus) {
+      if (key == LogicalKeyboardKey.arrowLeft) {
+        target = _titleLanguageFocus;
+      }
+      if (key == LogicalKeyboardKey.arrowUp) {
+        target = _featuredHomeContentFocus;
+      }
+      if (key == LogicalKeyboardKey.arrowDown) {
+        target = _continueWatchingFocus;
+      }
+    } else if (current == _continueWatchingFocus) {
+      if (key == LogicalKeyboardKey.arrowLeft) {
+        target = _showTitleStyleFocus;
+      }
+      if (key == LogicalKeyboardKey.arrowUp) {
+        target = _posterMetadataFocus;
+      }
+      if (key == LogicalKeyboardKey.arrowDown) {
+        target = shelfNodes.first;
       }
     } else if (current == _homeNavigationSectionFocus) {
       if (key == LogicalKeyboardKey.arrowUp &&
@@ -781,24 +865,23 @@ class _AccountsScreenState extends ConsumerState<AccountsScreen> {
         target = _inputFeedbackSectionFocus;
       }
     } else if (current == _inputFeedbackSectionFocus) {
-      if (key == LogicalKeyboardKey.arrowUp &&
-          !_expandedCustomizationSections.contains(
-            _CustomizationSection.homeNavigation,
-          )) {
-        target = _homeNavigationSectionFocus;
-      }
-      if (key == LogicalKeyboardKey.arrowDown &&
-          !_expandedCustomizationSections.contains(
-            _CustomizationSection.inputFeedback,
-          )) {
-        target = _closedCaptionsSectionFocus;
+      if (_activeArea != _SettingsArea.appearance) {
+        if (key == LogicalKeyboardKey.arrowUp &&
+            !_expandedCustomizationSections.contains(
+              _CustomizationSection.homeNavigation,
+            )) {
+          target = _homeNavigationSectionFocus;
+        }
+        if (key == LogicalKeyboardKey.arrowDown &&
+            !_expandedCustomizationSections.contains(
+              _CustomizationSection.inputFeedback,
+            )) {
+          target = _customizationResetFocus;
+        }
       }
     } else if (current == _closedCaptionsSectionFocus) {
-      if (key == LogicalKeyboardKey.arrowUp &&
-          !_expandedCustomizationSections.contains(
-            _CustomizationSection.inputFeedback,
-          )) {
-        target = _inputFeedbackSectionFocus;
+      if (key == LogicalKeyboardKey.arrowUp) {
+        target = _areaFocusNodes[_SettingsArea.playback];
       }
       if (key == LogicalKeyboardKey.arrowDown) {
         target =
@@ -810,34 +893,35 @@ class _AccountsScreenState extends ConsumerState<AccountsScreen> {
       }
     } else if (current == _captionTextColorFocus) {
       if (key == LogicalKeyboardKey.arrowUp) {
-        target = _closedCaptionsSectionFocus;
+        target = _activeArea == _SettingsArea.playback
+            ? _areaFocusNodes[_SettingsArea.playback]
+            : _closedCaptionsSectionFocus;
       }
     } else if (current == _playerControlsSectionFocus) {
       if (key == LogicalKeyboardKey.arrowUp &&
           !_expandedCustomizationSections.contains(
             _CustomizationSection.closedCaptions,
           )) {
-        target = _closedCaptionsSectionFocus;
-      }
-      if (key == LogicalKeyboardKey.arrowDown &&
-          !_expandedCustomizationSections.contains(
-            _CustomizationSection.playerControls,
-          )) {
-        target = _customizationResetFocus;
+        target = _activeArea == _SettingsArea.playback
+            ? _captionTextColorFocus
+            : _closedCaptionsSectionFocus;
       }
     } else if (current == _customizationResetFocus) {
-      if (key == LogicalKeyboardKey.arrowUp &&
-          !_expandedCustomizationSections.contains(
-            _CustomizationSection.playerControls,
-          )) {
-        target = _playerControlsSectionFocus;
+      if (key == LogicalKeyboardKey.arrowUp) {
+        target = _activeArea == _SettingsArea.appearance
+            ? _menuOrderFocus
+            : _inputFeedbackSectionFocus;
+      }
+      if (key == LogicalKeyboardKey.arrowRight &&
+          _activeArea == _SettingsArea.appearance) {
+        target = _continueWatchingFocus;
       }
       if (key == LogicalKeyboardKey.arrowDown) {
         return KeyEventResult.handled;
       }
     } else if (current == _debridProviderFocus) {
       if (key == LogicalKeyboardKey.arrowUp) {
-        target = _areaFocusNodes[_SettingsArea.streaming];
+        target = _areaFocusNodes[_SettingsArea.services];
       }
       if (key == LogicalKeyboardKey.arrowDown) target = selectedDebridAction;
     } else if (current == selectedDebridAction) {
@@ -848,11 +932,10 @@ class _AccountsScreenState extends ConsumerState<AccountsScreen> {
             : _debridStreamsFocus;
       }
     } else if (current == selectedDebridToken) {
-      if (key == LogicalKeyboardKey.arrowRight) target = selectedDebridLast;
       if (key == LogicalKeyboardKey.arrowUp) target = selectedDebridAction;
+      if (key == LogicalKeyboardKey.arrowDown) target = selectedDebridLast;
     } else if (current == selectedDebridLast) {
-      if (key == LogicalKeyboardKey.arrowLeft) target = selectedDebridToken;
-      if (key == LogicalKeyboardKey.arrowUp) target = selectedDebridAction;
+      if (key == LogicalKeyboardKey.arrowUp) target = selectedDebridToken;
       if (key == LogicalKeyboardKey.arrowDown) {
         target = _debridStreamsFocus;
       }
@@ -901,7 +984,7 @@ class _AccountsScreenState extends ConsumerState<AccountsScreen> {
       if (key == LogicalKeyboardKey.arrowDown) {
         target = preferences.autoPickSourceEnabled
             ? _autoPickSourceFocus
-            : _offlineDownloadsFocus;
+            : _localMediaFocus;
       }
     } else if (current == _autoPickSourceFocus) {
       if (key == LogicalKeyboardKey.arrowUp) target = _autoPickEnabledFocus;
@@ -962,44 +1045,46 @@ class _AccountsScreenState extends ConsumerState<AccountsScreen> {
             : _autoPickQualityFocus;
       }
       if (key == LogicalKeyboardKey.arrowDown) {
-        target = _offlineDownloadsFocus;
+        target = _localMediaFocus;
       }
     } else if (current == _offlineDownloadsFocus) {
       if (key == LogicalKeyboardKey.arrowUp) {
-        target = preferences.autoPickSourceEnabled
-            ? _autoPickAudioFocus
-            : _autoPickEnabledFocus;
+        target = _watchTogetherFocus;
       }
       if (key == LogicalKeyboardKey.arrowRight &&
           preferences.offlineDownloadsEnabled) {
         target = _downloadManagerFocus;
       }
-      if (key == LogicalKeyboardKey.arrowDown) target = _localMediaFocus;
-    } else if (current == _localMediaFocus) {
-      if (key == LogicalKeyboardKey.arrowUp) {
-        target = preferences.offlineDownloadsEnabled
-            ? _downloadManagerFocus
-            : _offlineDownloadsFocus;
+      if (key == LogicalKeyboardKey.arrowDown) {
+        if (preferences.offlineDownloadsEnabled) {
+          target = _downloadManagerFocus;
+        } else {
+          return KeyEventResult.handled;
+        }
       }
-      if (key == LogicalKeyboardKey.arrowDown) target = _watchTogetherFocus;
-    } else if (current == _downloadManagerFocus) {
+    } else if (current == _localMediaFocus) {
       if (key == LogicalKeyboardKey.arrowUp) {
         target = preferences.autoPickSourceEnabled
             ? _autoPickAudioFocus
             : _autoPickEnabledFocus;
       }
+      if (key == LogicalKeyboardKey.arrowDown) target = _watchTogetherFocus;
+    } else if (current == _downloadManagerFocus) {
+      if (key == LogicalKeyboardKey.arrowUp) target = _offlineDownloadsFocus;
       if (key == LogicalKeyboardKey.arrowLeft) {
         target = _offlineDownloadsFocus;
       }
-      if (key == LogicalKeyboardKey.arrowDown) target = _localMediaFocus;
+      if (key == LogicalKeyboardKey.arrowDown) {
+        return KeyEventResult.handled;
+      }
     } else if (current == _watchTogetherFocus) {
       if (key == LogicalKeyboardKey.arrowUp) target = _localMediaFocus;
-      // Streaming is the end of this tab. Keep focus here instead of pointing
-      // at a control which is not mounted while this tab is active.
-      if (key == LogicalKeyboardKey.arrowDown) target = _watchTogetherFocus;
+      if (key == LogicalKeyboardKey.arrowDown) {
+        target = _offlineDownloadsFocus;
+      }
     } else if (current == _trackingProviderFocus) {
       if (key == LogicalKeyboardKey.arrowUp) {
-        target = _areaFocusNodes[_SettingsArea.tracking];
+        target = _areaFocusNodes[_SettingsArea.accounts];
       }
       if (key == LogicalKeyboardKey.arrowDown) target = selectedTrackingAction;
     } else if (current == _anilistFocus) {
@@ -1020,23 +1105,17 @@ class _AccountsScreenState extends ConsumerState<AccountsScreen> {
       if (key == LogicalKeyboardKey.arrowUp) target = _trackingProviderFocus;
     } else if (current == _anilistTokenFocus) {
       if (key == LogicalKeyboardKey.arrowUp) target = _anilistFocus;
-      if (key == LogicalKeyboardKey.arrowRight) target = _anilistSaveFocus;
+      if (key == LogicalKeyboardKey.arrowDown) target = _anilistSaveFocus;
     } else if (current == _anilistSaveFocus) {
-      if (key == LogicalKeyboardKey.arrowUp) target = _anilistFocus;
-      if (key == LogicalKeyboardKey.arrowLeft) target = _anilistTokenFocus;
+      if (key == LogicalKeyboardKey.arrowUp) target = _anilistTokenFocus;
       if (key == LogicalKeyboardKey.arrowDown) {
         target = _localProfilesFocus;
       }
     } else if (current == _malTokenFocus) {
       if (key == LogicalKeyboardKey.arrowUp) target = _malFocus;
-      if (key == LogicalKeyboardKey.arrowLeft &&
-          focusNodeIsMounted(_anilistSaveFocus)) {
-        target = _anilistSaveFocus;
-      }
-      if (key == LogicalKeyboardKey.arrowRight) target = _malSaveFocus;
+      if (key == LogicalKeyboardKey.arrowDown) target = _malSaveFocus;
     } else if (current == _malSaveFocus) {
-      if (key == LogicalKeyboardKey.arrowUp) target = _malFocus;
-      if (key == LogicalKeyboardKey.arrowLeft) target = _malTokenFocus;
+      if (key == LogicalKeyboardKey.arrowUp) target = _malTokenFocus;
       if (key == LogicalKeyboardKey.arrowDown) {
         target = _localProfilesFocus;
       }
@@ -1068,8 +1147,12 @@ class _AccountsScreenState extends ConsumerState<AccountsScreen> {
         target = _dubEpisodeNotificationsFocus;
       }
       if (key == LogicalKeyboardKey.arrowDown) {
-        _scrollSettingsToEnd();
-        return KeyEventResult.handled;
+        if (focusNodeIsMounted(_discordPresenceFocus) &&
+            _discordPresenceFocus.canRequestFocus) {
+          target = _discordPresenceFocus;
+        } else {
+          return KeyEventResult.handled;
+        }
       }
     } else if (current == _dubEpisodeNotificationsFocus) {
       if (key == LogicalKeyboardKey.arrowUp) {
@@ -1079,8 +1162,12 @@ class _AccountsScreenState extends ConsumerState<AccountsScreen> {
         target = _subEpisodeNotificationsFocus;
       }
       if (key == LogicalKeyboardKey.arrowDown) {
-        _scrollSettingsToEnd();
-        return KeyEventResult.handled;
+        if (focusNodeIsMounted(_discordPresenceFocus) &&
+            _discordPresenceFocus.canRequestFocus) {
+          target = _discordPresenceFocus;
+        } else {
+          return KeyEventResult.handled;
+        }
       }
     } else if (current == _setupFocus) {
       if (key == LogicalKeyboardKey.arrowUp) {
@@ -1110,6 +1197,7 @@ class _AccountsScreenState extends ConsumerState<AccountsScreen> {
     } else if (current == _automaticUpdatesFocus) {
       if (key == LogicalKeyboardKey.arrowUp) target = _setupFocus;
       if (key == LogicalKeyboardKey.arrowRight) target = _checkUpdatesFocus;
+      if (key == LogicalKeyboardKey.arrowDown) target = _checkUpdatesFocus;
     } else if (current == _checkUpdatesFocus) {
       if (key == LogicalKeyboardKey.arrowUp) target = _setupFocus;
       if (key == LogicalKeyboardKey.arrowLeft) {
@@ -1118,34 +1206,38 @@ class _AccountsScreenState extends ConsumerState<AccountsScreen> {
       if (key == LogicalKeyboardKey.arrowDown) {
         target = ref.read(appUpdateControllerProvider).developerMode
             ? _updateChannelFocus
-            : _discordPresenceFocus;
+            : _discordQrFocus;
       }
     } else if (current == _updateChannelFocus) {
       if (key == LogicalKeyboardKey.arrowUp) target = _checkUpdatesFocus;
       if (key == LogicalKeyboardKey.arrowDown) target = _releaseHistoryFocus;
     } else if (current == _releaseHistoryFocus) {
       if (key == LogicalKeyboardKey.arrowUp) target = _updateChannelFocus;
-      if (key == LogicalKeyboardKey.arrowDown) target = _discordPresenceFocus;
+      if (key == LogicalKeyboardKey.arrowDown) target = _discordQrFocus;
     } else if (current == _discordPresenceFocus) {
       if (key == LogicalKeyboardKey.arrowUp) {
-        target = ref.read(appUpdateControllerProvider).developerMode
-            ? _releaseHistoryFocus
-            : _checkUpdatesFocus;
+        target = _subEpisodeNotificationsFocus;
       }
       if (key == LogicalKeyboardKey.arrowRight &&
           focusNodeIsMounted(_discordDisconnectFocus)) {
         target = _discordDisconnectFocus;
       }
-      if (key == LogicalKeyboardKey.arrowDown) target = _discordQrFocus;
+      if (key == LogicalKeyboardKey.arrowDown) {
+        return KeyEventResult.handled;
+      }
     } else if (current == _discordDisconnectFocus) {
       if (key == LogicalKeyboardKey.arrowLeft) target = _discordPresenceFocus;
-      if (key == LogicalKeyboardKey.arrowUp) target = _checkUpdatesFocus;
-      if (key == LogicalKeyboardKey.arrowDown) target = _discordQrFocus;
+      if (key == LogicalKeyboardKey.arrowUp) {
+        target = _subEpisodeNotificationsFocus;
+      }
+      if (key == LogicalKeyboardKey.arrowDown) {
+        return KeyEventResult.handled;
+      }
     } else if (current == _discordQrFocus) {
       if (key == LogicalKeyboardKey.arrowUp) {
-        target = focusNodeIsMounted(_discordDisconnectFocus)
-            ? _discordDisconnectFocus
-            : _discordPresenceFocus;
+        target = ref.read(appUpdateControllerProvider).developerMode
+            ? _releaseHistoryFocus
+            : _checkUpdatesFocus;
       }
       if (key == LogicalKeyboardKey.arrowRight ||
           key == LogicalKeyboardKey.arrowDown) {
@@ -1194,6 +1286,25 @@ class _AccountsScreenState extends ConsumerState<AccountsScreen> {
           key == LogicalKeyboardKey.arrowUp) {
         target = _privacyFocus;
       }
+      if (key == LogicalKeyboardKey.arrowDown) {
+        target = _anonymousCrashReportingFocus;
+      }
+    } else if (current == _anonymousCrashReportingFocus) {
+      if (key == LogicalKeyboardKey.arrowUp) target = _legalFocus;
+      if (key == LogicalKeyboardKey.arrowDown) {
+        if (focusNodeIsMounted(_anonymousUsageCountFocus)) {
+          target = _anonymousUsageCountFocus;
+        } else {
+          return KeyEventResult.handled;
+        }
+      }
+    } else if (current == _anonymousUsageCountFocus) {
+      if (key == LogicalKeyboardKey.arrowUp) {
+        target = _anonymousCrashReportingFocus;
+      }
+      if (key == LogicalKeyboardKey.arrowDown) {
+        return KeyEventResult.handled;
+      }
     }
 
     if (target == null || !focusNodeIsMounted(target)) {
@@ -1241,7 +1352,14 @@ class _AccountsScreenState extends ConsumerState<AccountsScreen> {
   }
 
   Future<void> _selectSettingsArea(_SettingsArea area) async {
-    setState(() => _activeArea = area);
+    final changedArea = area != _activeArea;
+    if (changedArea) {
+      setState(() => _activeArea = area);
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (!mounted || !_settingsScrollController.hasClients) return;
+        _settingsScrollController.jumpTo(0);
+      });
+    }
     if (area != _SettingsArea.system) {
       _systemActivationCount = 0;
       return;
@@ -1266,6 +1384,81 @@ class _AccountsScreenState extends ConsumerState<AccountsScreen> {
     );
   }
 
+  Future<void> _openMenuOrderDialog() async {
+    await showDialog<void>(
+      context: context,
+      builder: (dialogContext) => Dialog(
+        backgroundColor: Colors.transparent,
+        child: Consumer(
+          builder: (context, ref, _) {
+            final livePreferences = ref.watch(settingsPreferencesProvider);
+            final controller = ref.read(settingsPreferencesProvider.notifier);
+            final tvScale = _usesTvSettingsScale(context);
+            return Container(
+              width: tvScale ? 470 : 620,
+              padding: EdgeInsets.all(tvScale ? 9 : 18),
+              decoration: BoxDecoration(
+                color: context.appPalette.surface,
+                borderRadius: BorderRadius.circular(12),
+                border: Border.all(
+                  color: context.appPalette.accent.withValues(alpha: .7),
+                ),
+              ),
+              child: ConstrainedBox(
+                constraints: BoxConstraints(
+                  maxHeight: MediaQuery.sizeOf(context).height * .78,
+                ),
+                child: SingleChildScrollView(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Row(
+                        children: [
+                          Expanded(
+                            child: Text(
+                              'Menu order',
+                              style: Theme.of(context).textTheme.titleLarge
+                                  ?.copyWith(
+                                    fontSize: tvScale ? 18 : null,
+                                    fontWeight: FontWeight.w800,
+                                  ),
+                            ),
+                          ),
+                          IconButton(
+                            tooltip: 'Close',
+                            onPressed: () => Navigator.of(dialogContext).pop(),
+                            icon: const Icon(Icons.close_rounded),
+                          ),
+                        ],
+                      ),
+                      SizedBox(height: tvScale ? 4 : 8),
+                      _TopNavigationOrganizer(
+                        preferences: livePreferences,
+                        focusNodes: _menuOrderDialogFocusNodes,
+                        onToggle: (destination) {
+                          final visible = livePreferences
+                              .isTopNavigationDestinationVisible(destination);
+                          controller.setTopNavigationDestinationVisible(
+                            destination,
+                            !visible,
+                          );
+                        },
+                        onSettingsPlacementChanged:
+                            controller.setSettingsEntryPlacement,
+                        onMove: controller.moveTopNavigationDestination,
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+            );
+          },
+        ),
+      ),
+    );
+    if (mounted) _menuOrderFocus.requestFocus();
+  }
+
   @override
   Widget build(BuildContext context) {
     final debrid = ref.watch(realDebridSettingsControllerProvider);
@@ -1282,10 +1475,87 @@ class _AccountsScreenState extends ConsumerState<AccountsScreen> {
     final preferences = ref.watch(settingsPreferencesProvider);
     final downloads = ref.watch(downloadManagerProvider);
     final isTelevision = ref.watch(isTelevisionProvider);
+    final showAnonymousUsageCount = ref.watch(isInstalledBetaBuildProvider);
+
+    Widget customizationPanel(
+      Set<_CustomizationSection> visibleSections, {
+      required bool showReset,
+    }) => _CustomizationPanel(
+      preferences: preferences,
+      titlePreference: titlePreference,
+      titleLanguageFocusNode: _titleLanguageFocus,
+      showTitleStyleFocusNode: _showTitleStyleFocus,
+      onTitleLanguageChanged: (preference) => ref
+          .read(titleLanguagePreferenceProvider.notifier)
+          .setPreference(preference),
+      controller: ref.read(settingsPreferencesProvider.notifier),
+      firstFocusNode: _customizationFocus,
+      displaySectionFocusNode: _displaySectionFocus,
+      homeNavigationSectionFocusNode: _homeNavigationSectionFocus,
+      featuredHomeContentFocusNode: _featuredHomeContentFocus,
+      topNavigationRowFocusNodes: _topNavigationRowFocusNodes,
+      inputFeedbackSectionFocusNode: _inputFeedbackSectionFocus,
+      closedCaptionsSectionFocusNode: _closedCaptionsSectionFocus,
+      captionTextColorFocusNode: _captionTextColorFocus,
+      playerControlsSectionFocusNode: _playerControlsSectionFocus,
+      resetFocusNode: _customizationResetFocus,
+      expandedSections: _expandedCustomizationSections,
+      onSectionExpandedChanged: _setCustomizationSectionExpanded,
+      onOpenThemeStudio: () => context.push(ThemeStudioScreen.routePath),
+      onReset: () async {
+        final controller = ref.read(settingsPreferencesProvider.notifier);
+        await controller.resetAppearanceAndNavigation();
+        await ref.read(homeShelfPreferencesProvider.notifier).reset();
+        await ref.read(homeShelfOrderProvider.notifier).reset();
+      },
+      visibleSections: visibleSections,
+      showReset: showReset,
+    );
+
+    Future<void> resetAppearance() async {
+      final controller = ref.read(settingsPreferencesProvider.notifier);
+      await controller.resetAppearanceAndNavigation();
+      await ref.read(homeShelfPreferencesProvider.notifier).reset();
+      await ref.read(homeShelfOrderProvider.notifier).reset();
+    }
+
+    Widget offlineDownloadsPanel() => Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        _AppearanceToggleRow(
+          key: const ValueKey('settings-offline-downloads-toggle'),
+          label: 'Offline downloads',
+          subtitle: !preferences.offlineDownloadsEnabled
+              ? 'Hide download controls while keeping existing files and jobs safe.'
+              : downloads.jobs.isEmpty
+              ? 'Download episodes for normal offline playback.'
+              : '${downloads.jobs.length} queued or saved episode${downloads.jobs.length == 1 ? '' : 's'} • ${_formatStorageBytes(downloads.storageUsedBytes)} used',
+          icon: Icons.download_for_offline_outlined,
+          value: preferences.offlineDownloadsEnabled,
+          focusNode: _offlineDownloadsFocus,
+          onChanged: ref
+              .read(settingsPreferencesProvider.notifier)
+              .setOfflineDownloadsEnabled,
+        ),
+        if (preferences.offlineDownloadsEnabled) ...[
+          const SizedBox(height: 8),
+          _AppearanceActionRow(
+            key: const ValueKey('settings-download-manager-button'),
+            label: 'Download manager',
+            subtitle: 'Review active jobs, saved episodes, and device storage.',
+            icon: Icons.download_rounded,
+            focusNode: _downloadManagerFocus,
+            onPressed: () => context.push('/downloads'),
+          ),
+        ],
+      ],
+    );
     return TetoTopLevelShell(
       preferences: preferences,
       activeDestination: TopNavigationDestination.settings,
-      firstContentFocusNode: _areaFocusNodes[_activeArea]!,
+      firstContentFocusNode: _activeArea == _SettingsArea.appearance
+          ? _customizationFocus
+          : _areaFocusNodes[_activeArea]!,
       autofocusRail: widget.autofocusNavigation,
       resizeToAvoidBottomInset: true,
       builder: (context, layout) => Focus(
@@ -1295,10 +1565,9 @@ class _AccountsScreenState extends ConsumerState<AccountsScreen> {
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            LayoutBuilder(
-              builder: (context, constraints) {
-                final showSecurityLabel = constraints.maxWidth >= 1180;
-                return Row(
+            if (!layout.usesTvRail) ...[
+              LayoutBuilder(
+                builder: (context, constraints) => Row(
                   children: [
                     if (preferences.interfaceMode == InterfaceMode.phone) ...[
                       _TvIconButton(
@@ -1314,10 +1583,7 @@ class _AccountsScreenState extends ConsumerState<AccountsScreen> {
                         maxLines: 1,
                         overflow: TextOverflow.ellipsis,
                         style: Theme.of(context).textTheme.headlineSmall
-                            ?.copyWith(
-                              fontSize: layout.usesTvRail ? 30 : null,
-                              fontWeight: FontWeight.w800,
-                            ),
+                            ?.copyWith(fontWeight: FontWeight.w800),
                       ),
                     ),
                     const SizedBox(width: 12),
@@ -1329,26 +1595,24 @@ class _AccountsScreenState extends ConsumerState<AccountsScreen> {
                         color: context.appPalette.secondaryAccent,
                       ),
                     ),
-                    if (showSecurityLabel) ...[
-                      const SizedBox(width: 8),
-                      Text(
-                        'Secrets stay encrypted on this device',
-                        style: Theme.of(context).textTheme.bodyMedium,
-                      ),
-                    ],
                   ],
-                );
-              },
-            ),
-            const SizedBox(height: 12),
+                ),
+              ),
+              const SizedBox(height: 12),
+            ],
             _SettingsAreaTabs(
               selected: _activeArea,
               focusNodes: _areaFocusNodes,
               onSelected: _selectSettingsArea,
             ),
-            const SizedBox(height: 12),
+            SizedBox(
+              height: layout.usesTvRail
+                  ? 6
+                  : (_activeArea == _SettingsArea.appearance ? 16 : 12),
+            ),
             Expanded(
               child: ListView(
+                key: const ValueKey('settings-content-list'),
                 controller: _settingsScrollController,
                 scrollCacheExtent: const ScrollCacheExtent.pixels(5000),
                 keyboardDismissBehavior:
@@ -1359,843 +1623,900 @@ class _AccountsScreenState extends ConsumerState<AccountsScreen> {
                       (layout.usesTvRail ? 88 : 24),
                 ),
                 children: [
-                  if (_activeArea == _SettingsArea.customize) ...[
-                    const _SectionHeader(
-                      icon: Icons.tune_rounded,
-                      title: 'APPEARANCE & NAVIGATION',
-                      subtitle:
-                          'Personalize layout, Home content, controls, captions, and sounds.',
-                    ),
-                    const SizedBox(height: 8),
-                    Align(
-                      alignment: Alignment.centerRight,
-                      child: _TvTextButton(
-                        key: const ValueKey('customize-toggle-all-sections'),
-                        label: _allCustomizationSectionsExpanded
-                            ? 'Collapse all'
-                            : 'Expand all',
-                        icon: _allCustomizationSectionsExpanded
-                            ? Icons.unfold_less_rounded
-                            : Icons.unfold_more_rounded,
-                        focusNode: _customizeSectionsToggleFocus,
-                        onPressed: _toggleAllCustomizationSections,
+                  if (_activeArea == _SettingsArea.appearance) ...[
+                    if (!layout.usesTvRail) ...[
+                      const _SectionHeader(
+                        icon: Icons.palette_rounded,
+                        title: 'APPEARANCE',
+                        subtitle:
+                            'Personalize TetoTV, the Home screen, navigation, and feedback.',
                       ),
-                    ),
-                    const SizedBox(height: 8),
-                    _HomeShelfOrganizer(
-                      order: homeShelfOrder,
-                      enabled: homeShelves,
-                      focusNodes: _shelfFocusNodes,
-                      sectionFocusNode: _homeShelvesSectionFocus,
-                      expanded: _expandedCustomizationSections.contains(
-                        _CustomizationSection.homeShelves,
-                      ),
-                      onExpandedChanged: (expanded) =>
-                          _setCustomizationSectionExpanded(
-                            _CustomizationSection.homeShelves,
-                            expanded,
-                          ),
-                      onToggle: (shelf) => ref
-                          .read(homeShelfPreferencesProvider.notifier)
-                          .toggle(shelf),
-                      onMove: (shelf, offset) => ref
-                          .read(homeShelfOrderProvider.notifier)
-                          .move(shelf, offset),
-                    ),
-                    const SizedBox(height: 10),
-                    _CustomizationPanel(
+                      const SizedBox(height: 8),
+                    ],
+                    _AppearanceSettingsLayout(
                       preferences: preferences,
-                      showAnonymousUsageCount: ref.watch(
-                        isInstalledBetaBuildProvider,
-                      ),
                       titlePreference: titlePreference,
-                      titleLanguageFocusNode: _titleLanguageFocus,
-                      showTitleStyleFocusNode: _showTitleStyleFocus,
-                      onTitleLanguageChanged: (preference) => ref
-                          .read(titleLanguagePreferenceProvider.notifier)
-                          .setPreference(preference),
+                      homeShelves: homeShelves,
+                      homeShelfOrder: homeShelfOrder,
                       controller: ref.read(
                         settingsPreferencesProvider.notifier,
                       ),
-                      firstFocusNode: _customizationFocus,
-                      displaySectionFocusNode: _displaySectionFocus,
-                      homeNavigationSectionFocusNode:
-                          _homeNavigationSectionFocus,
-                      featuredHomeContentFocusNode: _featuredHomeContentFocus,
-                      topNavigationRowFocusNodes: _topNavigationRowFocusNodes,
-                      inputFeedbackSectionFocusNode: _inputFeedbackSectionFocus,
-                      closedCaptionsSectionFocusNode:
-                          _closedCaptionsSectionFocus,
-                      captionTextColorFocusNode: _captionTextColorFocus,
-                      playerControlsSectionFocusNode:
-                          _playerControlsSectionFocus,
+                      themeStudioFocusNode: _customizationFocus,
+                      titleLanguageFocusNode: _titleLanguageFocus,
+                      showTitleStyleFocusNode: _showTitleStyleFocus,
+                      navigationSizeFocusNode: _navigationSizeFocus,
+                      menuOrderFocusNode: _menuOrderFocus,
                       resetFocusNode: _customizationResetFocus,
-                      expandedSections: _expandedCustomizationSections,
-                      onSectionExpandedChanged:
-                          _setCustomizationSectionExpanded,
+                      featuredFocusNode: _featuredHomeContentFocus,
+                      posterMetadataFocusNode: _posterMetadataFocus,
+                      continueWatchingFocusNode: _continueWatchingFocus,
+                      displayOptionsFirstFocusNode: _displaySectionFocus,
+                      inputFeedbackFirstFocusNode: _inputFeedbackSectionFocus,
+                      shelfFocusNodes: _shelfFocusNodes,
                       onOpenThemeStudio: () =>
                           context.push(ThemeStudioScreen.routePath),
-                      onReset: () async {
-                        final controller = ref.read(
-                          settingsPreferencesProvider.notifier,
-                        );
-                        await controller.resetCustomization();
-                        await controller.resetAppearance();
-                        await ref
-                            .read(homeShelfPreferencesProvider.notifier)
-                            .reset();
-                        await ref.read(homeShelfOrderProvider.notifier).reset();
-                      },
+                      onOpenMenuOrder: _openMenuOrderDialog,
+                      onTitleLanguageChanged: (preference) => ref
+                          .read(titleLanguagePreferenceProvider.notifier)
+                          .setPreference(preference),
+                      onReset: resetAppearance,
+                      onShelfToggle: (shelf) => ref
+                          .read(homeShelfPreferencesProvider.notifier)
+                          .toggle(shelf),
+                      onShelfMove: (shelf, offset) => ref
+                          .read(homeShelfOrderProvider.notifier)
+                          .move(shelf, offset),
                     ),
-                    const SizedBox(height: 10),
+                    SizedBox(height: layout.usesTvRail ? 5 : 10),
                   ],
-                  if (_activeArea == _SettingsArea.streaming) ...[
-                    const _SectionHeader(
-                      icon: Icons.cloud_done_rounded,
-                      title: 'DEBRID STREAMING',
-                      subtitle: 'Choose the provider used to resolve streams.',
+                  if (_activeArea == _SettingsArea.playback) ...[
+                    if (!layout.usesTvRail) ...[
+                      const _SectionHeader(
+                        icon: Icons.play_circle_rounded,
+                        title: 'PLAYBACK',
+                        subtitle:
+                            'Tune captions, player behavior, audio, skipping, and seeking.',
+                      ),
+                      const SizedBox(height: 8),
+                    ],
+                    _SettingsResponsiveColumns(
+                      left: _SettingsSectionCard(
+                        key: const ValueKey('settings-card-playback-captions'),
+                        title: 'Closed captions',
+                        subtitle:
+                            'Style subtitles for comfortable viewing on every screen.',
+                        child: customizationPanel(const {
+                          _CustomizationSection.closedCaptions,
+                        }, showReset: false),
+                      ),
+                      right: _SettingsSectionCard(
+                        key: const ValueKey('settings-card-playback-player'),
+                        title: 'Player controls',
+                        subtitle:
+                            'Choose audio, skipping, seeking, and playback behavior.',
+                        child: customizationPanel(const {
+                          _CustomizationSection.playerControls,
+                        }, showReset: false),
+                      ),
+                    ),
+                    SizedBox(height: layout.usesTvRail ? 5 : 10),
+                  ],
+                  if (_activeArea == _SettingsArea.services) ...[
+                    if (!layout.usesTvRail) ...[
+                      const _SectionHeader(
+                        icon: Icons.hub_rounded,
+                        title: 'SERVICES',
+                        subtitle:
+                            'Connect providers and choose how episode sources are found.',
+                      ),
+                      const SizedBox(height: 8),
+                    ],
+                    _SettingsResponsiveColumns(
+                      left: _SettingsSectionCard(
+                        key: const ValueKey('settings-card-services-debrid'),
+                        title: 'Debrid streaming',
+                        subtitle:
+                            'Choose and securely connect the provider used to resolve streams.',
+                        child: Column(
+                          crossAxisAlignment: CrossAxisAlignment.stretch,
+                          children: [
+                            _SettingsSelection<DebridService>(
+                              focusNode: _debridProviderFocus,
+                              label: 'Debrid provider',
+                              value: preferences.debridProvider,
+                              options: [
+                                for (final service in DebridService.values)
+                                  _SettingsOption(
+                                    value: service,
+                                    label: service.displayName,
+                                    detail:
+                                        switch (service) {
+                                          DebridService.realDebrid =>
+                                            debrid.hasSavedToken,
+                                          DebridService.torBox =>
+                                            torBox.hasSavedToken,
+                                          DebridService.allDebrid =>
+                                            allDebrid.hasSavedToken,
+                                          DebridService.premiumize =>
+                                            premiumize.hasSavedToken,
+                                        }
+                                        ? 'Connected'
+                                        : 'Not connected',
+                                  ),
+                              ],
+                              onSelected: ref
+                                  .read(settingsPreferencesProvider.notifier)
+                                  .setDebridProvider,
+                              showDivider: true,
+                            ),
+                            switch (preferences.debridProvider) {
+                              DebridService.realDebrid => _RealDebridPanel(
+                                state: debrid,
+                                onDisconnect: () => ref
+                                    .read(
+                                      realDebridSettingsControllerProvider
+                                          .notifier,
+                                    )
+                                    .disconnect(),
+                                onDeviceConnect: () =>
+                                    context.push('/pair/realdebrid'),
+                                connectFocusNode: _debridConnectFocus,
+                              ),
+                              DebridService.torBox => _TorBoxPanel(
+                                state: torBox,
+                                tokenController: _torBoxTokenController,
+                                onSave: () async {
+                                  final saved = await ref
+                                      .read(
+                                        torBoxSettingsControllerProvider
+                                            .notifier,
+                                      )
+                                      .saveAndValidate(
+                                        _torBoxTokenController.text,
+                                      );
+                                  if (saved) _torBoxTokenController.clear();
+                                },
+                                onDisconnect: () => ref
+                                    .read(
+                                      torBoxSettingsControllerProvider.notifier,
+                                    )
+                                    .disconnect(),
+                                onDeviceConnect: () async {
+                                  await context.push('/pair/torbox');
+                                  await ref
+                                      .read(
+                                        torBoxSettingsControllerProvider
+                                            .notifier,
+                                      )
+                                      .load();
+                                },
+                                actionFocusNode: _torBoxActionFocus,
+                                tokenFocusNode: _torBoxTokenFocus,
+                                saveFocusNode: _torBoxSaveFocus,
+                              ),
+                              DebridService.allDebrid => _ApiKeyDebridPanel(
+                                title: 'AllDebrid',
+                                icon: Icons.cloud_sync_rounded,
+                                gradient: [
+                                  context.appPalette.accent,
+                                  context.appPalette.secondaryAccent,
+                                ],
+                                connected: allDebrid.account != null,
+                                hasSavedToken: allDebrid.hasSavedToken,
+                                connectedLabel: 'PREMIUM',
+                                description: allDebrid.account == null
+                                    ? 'Authorize with AllDebrid PIN, or enter a personal API key.'
+                                    : 'Connected as ${allDebrid.account!.username}. '
+                                          'Torrent files resolve through AllDebrid only.',
+                                errorMessage: allDebrid.errorMessage,
+                                isLoading: allDebrid.isLoading,
+                                tokenController: _allDebridTokenController,
+                                tokenTitle: 'AllDebrid API key',
+                                keyboardTitle: 'Enter AllDebrid API key',
+                                connectLabel: 'Connect by PIN',
+                                connectIcon: Icons.qr_code_rounded,
+                                onSave: () async {
+                                  final saved = await ref
+                                      .read(
+                                        allDebridSettingsControllerProvider
+                                            .notifier,
+                                      )
+                                      .saveAndValidate(
+                                        _allDebridTokenController.text,
+                                      );
+                                  if (saved) _allDebridTokenController.clear();
+                                },
+                                onDisconnect: () => ref
+                                    .read(
+                                      allDebridSettingsControllerProvider
+                                          .notifier,
+                                    )
+                                    .disconnect(),
+                                onConnect: () async {
+                                  await context.push('/pair/alldebrid');
+                                  await ref
+                                      .read(
+                                        allDebridSettingsControllerProvider
+                                            .notifier,
+                                      )
+                                      .load();
+                                },
+                                actionFocusNode: _allDebridActionFocus,
+                                tokenFocusNode: _allDebridTokenFocus,
+                                saveFocusNode: _allDebridSaveFocus,
+                              ),
+                              DebridService.premiumize => _ApiKeyDebridPanel(
+                                title: 'Premiumize',
+                                icon: Icons.cloud_queue_rounded,
+                                gradient: [
+                                  context.appPalette.secondaryAccent,
+                                  context.appPalette.accentBright,
+                                ],
+                                connected: premiumize.account != null,
+                                hasSavedToken: premiumize.hasSavedToken,
+                                connectedLabel: 'PREMIUM',
+                                description: premiumize.account == null
+                                    ? 'Enter the API key from your Premiumize account page.'
+                                    : 'Connected as customer '
+                                          '${premiumize.account!.customerId}. '
+                                          'Torrent files resolve through Premiumize only.',
+                                errorMessage: premiumize.errorMessage,
+                                isLoading: premiumize.isLoading,
+                                tokenController: _premiumizeTokenController,
+                                tokenTitle: 'Premiumize API key',
+                                keyboardTitle: 'Enter Premiumize API key',
+                                connectLabel: 'Connection help',
+                                connectIcon: Icons.key_rounded,
+                                onSave: () async {
+                                  final saved = await ref
+                                      .read(
+                                        premiumizeSettingsControllerProvider
+                                            .notifier,
+                                      )
+                                      .saveAndValidate(
+                                        _premiumizeTokenController.text,
+                                      );
+                                  if (saved) _premiumizeTokenController.clear();
+                                },
+                                onDisconnect: () => ref
+                                    .read(
+                                      premiumizeSettingsControllerProvider
+                                          .notifier,
+                                    )
+                                    .disconnect(),
+                                onConnect: () async {
+                                  await context.push('/pair/premiumize');
+                                  await ref
+                                      .read(
+                                        premiumizeSettingsControllerProvider
+                                            .notifier,
+                                      )
+                                      .load();
+                                },
+                                actionFocusNode: _premiumizeActionFocus,
+                                tokenFocusNode: _premiumizeTokenFocus,
+                                saveFocusNode: _premiumizeSaveFocus,
+                              ),
+                            },
+                          ],
+                        ),
+                      ),
+                      right: _SettingsSectionCard(
+                        key: const ValueKey('settings-card-services-sources'),
+                        title: 'Sources & stream order',
+                        subtitle:
+                            'Choose which source types are searched and how results are ranked.',
+                        child: Column(
+                          crossAxisAlignment: CrossAxisAlignment.stretch,
+                          children: [
+                            _StreamingSourcesPanel(
+                              preferences: preferences,
+                              debridFocusNode: _debridStreamsFocus,
+                              webFocusNode: _webStreamsFocus,
+                              directTorrentFocusNode: _directTorrentFocus,
+                              marketplaceFocusNode: _marketplaceFocus,
+                              onDebridChanged: ref
+                                  .read(settingsPreferencesProvider.notifier)
+                                  .setDebridStreamsEnabled,
+                              onWebChanged: ref
+                                  .read(settingsPreferencesProvider.notifier)
+                                  .setWebStreamsEnabled,
+                              onDirectTorrentChanged: _setDirectTorrentEnabled,
+                              onMarketplace: () =>
+                                  context.push('/settings/marketplace'),
+                            ),
+                            const SizedBox(height: 8),
+                            _StreamRankingPanel(
+                              preferences: preferences,
+                              debridSortFocusNode: _debridSortFocus,
+                              sourcePriorityFocusNode: _sourcePriorityFocus,
+                              webQualityFocusNode: _webQualityFocus,
+                              onDebridSortSelected: ref
+                                  .read(settingsPreferencesProvider.notifier)
+                                  .setDebridStreamSort,
+                              onSourcePrioritySelected: ref
+                                  .read(settingsPreferencesProvider.notifier)
+                                  .setStreamSourcePriority,
+                              onWebQualitySelected: ref
+                                  .read(settingsPreferencesProvider.notifier)
+                                  .setWebStreamQuality,
+                            ),
+                          ],
+                        ),
+                      ),
                     ),
                     const SizedBox(height: 8),
-                    _SettingsSelection<DebridService>(
-                      focusNode: _debridProviderFocus,
-                      label: 'Debrid provider',
-                      value: preferences.debridProvider,
-                      options: [
-                        for (final service in DebridService.values)
-                          _SettingsOption(
-                            value: service,
-                            label: service.displayName,
-                            detail:
-                                switch (service) {
-                                  DebridService.realDebrid =>
-                                    debrid.hasSavedToken,
-                                  DebridService.torBox => torBox.hasSavedToken,
-                                  DebridService.allDebrid =>
-                                    allDebrid.hasSavedToken,
-                                  DebridService.premiumize =>
-                                    premiumize.hasSavedToken,
-                                }
-                                ? 'Connected'
-                                : 'Not connected',
-                          ),
-                      ],
-                      onSelected: ref
-                          .read(settingsPreferencesProvider.notifier)
-                          .setDebridProvider,
-                    ),
-                    const SizedBox(height: 8),
-                    switch (preferences.debridProvider) {
-                      DebridService.realDebrid => _RealDebridPanel(
-                        state: debrid,
-                        onDisconnect: () => ref
-                            .read(realDebridSettingsControllerProvider.notifier)
-                            .disconnect(),
-                        onDeviceConnect: () => context.push('/pair/realdebrid'),
-                        connectFocusNode: _debridConnectFocus,
-                      ),
-                      DebridService.torBox => _TorBoxPanel(
-                        state: torBox,
-                        tokenController: _torBoxTokenController,
-                        onSave: () async {
-                          final saved = await ref
-                              .read(torBoxSettingsControllerProvider.notifier)
-                              .saveAndValidate(_torBoxTokenController.text);
-                          if (saved) _torBoxTokenController.clear();
-                        },
-                        onDisconnect: () => ref
-                            .read(torBoxSettingsControllerProvider.notifier)
-                            .disconnect(),
-                        onDeviceConnect: () async {
-                          await context.push('/pair/torbox');
-                          await ref
-                              .read(torBoxSettingsControllerProvider.notifier)
-                              .load();
-                        },
-                        actionFocusNode: _torBoxActionFocus,
-                        tokenFocusNode: _torBoxTokenFocus,
-                        saveFocusNode: _torBoxSaveFocus,
-                      ),
-                      DebridService.allDebrid => _ApiKeyDebridPanel(
-                        title: 'AllDebrid',
-                        icon: Icons.cloud_sync_rounded,
-                        gradient: [
-                          context.appPalette.accent,
-                          context.appPalette.secondaryAccent,
-                        ],
-                        connected: allDebrid.account != null,
-                        hasSavedToken: allDebrid.hasSavedToken,
-                        connectedLabel: 'PREMIUM',
-                        description: allDebrid.account == null
-                            ? 'Authorize with AllDebrid PIN, or enter a personal API key.'
-                            : 'Connected as ${allDebrid.account!.username}. '
-                                  'Torrent files resolve through AllDebrid only.',
-                        errorMessage: allDebrid.errorMessage,
-                        isLoading: allDebrid.isLoading,
-                        tokenController: _allDebridTokenController,
-                        tokenTitle: 'AllDebrid API key',
-                        keyboardTitle: 'Enter AllDebrid API key',
-                        connectLabel: 'Connect by PIN',
-                        connectIcon: Icons.qr_code_rounded,
-                        onSave: () async {
-                          final saved = await ref
-                              .read(
-                                allDebridSettingsControllerProvider.notifier,
-                              )
-                              .saveAndValidate(_allDebridTokenController.text);
-                          if (saved) _allDebridTokenController.clear();
-                        },
-                        onDisconnect: () => ref
-                            .read(allDebridSettingsControllerProvider.notifier)
-                            .disconnect(),
-                        onConnect: () async {
-                          await context.push('/pair/alldebrid');
-                          await ref
-                              .read(
-                                allDebridSettingsControllerProvider.notifier,
-                              )
-                              .load();
-                        },
-                        actionFocusNode: _allDebridActionFocus,
-                        tokenFocusNode: _allDebridTokenFocus,
-                        saveFocusNode: _allDebridSaveFocus,
-                      ),
-                      DebridService.premiumize => _ApiKeyDebridPanel(
-                        title: 'Premiumize',
-                        icon: Icons.cloud_queue_rounded,
-                        gradient: [
-                          context.appPalette.secondaryAccent,
-                          context.appPalette.accentBright,
-                        ],
-                        connected: premiumize.account != null,
-                        hasSavedToken: premiumize.hasSavedToken,
-                        connectedLabel: 'PREMIUM',
-                        description: premiumize.account == null
-                            ? 'Enter the API key from your Premiumize account page.'
-                            : 'Connected as customer '
-                                  '${premiumize.account!.customerId}. '
-                                  'Torrent files resolve through Premiumize only.',
-                        errorMessage: premiumize.errorMessage,
-                        isLoading: premiumize.isLoading,
-                        tokenController: _premiumizeTokenController,
-                        tokenTitle: 'Premiumize API key',
-                        keyboardTitle: 'Enter Premiumize API key',
-                        connectLabel: 'Connection help',
-                        connectIcon: Icons.key_rounded,
-                        onSave: () async {
-                          final saved = await ref
-                              .read(
-                                premiumizeSettingsControllerProvider.notifier,
-                              )
-                              .saveAndValidate(_premiumizeTokenController.text);
-                          if (saved) _premiumizeTokenController.clear();
-                        },
-                        onDisconnect: () => ref
-                            .read(premiumizeSettingsControllerProvider.notifier)
-                            .disconnect(),
-                        onConnect: () async {
-                          await context.push('/pair/premiumize');
-                          await ref
-                              .read(
-                                premiumizeSettingsControllerProvider.notifier,
-                              )
-                              .load();
-                        },
-                        actionFocusNode: _premiumizeActionFocus,
-                        tokenFocusNode: _premiumizeTokenFocus,
-                        saveFocusNode: _premiumizeSaveFocus,
-                      ),
-                    },
-                    const SizedBox(height: 14),
-                    const _SectionHeader(
-                      icon: Icons.stream_rounded,
-                      title: 'SOURCES',
+                    _SettingsSectionCard(
+                      key: const ValueKey('settings-card-services-autopick'),
+                      title: 'Automatic source selection',
                       subtitle:
-                          'Choose which source types are searched for each episode.',
-                    ),
-                    const SizedBox(height: 8),
-                    _StreamingSourcesPanel(
-                      preferences: preferences,
-                      debridFocusNode: _debridStreamsFocus,
-                      webFocusNode: _webStreamsFocus,
-                      directTorrentFocusNode: _directTorrentFocus,
-                      marketplaceFocusNode: _marketplaceFocus,
-                      onDebridChanged: ref
-                          .read(settingsPreferencesProvider.notifier)
-                          .setDebridStreamsEnabled,
-                      onWebChanged: ref
-                          .read(settingsPreferencesProvider.notifier)
-                          .setWebStreamsEnabled,
-                      onDirectTorrentChanged: _setDirectTorrentEnabled,
-                      onMarketplace: () =>
-                          context.push('/settings/marketplace'),
-                    ),
-                    const SizedBox(height: 8),
-                    _StreamRankingPanel(
-                      preferences: preferences,
-                      debridSortFocusNode: _debridSortFocus,
-                      sourcePriorityFocusNode: _sourcePriorityFocus,
-                      webQualityFocusNode: _webQualityFocus,
-                      onDebridSortSelected: ref
-                          .read(settingsPreferencesProvider.notifier)
-                          .setDebridStreamSort,
-                      onSourcePrioritySelected: ref
-                          .read(settingsPreferencesProvider.notifier)
-                          .setStreamSourcePriority,
-                      onWebQualitySelected: ref
-                          .read(settingsPreferencesProvider.notifier)
-                          .setWebStreamQuality,
-                    ),
-                    const SizedBox(height: 8),
-                    _AutoPickSourcePanel(
-                      preferences: preferences,
-                      enabledFocusNode: _autoPickEnabledFocus,
-                      sourceSectionFocusNode: _autoPickSourceFocus,
-                      qualitySectionFocusNode: _autoPickQualityFocus,
-                      sourceRowFocusNodes: _autoPickSourceRowFocusNodes,
-                      qualityRowFocusNodes: _autoPickQualityRowFocusNodes,
-                      sourceExpanded: _expandedAutoPickPrioritySections
-                          .contains(_AutoPickPrioritySection.source),
-                      qualityExpanded: _expandedAutoPickPrioritySections
-                          .contains(_AutoPickPrioritySection.quality),
-                      audioFocusNode: _autoPickAudioFocus,
-                      onEnabledChanged: ref
-                          .read(settingsPreferencesProvider.notifier)
-                          .setAutoPickSourceEnabled,
-                      onSourceMoved: ref
-                          .read(settingsPreferencesProvider.notifier)
-                          .moveAutoPickSourcePriority,
-                      onQualityMoved: ref
-                          .read(settingsPreferencesProvider.notifier)
-                          .moveAutoPickQualityPriority,
-                      onSourceExpandedChanged: (expanded) =>
-                          _setAutoPickPrioritySectionExpanded(
-                            _AutoPickPrioritySection.source,
-                            expanded,
-                          ),
-                      onQualityExpandedChanged: (expanded) =>
-                          _setAutoPickPrioritySectionExpanded(
-                            _AutoPickPrioritySection.quality,
-                            expanded,
-                          ),
-                      onAudioSelected: ref
-                          .read(settingsPreferencesProvider.notifier)
-                          .setAutoPickAudio,
-                    ),
-                    const SizedBox(height: 8),
-                    _Panel(
-                      child: LayoutBuilder(
-                        builder: (context, constraints) {
-                          final summary = Column(
-                            crossAxisAlignment: CrossAxisAlignment.start,
-                            children: [
-                              Text(
-                                'Offline downloads',
-                                style: TextStyle(
-                                  color: context.appPalette.primaryText,
-                                  fontSize: 14,
-                                  fontWeight: FontWeight.w800,
-                                ),
-                              ),
-                              const SizedBox(height: 3),
-                              Text(
-                                !preferences.offlineDownloadsEnabled
-                                    ? 'Download controls and saved copies are hidden. Existing files and jobs stay intact.'
-                                    : downloads.jobs.isEmpty
-                                    ? 'Download episodes for normal offline playback.'
-                                    : '${downloads.jobs.length} queued or saved episode${downloads.jobs.length == 1 ? '' : 's'} • ${_formatStorageBytes(downloads.storageUsedBytes)} used',
-                                style: TextStyle(
-                                  color: context.appPalette.mutedText,
-                                  fontSize: 11,
-                                ),
-                              ),
-                            ],
-                          );
-                          final toggle = _PreferenceChip(
-                            key: const ValueKey(
-                              'settings-offline-downloads-toggle',
+                          'Prioritize source type, quality, and audio when TetoTV chooses for you.',
+                      child: _AutoPickSourcePanel(
+                        preferences: preferences,
+                        enabledFocusNode: _autoPickEnabledFocus,
+                        sourceSectionFocusNode: _autoPickSourceFocus,
+                        qualitySectionFocusNode: _autoPickQualityFocus,
+                        sourceRowFocusNodes: _autoPickSourceRowFocusNodes,
+                        qualityRowFocusNodes: _autoPickQualityRowFocusNodes,
+                        sourceExpanded: _expandedAutoPickPrioritySections
+                            .contains(_AutoPickPrioritySection.source),
+                        qualityExpanded: _expandedAutoPickPrioritySections
+                            .contains(_AutoPickPrioritySection.quality),
+                        audioFocusNode: _autoPickAudioFocus,
+                        onEnabledChanged: ref
+                            .read(settingsPreferencesProvider.notifier)
+                            .setAutoPickSourceEnabled,
+                        onSourceMoved: ref
+                            .read(settingsPreferencesProvider.notifier)
+                            .moveAutoPickSourcePriority,
+                        onQualityMoved: ref
+                            .read(settingsPreferencesProvider.notifier)
+                            .moveAutoPickQualityPriority,
+                        onSourceExpandedChanged: (expanded) =>
+                            _setAutoPickPrioritySectionExpanded(
+                              _AutoPickPrioritySection.source,
+                              expanded,
                             ),
-                            label: preferences.offlineDownloadsEnabled
-                                ? 'ENABLED'
-                                : 'OFF',
-                            selected: preferences.offlineDownloadsEnabled,
-                            focusNode: _offlineDownloadsFocus,
-                            onPressed: () => ref
-                                .read(settingsPreferencesProvider.notifier)
-                                .setOfflineDownloadsEnabled(
-                                  !preferences.offlineDownloadsEnabled,
-                                ),
-                          );
-                          final manager = _TvTextButton(
-                            key: const ValueKey(
-                              'settings-download-manager-button',
+                        onQualityExpandedChanged: (expanded) =>
+                            _setAutoPickPrioritySectionExpanded(
+                              _AutoPickPrioritySection.quality,
+                              expanded,
                             ),
-                            label: 'Download Manager',
-                            icon: Icons.download_rounded,
-                            focusNode: _downloadManagerFocus,
-                            onPressed: () => context.push('/downloads'),
-                          );
-                          if (constraints.maxWidth < 560) {
-                            return Column(
+                        onAudioSelected: ref
+                            .read(settingsPreferencesProvider.notifier)
+                            .setAutoPickAudio,
+                      ),
+                    ),
+                    SizedBox(height: layout.usesTvRail ? 5 : 10),
+                  ],
+                  if (_activeArea == _SettingsArea.services) ...[
+                    _SettingsResponsiveColumns(
+                      left: _SettingsSectionCard(
+                        key: const ValueKey('settings-card-services-features'),
+                        title: 'Libraries & features',
+                        subtitle:
+                            'Manage local libraries, Watch Party, and offline viewing.',
+                        child: Column(
+                          crossAxisAlignment: CrossAxisAlignment.stretch,
+                          children: [
+                            _AppearanceActionRow(
+                              label: 'Local, Jellyfin & Plex sources',
+                              subtitle:
+                                  'Connect libraries and add local files that appear in the normal source picker.',
+                              value: 'Manage sources',
+                              icon: Icons.video_library_outlined,
+                              focusNode: _localMediaFocus,
+                              showDivider: true,
+                              onPressed: () =>
+                                  context.push('/settings/local-media'),
+                            ),
+                            _AppearanceToggleRow(
+                              key: const ValueKey(
+                                'settings-watch-party-toggle',
+                              ),
+                              label: 'Watch Party',
+                              subtitle: preferences.showWatchTogether
+                                  ? 'Available in navigation, episode actions, and the player.'
+                                  : 'Hidden from navigation, episode actions, and the player.',
+                              icon: Icons.groups_2_outlined,
+                              value: preferences.showWatchTogether,
+                              focusNode: _watchTogetherFocus,
+                              showDivider: true,
+                              onChanged: ref
+                                  .read(settingsPreferencesProvider.notifier)
+                                  .setShowWatchTogether,
+                            ),
+                            offlineDownloadsPanel(),
+                          ],
+                        ),
+                      ),
+                      right: _SettingsSectionCard(
+                        key: const ValueKey('settings-card-services-privacy'),
+                        title: 'Streaming privacy',
+                        subtitle:
+                            'Control privacy-sensitive source and playback behavior.',
+                        child: _StreamingPrivacyPanel(preferences: preferences),
+                      ),
+                    ),
+                    SizedBox(height: layout.usesTvRail ? 5 : 10),
+                  ],
+                  if (_activeArea == _SettingsArea.accounts) ...[
+                    if (!layout.usesTvRail) ...[
+                      const _SectionHeader(
+                        icon: Icons.sync_alt_rounded,
+                        title: 'ACCOUNTS',
+                        subtitle:
+                            'Profiles, anime tracking, notifications, and linked services.',
+                      ),
+                      const SizedBox(height: 8),
+                    ],
+                    _SettingsResponsiveColumns(
+                      left: Column(
+                        crossAxisAlignment: CrossAxisAlignment.stretch,
+                        children: [
+                          _SettingsSectionCard(
+                            key: const ValueKey(
+                              'settings-card-accounts-tracking',
+                            ),
+                            title: 'Anime tracking',
+                            subtitle:
+                                'Connect a list provider and keep episode progress synchronized.',
+                            child: Column(
                               crossAxisAlignment: CrossAxisAlignment.stretch,
                               children: [
-                                Row(
-                                  crossAxisAlignment: CrossAxisAlignment.start,
-                                  children: [
-                                    Expanded(child: summary),
-                                    const SizedBox(width: 12),
-                                    toggle,
+                                _SettingsSelection<TrackingProvider>(
+                                  focusNode: _trackingProviderFocus,
+                                  label: 'Anime-list provider',
+                                  value: preferences.trackingProvider,
+                                  options: [
+                                    for (final provider
+                                        in TrackingProvider.values)
+                                      _SettingsOption(
+                                        value: provider,
+                                        label: provider.displayName,
+                                        detail: tracking.isConnected(provider)
+                                            ? 'Connected as ${tracking.usernames[provider]}'
+                                            : 'Not connected',
+                                      ),
                                   ],
+                                  onSelected: ref
+                                      .read(
+                                        settingsPreferencesProvider.notifier,
+                                      )
+                                      .setTrackingProvider,
+                                  showDivider: true,
                                 ),
-                                if (preferences.offlineDownloadsEnabled) ...[
-                                  const SizedBox(height: 8),
-                                  Align(
-                                    alignment: Alignment.centerRight,
-                                    child: manager,
-                                  ),
-                                ],
-                              ],
-                            );
-                          }
-                          return Row(
-                            children: [
-                              Expanded(child: summary),
-                              const SizedBox(width: 12),
-                              toggle,
-                              if (preferences.offlineDownloadsEnabled) ...[
-                                const SizedBox(width: 8),
-                                manager,
-                              ],
-                            ],
-                          );
-                        },
-                      ),
-                    ),
-                    const SizedBox(height: 8),
-                    _Panel(
-                      child: Row(
-                        children: [
-                          Expanded(
-                            child: Column(
-                              crossAxisAlignment: CrossAxisAlignment.start,
-                              children: [
-                                Text(
-                                  'Local, Jellyfin & Plex sources',
-                                  style: TextStyle(
-                                    color: context.appPalette.primaryText,
-                                    fontSize: 14,
-                                    fontWeight: FontWeight.w800,
-                                  ),
-                                ),
-                                SizedBox(height: 3),
-                                Text(
-                                  'Connect libraries and add local files. Matching episodes appear in the normal source picker.',
-                                  style: TextStyle(
-                                    color: context.appPalette.mutedText,
-                                    fontSize: 11,
-                                  ),
-                                ),
-                              ],
-                            ),
-                          ),
-                          const SizedBox(width: 12),
-                          _TvTextButton(
-                            label: 'Manage sources',
-                            icon: Icons.settings_input_component_rounded,
-                            focusNode: _localMediaFocus,
-                            onPressed: () =>
-                                context.push('/settings/local-media'),
-                          ),
-                        ],
-                      ),
-                    ),
-                    const SizedBox(height: 8),
-                    _Panel(
-                      child: Row(
-                        children: [
-                          Expanded(
-                            child: Column(
-                              crossAxisAlignment: CrossAxisAlignment.start,
-                              children: [
-                                Text(
-                                  'Watch Party',
-                                  style: TextStyle(
-                                    color: context.appPalette.primaryText,
-                                    fontSize: 14,
-                                    fontWeight: FontWeight.w800,
-                                  ),
-                                ),
-                                SizedBox(height: 3),
-                                Text(
-                                  preferences.showWatchTogether
-                                      ? 'Enabled in navigation, episode actions, and the player.'
-                                      : 'Hidden from navigation, episode actions, and the player.',
-                                  style: TextStyle(
-                                    color: context.appPalette.mutedText,
-                                    fontSize: 11,
-                                  ),
+                                _TrackingPanel(
+                                  provider: preferences.trackingProvider,
+                                  color:
+                                      preferences.trackingProvider ==
+                                          TrackingProvider.anilist
+                                      ? context.appPalette.accentBright
+                                      : const Color(0xFFB41F3D),
+                                  description:
+                                      preferences.trackingProvider ==
+                                          TrackingProvider.anilist
+                                      ? 'Seasonal discovery, lists, and automatic episode progress.'
+                                      : 'Sync watch progress and MAL statuses automatically.',
+                                  username: tracking
+                                      .usernames[preferences.trackingProvider],
+                                  error: tracking
+                                      .errors[preferences.trackingProvider],
+                                  isLoading: tracking.isLoading,
+                                  onConnect: () async {
+                                    await context.push(
+                                      preferences.trackingProvider ==
+                                              TrackingProvider.anilist
+                                          ? '/pair/anilist'
+                                          : '/pair/myanimelist',
+                                    );
+                                    await ref
+                                        .read(
+                                          trackingAccountsControllerProvider
+                                              .notifier,
+                                        )
+                                        .load();
+                                  },
+                                  onDisconnect: () => ref
+                                      .read(
+                                        trackingAccountsControllerProvider
+                                            .notifier,
+                                      )
+                                      .disconnect(preferences.trackingProvider),
+                                  onSaveToken: (token) => ref
+                                      .read(
+                                        trackingAccountsControllerProvider
+                                            .notifier,
+                                      )
+                                      .save(
+                                        preferences.trackingProvider,
+                                        token,
+                                      ),
+                                  focusNode:
+                                      preferences.trackingProvider ==
+                                          TrackingProvider.anilist
+                                      ? _anilistFocus
+                                      : _malFocus,
+                                  tokenFocusNode:
+                                      preferences.trackingProvider ==
+                                          TrackingProvider.anilist
+                                      ? _anilistTokenFocus
+                                      : _malTokenFocus,
+                                  saveFocusNode:
+                                      preferences.trackingProvider ==
+                                          TrackingProvider.anilist
+                                      ? _anilistSaveFocus
+                                      : _malSaveFocus,
                                 ),
                               ],
                             ),
                           ),
-                          const SizedBox(width: 12),
-                          _PreferenceChip(
-                            key: const ValueKey('settings-watch-party-toggle'),
-                            label: preferences.showWatchTogether
-                                ? 'ENABLED'
-                                : 'DISABLED',
-                            selected: preferences.showWatchTogether,
-                            focusNode: _watchTogetherFocus,
-                            onPressed: () => ref
-                                .read(settingsPreferencesProvider.notifier)
-                                .setShowWatchTogether(
-                                  !preferences.showWatchTogether,
-                                ),
-                          ),
-                        ],
-                      ),
-                    ),
-                    const SizedBox(height: 14),
-                    _StreamingPrivacyPanel(preferences: preferences),
-                    const SizedBox(height: 10),
-                  ],
-                  if (_activeArea == _SettingsArea.tracking) ...[
-                    const _SectionHeader(
-                      icon: Icons.sync_alt_rounded,
-                      title: 'ANIME TRACKING',
-                      subtitle: 'Configure one list service at a time.',
-                    ),
-                    const SizedBox(height: 8),
-                    _SettingsSelection<TrackingProvider>(
-                      focusNode: _trackingProviderFocus,
-                      label: 'Anime-list provider',
-                      value: preferences.trackingProvider,
-                      options: [
-                        for (final provider in TrackingProvider.values)
-                          _SettingsOption(
-                            value: provider,
-                            label: provider.displayName,
-                            detail: tracking.isConnected(provider)
-                                ? 'Connected as ${tracking.usernames[provider]}'
-                                : 'Not connected',
-                          ),
-                      ],
-                      onSelected: ref
-                          .read(settingsPreferencesProvider.notifier)
-                          .setTrackingProvider,
-                    ),
-                    const SizedBox(height: 8),
-                    _TrackingPanel(
-                      provider: preferences.trackingProvider,
-                      color:
-                          preferences.trackingProvider ==
-                              TrackingProvider.anilist
-                          ? context.appPalette.accentBright
-                          : const Color(0xFFB41F3D),
-                      description:
-                          preferences.trackingProvider ==
-                              TrackingProvider.anilist
-                          ? 'Seasonal discovery, lists, and automatic episode progress.'
-                          : 'Sync watch progress and MAL statuses automatically.',
-                      username:
-                          tracking.usernames[preferences.trackingProvider],
-                      error: tracking.errors[preferences.trackingProvider],
-                      isLoading: tracking.isLoading,
-                      onConnect: () async {
-                        await context.push(
-                          preferences.trackingProvider ==
-                                  TrackingProvider.anilist
-                              ? '/pair/anilist'
-                              : '/pair/myanimelist',
-                        );
-                        await ref
-                            .read(trackingAccountsControllerProvider.notifier)
-                            .load();
-                      },
-                      onDisconnect: () => ref
-                          .read(trackingAccountsControllerProvider.notifier)
-                          .disconnect(preferences.trackingProvider),
-                      onSaveToken: (token) => ref
-                          .read(trackingAccountsControllerProvider.notifier)
-                          .save(preferences.trackingProvider, token),
-                      focusNode:
-                          preferences.trackingProvider ==
-                              TrackingProvider.anilist
-                          ? _anilistFocus
-                          : _malFocus,
-                      tokenFocusNode:
-                          preferences.trackingProvider ==
-                              TrackingProvider.anilist
-                          ? _anilistTokenFocus
-                          : _malTokenFocus,
-                      saveFocusNode:
-                          preferences.trackingProvider ==
-                              TrackingProvider.anilist
-                          ? _anilistSaveFocus
-                          : _malSaveFocus,
-                    ),
-                    const SizedBox(height: 8),
-                    _LocalProfilesPanel(
-                      state: localProfiles,
-                      focusNode: _localProfilesFocus,
-                    ),
-                    const SizedBox(height: 8),
-                    _SettingsSelection<TrackerUpdateThreshold>(
-                      focusNode: _trackingThresholdFocus,
-                      label: 'When to update episode progress',
-                      value: preferences.trackerUpdateThreshold,
-                      options: [
-                        for (final threshold in TrackerUpdateThreshold.values)
-                          _SettingsOption(
-                            value: threshold,
-                            label: threshold.displayName,
-                            detail: threshold.description,
-                          ),
-                      ],
-                      onSelected: ref
-                          .read(settingsPreferencesProvider.notifier)
-                          .setTrackerUpdateThreshold,
-                    ),
-                    const SizedBox(height: 5),
-                    Text(
-                      'Trackers store whole completed episodes, so the '
-                      'selected percentage marks the current episode watched.',
-                      style: TextStyle(
-                        color: context.appPalette.mutedText,
-                        fontSize: 11,
-                      ),
-                    ),
-                    const SizedBox(height: 10),
-                    _Panel(
-                      child: Row(
-                        crossAxisAlignment: CrossAxisAlignment.center,
-                        children: [
-                          Expanded(
-                            child: Column(
-                              crossAxisAlignment: CrossAxisAlignment.start,
-                              children: [
-                                Text(
-                                  'New-episode notifications',
-                                  style: TextStyle(
-                                    color: context.appPalette.primaryText,
-                                    fontSize: 14,
-                                    fontWeight: FontWeight.w800,
-                                  ),
-                                ),
-                                const SizedBox(height: 3),
-                                Text(
-                                  'Sub / simulcast uses the normal Calendar airtime. '
-                                  'Dub alerts wait for a verified dub schedule and are never guessed from the normal airing.',
-                                  style: TextStyle(
-                                    color: context.appPalette.mutedText,
-                                    fontSize: 11,
-                                  ),
-                                ),
-                              ],
-                            ),
-                          ),
-                          const SizedBox(width: 12),
-                          _PreferenceChip(
+                          const SizedBox(height: 8),
+                          _SettingsSectionCard(
                             key: const ValueKey(
-                              'settings-sub-episode-notifications',
+                              'settings-card-accounts-profiles',
                             ),
-                            label: preferences.subEpisodeNotificationsEnabled
-                                ? 'SUB ON'
-                                : 'SUB OFF',
-                            selected:
-                                preferences.subEpisodeNotificationsEnabled,
-                            focusNode: _subEpisodeNotificationsFocus,
-                            onPressed: () => ref
-                                .read(settingsPreferencesProvider.notifier)
-                                .setSubEpisodeNotificationsEnabled(
-                                  !preferences.subEpisodeNotificationsEnabled,
-                                ),
-                          ),
-                          const SizedBox(width: 7),
-                          _PreferenceChip(
-                            key: const ValueKey(
-                              'settings-dub-episode-notifications',
+                            title: 'Profiles',
+                            subtitle:
+                                'Manage local viewers and their separate preferences.',
+                            child: _LocalProfilesPanel(
+                              state: localProfiles,
+                              focusNode: _localProfilesFocus,
                             ),
-                            label: preferences.dubEpisodeNotificationsEnabled
-                                ? 'DUB: WHEN VERIFIED'
-                                : 'DUB OFF',
-                            selected:
-                                preferences.dubEpisodeNotificationsEnabled,
-                            focusNode: _dubEpisodeNotificationsFocus,
-                            onPressed: () => ref
-                                .read(settingsPreferencesProvider.notifier)
-                                .setDubEpisodeNotificationsEnabled(
-                                  !preferences.dubEpisodeNotificationsEnabled,
-                                ),
                           ),
                         ],
+                      ),
+                      right: _SettingsSectionCard(
+                        key: const ValueKey('settings-card-accounts-behavior'),
+                        title: 'Progress & notifications',
+                        subtitle:
+                            'Choose when progress syncs and which episode alerts appear.',
+                        child: Column(
+                          crossAxisAlignment: CrossAxisAlignment.stretch,
+                          children: [
+                            _SettingsSelection<TrackerUpdateThreshold>(
+                              key: const ValueKey(
+                                'settings-tracking-update-threshold',
+                              ),
+                              focusNode: _trackingThresholdFocus,
+                              label: 'When to update episode progress',
+                              value: preferences.trackerUpdateThreshold,
+                              options: [
+                                for (final threshold
+                                    in TrackerUpdateThreshold.values)
+                                  _SettingsOption(
+                                    value: threshold,
+                                    label: threshold.displayName,
+                                    detail: threshold.description,
+                                  ),
+                              ],
+                              onSelected: ref
+                                  .read(settingsPreferencesProvider.notifier)
+                                  .setTrackerUpdateThreshold,
+                              showDivider: true,
+                            ),
+                            const _SettingsSupportingText(
+                              'Trackers store whole completed episodes, so the '
+                              'selected percentage marks the current episode watched.',
+                            ),
+                            _AppearanceToggleRow(
+                              key: const ValueKey(
+                                'settings-sub-episode-notifications',
+                              ),
+                              label: 'Sub & simulcast alerts',
+                              subtitle:
+                                  'Notify when a subtitled or simulcast episode reaches its normal airtime.',
+                              icon: Icons.subtitles_outlined,
+                              value: preferences.subEpisodeNotificationsEnabled,
+                              focusNode: _subEpisodeNotificationsFocus,
+                              showDivider: true,
+                              onChanged: ref
+                                  .read(settingsPreferencesProvider.notifier)
+                                  .setSubEpisodeNotificationsEnabled,
+                            ),
+                            _AppearanceToggleRow(
+                              key: const ValueKey(
+                                'settings-dub-episode-notifications',
+                              ),
+                              label: 'Verified dub alerts',
+                              subtitle:
+                                  'Notify only when a dubbed episode has a verified release schedule.',
+                              icon: Icons.record_voice_over_outlined,
+                              value: preferences.dubEpisodeNotificationsEnabled,
+                              focusNode: _dubEpisodeNotificationsFocus,
+                              onChanged: ref
+                                  .read(settingsPreferencesProvider.notifier)
+                                  .setDubEpisodeNotificationsEnabled,
+                            ),
+                          ],
+                        ),
                       ),
                     ),
                     const SizedBox(height: 10),
                   ],
                   if (_activeArea == _SettingsArea.system) ...[
-                    const _SectionHeader(
-                      icon: Icons.memory_rounded,
-                      title: 'SYSTEM & SUPPORT',
-                      subtitle:
-                          'Setup, device compatibility, diagnostics, and app updates.',
-                    ),
-                    const SizedBox(height: 8),
-                    _Panel(
-                      child: LayoutBuilder(
-                        builder: (context, constraints) {
-                          final actions = [
-                            _TvTextButton(
-                              label: 'Run setup again',
-                              icon: Icons.auto_awesome_rounded,
-                              focusNode: _setupFocus,
-                              onPressed: () => context.push('/setup/start'),
+                    if (!layout.usesTvRail) ...[
+                      const _SectionHeader(
+                        icon: Icons.settings_rounded,
+                        title: 'SYSTEM',
+                        subtitle:
+                            'Manage this device, updates, diagnostics, privacy, storage, and legal information.',
+                      ),
+                      const SizedBox(height: 8),
+                    ],
+                    _SettingsResponsiveColumns(
+                      left: Column(
+                        crossAxisAlignment: CrossAxisAlignment.stretch,
+                        children: [
+                          _SettingsSectionCard(
+                            key: const ValueKey('settings-card-system-support'),
+                            title: 'Device & support',
+                            subtitle:
+                                'Setup, device compatibility, calibration, and diagnostics.',
+                            child: Column(
+                              children: [
+                                _AppearanceActionRow(
+                                  label: 'Run setup again',
+                                  subtitle:
+                                      'Change setup method or reconnect your services.',
+                                  icon: Icons.auto_awesome_rounded,
+                                  focusNode: _setupFocus,
+                                  showDivider: true,
+                                  onPressed: () => context.push('/setup/start'),
+                                ),
+                                _AppearanceActionRow(
+                                  label: 'Device calibration',
+                                  subtitle:
+                                      'Adjust display fit, input, and playback compatibility.',
+                                  icon: Icons.tune_rounded,
+                                  focusNode: _calibrationFocus,
+                                  showDivider: true,
+                                  onPressed: () =>
+                                      context.push('/settings/device-setup'),
+                                ),
+                                _AppearanceActionRow(
+                                  label: 'Diagnostics',
+                                  subtitle:
+                                      'Review system health and export troubleshooting details.',
+                                  icon: Icons.monitor_heart_rounded,
+                                  focusNode: _diagnosticsFocus,
+                                  onPressed: () =>
+                                      context.push('/settings/diagnostics'),
+                                ),
+                              ],
                             ),
-                            _TvTextButton(
-                              label: 'Device calibration',
-                              icon: Icons.tune_rounded,
-                              focusNode: _calibrationFocus,
-                              onPressed: () =>
-                                  context.push('/settings/device-setup'),
+                          ),
+                        ],
+                      ),
+                      right: Column(
+                        crossAxisAlignment: CrossAxisAlignment.stretch,
+                        children: [
+                          _SettingsSectionCard(
+                            key: const ValueKey('settings-card-system-updates'),
+                            title: 'App updates',
+                            subtitle:
+                                'Stable public releases download directly to this device.',
+                            child: Column(
+                              crossAxisAlignment: CrossAxisAlignment.stretch,
+                              children: [
+                                _AppUpdatePanel(
+                                  state: appUpdate,
+                                  automaticFocusNode: _automaticUpdatesFocus,
+                                  checkFocusNode: _checkUpdatesFocus,
+                                  onToggleAutomatic: () => ref
+                                      .read(
+                                        appUpdateControllerProvider.notifier,
+                                      )
+                                      .setAutomaticUpdates(
+                                        !appUpdate.automaticUpdates,
+                                      ),
+                                  onCheckOrInstall: () {
+                                    final controller = ref.read(
+                                      appUpdateControllerProvider.notifier,
+                                    );
+                                    if (appUpdate.downloadedPath != null) {
+                                      controller.installDownloadedUpdate();
+                                    } else {
+                                      controller.checkForUpdates(
+                                        launchInstaller: true,
+                                      );
+                                    }
+                                  },
+                                ),
+                                const SizedBox(height: 8),
+                                _DeveloperUpdatePanel(
+                                  state: appUpdate,
+                                  channelFocusNode: _updateChannelFocus,
+                                  releaseHistoryFocusNode: _releaseHistoryFocus,
+                                  onChannelSelected: ref
+                                      .read(
+                                        appUpdateControllerProvider.notifier,
+                                      )
+                                      .setUpdateChannel,
+                                  onRefreshHistory: ref
+                                      .read(
+                                        appUpdateControllerProvider.notifier,
+                                      )
+                                      .refreshReleaseHistory,
+                                  onReleaseSelected: ref
+                                      .read(
+                                        appUpdateControllerProvider.notifier,
+                                      )
+                                      .installReleaseFromHistory,
+                                ),
+                              ],
                             ),
-                            _TvTextButton(
-                              label: 'Diagnostics',
-                              icon: Icons.monitor_heart_rounded,
-                              focusNode: _diagnosticsFocus,
-                              onPressed: () =>
-                                  context.push('/settings/diagnostics'),
-                            ),
-                          ];
-                          return Wrap(
-                            spacing: 8,
-                            runSpacing: 8,
-                            children: actions,
-                          );
-                        },
+                          ),
+                        ],
                       ),
                     ),
-                    const SizedBox(height: 12),
-                    const _SectionHeader(
-                      icon: Icons.system_update_alt_rounded,
-                      title: 'APP UPDATES',
-                      subtitle:
-                          'Stable public releases download directly to this device.',
-                    ),
-                    const SizedBox(height: 8),
-                    _AppUpdatePanel(
-                      state: appUpdate,
-                      automaticFocusNode: _automaticUpdatesFocus,
-                      checkFocusNode: _checkUpdatesFocus,
-                      onToggleAutomatic: () => ref
-                          .read(appUpdateControllerProvider.notifier)
-                          .setAutomaticUpdates(!appUpdate.automaticUpdates),
-                      onCheckOrInstall: () {
-                        final controller = ref.read(
-                          appUpdateControllerProvider.notifier,
-                        );
-                        if (appUpdate.downloadedPath != null) {
-                          controller.installDownloadedUpdate();
-                        } else {
-                          controller.checkForUpdates(launchInstaller: true);
-                        }
-                      },
-                    ),
-                    const SizedBox(height: 8),
-                    _DeveloperUpdatePanel(
-                      state: appUpdate,
-                      channelFocusNode: _updateChannelFocus,
-                      releaseHistoryFocusNode: _releaseHistoryFocus,
-                      onChannelSelected: ref
-                          .read(appUpdateControllerProvider.notifier)
-                          .setUpdateChannel,
-                      onRefreshHistory: ref
-                          .read(appUpdateControllerProvider.notifier)
-                          .refreshReleaseHistory,
-                      onReleaseSelected: ref
-                          .read(appUpdateControllerProvider.notifier)
-                          .installReleaseFromHistory,
-                    ),
-                    const SizedBox(height: 12),
-                    const _SectionHeader(
-                      icon: Icons.sports_esports_rounded,
-                      title: 'DISCORD RICH PRESENCE',
+                    SizedBox(height: layout.usesTvRail ? 6 : 12),
+                  ],
+                  if (_activeArea == _SettingsArea.accounts) ...[
+                    _SettingsSectionCard(
+                      key: const ValueKey('settings-card-accounts-discord'),
+                      title: 'Discord Rich Presence',
                       subtitle:
                           'Control the optional Discord activity shown while you watch.',
-                    ),
-                    const SizedBox(height: 8),
-                    _DiscordPresencePanel(
-                      state: discordPresence,
-                      primaryFocusNode: _discordPresenceFocus,
-                      unlinkFocusNode: _discordDisconnectFocus,
-                      onLink: () async {
-                        final resolver = ref.read(
-                          discordAccountLinkResolverProvider,
-                        );
-                        final controller = ref.read(
-                          discordPresenceControllerProvider.notifier,
-                        );
-                        final flow = await resolver.resolve(
-                          startupTelevision: isTelevision,
-                        );
-                        if (!context.mounted) return;
-                        if (flow == DiscordAccountLinkFlow.deviceQr) {
-                          await context.push('/pair/discord');
-                        } else {
-                          final confirmation =
-                              await showDiscordMinimumAgeConfirmationDialog(
-                                context,
-                              );
-                          if (confirmation != null) {
-                            await controller.linkAccount(confirmation);
+                      child: _DiscordPresencePanel(
+                        state: discordPresence,
+                        primaryFocusNode: _discordPresenceFocus,
+                        unlinkFocusNode: _discordDisconnectFocus,
+                        onLink: () async {
+                          final resolver = ref.read(
+                            discordAccountLinkResolverProvider,
+                          );
+                          final controller = ref.read(
+                            discordPresenceControllerProvider.notifier,
+                          );
+                          final flow = await resolver.resolve(
+                            startupTelevision: isTelevision,
+                          );
+                          if (!context.mounted) return;
+                          if (flow == DiscordAccountLinkFlow.deviceQr) {
+                            await context.push('/pair/discord');
+                          } else {
+                            final confirmation =
+                                await showDiscordMinimumAgeConfirmationDialog(
+                                  context,
+                                );
+                            if (confirmation != null) {
+                              await controller.linkAccount(confirmation);
+                            }
                           }
-                        }
-                      },
-                      onToggle: () => ref
-                          .read(discordPresenceControllerProvider.notifier)
-                          .setEnabled(!discordPresence.enabled),
-                      onRetry: () => ref
-                          .read(discordPresenceControllerProvider.notifier)
-                          .retry(),
-                      onUnlink: () => ref
-                          .read(discordPresenceControllerProvider.notifier)
-                          .unlinkAccount(),
+                        },
+                        onToggle: () => ref
+                            .read(discordPresenceControllerProvider.notifier)
+                            .setEnabled(!discordPresence.enabled),
+                        onRetry: () => ref
+                            .read(discordPresenceControllerProvider.notifier)
+                            .retry(),
+                        onUnlink: () => ref
+                            .read(discordPresenceControllerProvider.notifier)
+                            .unlinkAccount(),
+                      ),
                     ),
-                    const SizedBox(height: 12),
-                    const _SectionHeader(
-                      icon: Icons.forum_rounded,
-                      title: 'COMMUNITY',
-                      subtitle:
-                          'Join the TetoTV Discord for announcements, support, and feature requests.',
-                    ),
-                    const SizedBox(height: 8),
-                    _CommunityPanels(
-                      discordQrFocusNode: _discordQrFocus,
-                      discordFocusNode: _discordFocus,
-                      donationQrFocusNode: _donationQrFocus,
-                      donationFocusNode: _donateFocus,
-                    ),
-                    const SizedBox(height: 12),
-                    const _SectionHeader(
-                      icon: Icons.storage_rounded,
-                      title: 'STORAGE & RESET',
-                      subtitle:
-                          'Remove temporary files or return TetoTV to first-time setup.',
-                    ),
-                    const SizedBox(height: 8),
-                    _StorageResetPanel(
-                      clearCacheFocusNode: _clearCacheFocus,
-                      resetAppFocusNode: _resetAppFocus,
-                    ),
-                    const SizedBox(height: 12),
-                    const _SectionHeader(
-                      icon: Icons.info_rounded,
-                      title: 'ABOUT & LEGAL',
-                      subtitle:
-                          'Privacy, attribution, and open-source notices.',
-                    ),
-                    const SizedBox(height: 8),
-                    _LegalNoticesPanel(
-                      privacyFocusNode: _privacyFocus,
-                      licenseFocusNode: _legalFocus,
+                    SizedBox(height: layout.usesTvRail ? 6 : 12),
+                  ],
+                  if (_activeArea == _SettingsArea.system) ...[
+                    _SettingsResponsiveColumns(
+                      left: Column(
+                        crossAxisAlignment: CrossAxisAlignment.stretch,
+                        children: [
+                          _SettingsSectionCard(
+                            key: const ValueKey(
+                              'settings-card-system-community',
+                            ),
+                            title: 'Community',
+                            subtitle:
+                                'Join the TetoTV Discord for announcements, support, and feature requests.',
+                            child: _CommunityPanels(
+                              discordQrFocusNode: _discordQrFocus,
+                              discordFocusNode: _discordFocus,
+                              donationQrFocusNode: _donationQrFocus,
+                              donationFocusNode: _donateFocus,
+                            ),
+                          ),
+                        ],
+                      ),
+                      right: Column(
+                        crossAxisAlignment: CrossAxisAlignment.stretch,
+                        children: [
+                          _SettingsSectionCard(
+                            key: const ValueKey('settings-card-system-storage'),
+                            title: 'Storage & reset',
+                            subtitle:
+                                'Remove temporary files or return TetoTV to first-time setup.',
+                            child: _StorageResetPanel(
+                              clearCacheFocusNode: _clearCacheFocus,
+                              resetAppFocusNode: _resetAppFocus,
+                            ),
+                          ),
+                          SizedBox(height: layout.usesTvRail ? 6 : 12),
+                          _SettingsSectionCard(
+                            key: const ValueKey('settings-card-system-legal'),
+                            title: 'About & legal',
+                            subtitle:
+                                'Privacy, attribution, and open-source notices.',
+                            child: _LegalNoticesPanel(
+                              privacyFocusNode: _privacyFocus,
+                              licenseFocusNode: _legalFocus,
+                            ),
+                          ),
+                          SizedBox(height: layout.usesTvRail ? 6 : 12),
+                          _SettingsSectionCard(
+                            key: const ValueKey(
+                              'settings-card-system-privacy-diagnostics',
+                            ),
+                            title: 'Privacy & diagnostics',
+                            subtitle:
+                                'Control optional privacy-safe reporting and Beta activity signals.',
+                            child: Column(
+                              crossAxisAlignment: CrossAxisAlignment.stretch,
+                              children: [
+                                _AppearanceToggleRow(
+                                  key: const ValueKey(
+                                    'settings-anonymous-crash-reports',
+                                  ),
+                                  label: 'Anonymous crash reports',
+                                  subtitle:
+                                      'Send a redacted technical report after an unexpected crash.',
+                                  icon: Icons.monitor_heart_outlined,
+                                  value: preferences
+                                      .anonymousCrashReportingEnabled,
+                                  focusNode: _anonymousCrashReportingFocus,
+                                  showDivider: true,
+                                  onChanged: ref
+                                      .read(
+                                        settingsPreferencesProvider.notifier,
+                                      )
+                                      .setAnonymousCrashReportingEnabled,
+                                ),
+                                if (showAnonymousUsageCount)
+                                  _AppearanceToggleRow(
+                                    key: const ValueKey(
+                                      'settings-anonymous-live-count',
+                                    ),
+                                    label: 'Anonymous live count',
+                                    subtitle:
+                                        'Include this device in the privacy-safe Beta activity count.',
+                                    icon: Icons.groups_2_outlined,
+                                    value:
+                                        preferences.anonymousUsageCountEnabled,
+                                    focusNode: _anonymousUsageCountFocus,
+                                    showDivider: true,
+                                    onChanged: ref
+                                        .read(
+                                          settingsPreferencesProvider.notifier,
+                                        )
+                                        .setAnonymousUsageCountEnabled,
+                                  ),
+                                Padding(
+                                  padding: EdgeInsets.symmetric(
+                                    horizontal: _usesTvSettingsScale(context)
+                                        ? 10
+                                        : 13,
+                                    vertical: _usesTvSettingsScale(context)
+                                        ? 6
+                                        : 11,
+                                  ),
+                                  child: Text(
+                                    'Crash reports are off by default and contain only the app/build, error type and time, Android version, CPU architecture, device class, and a redacted technical trace. They never include a show, episode, account, device ID, source, or URL.'
+                                    '${showAnonymousUsageCount ? ' The Beta live count shares only whether TetoTV is active or has an MPV player open. It contains no profile or media details; normal HTTPS delivery and short-lived abuse limits may process an IP address, but the presence record does not store it.' : ''}',
+                                    style: TextStyle(
+                                      color: context.appPalette.mutedText,
+                                      fontSize: _usesTvSettingsScale(context)
+                                          ? 12
+                                          : 11,
+                                      height: 1.35,
+                                    ),
+                                  ),
+                                ),
+                              ],
+                            ),
+                          ),
+                        ],
+                      ),
                     ),
                   ],
                 ],
@@ -2221,102 +2542,80 @@ class _SettingsAreaTabs extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final tvScale = _usesTvSettingsScale(context);
+
     Widget tab(_SettingsArea area, {required bool compact}) {
       final active = area == selected;
-      final (icon, label) = switch (area) {
-        _SettingsArea.customize => (Icons.tune_rounded, 'Customize'),
-        _SettingsArea.streaming => (Icons.live_tv_rounded, 'Streaming'),
-        _SettingsArea.tracking => (Icons.sync_rounded, 'Tracking'),
-        _SettingsArea.system => (Icons.settings_rounded, 'System'),
+      final label = switch (area) {
+        _SettingsArea.appearance => 'Appearance',
+        _SettingsArea.playback => 'Playback',
+        _SettingsArea.services => 'Services',
+        _SettingsArea.accounts => 'Accounts',
+        _SettingsArea.system => 'System',
       };
       return TvFocusable(
+        key: ValueKey('settings-area-${area.name}'),
         focusNode: focusNodes[area],
-        autofocus: area == selected,
+        autofocus: area == selected && selected != _SettingsArea.appearance,
         onPressed: () => onSelected(area),
-        focusScale: 1.02,
-        borderRadius: BorderRadius.circular(12),
+        focusScale: 1.01,
+        borderRadius: BorderRadius.circular(8),
         child: AnimatedContainer(
           duration: const Duration(milliseconds: 120),
+          constraints: BoxConstraints(
+            minWidth: compact ? 0 : (tvScale ? 104 : 150),
+          ),
           padding: EdgeInsets.symmetric(
-            horizontal: compact ? 4 : 16,
-            vertical: compact ? 5 : 0,
+            horizontal: compact ? 3 : (tvScale ? 8 : 16),
+            vertical: compact ? 10 : (tvScale ? 4 : 10),
           ),
           decoration: BoxDecoration(
-            color: active
-                ? context.appPalette.accent
-                : context.appPalette.surface,
-            borderRadius: BorderRadius.circular(12),
-            border: Border.all(
-              color: active
-                  ? context.appPalette.accentBright
-                  : _settingsBorderColor(context, .08),
+            border: Border(
+              bottom: BorderSide(
+                color: active
+                    ? context.appPalette.accentBright
+                    : Colors.transparent,
+                width: 3,
+              ),
             ),
           ),
-          child: compact
-              ? Column(
-                  mainAxisAlignment: MainAxisAlignment.center,
-                  children: [
-                    Icon(
-                      icon,
-                      size: 18,
+          child: Row(
+            mainAxisSize: MainAxisSize.min,
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              Flexible(
+                child: FittedBox(
+                  fit: BoxFit.scaleDown,
+                  child: Text(
+                    label,
+                    maxLines: 1,
+                    style: TextStyle(
                       color: active
-                          ? _settingsAccentForeground(context)
-                          : context.appPalette.primaryText,
+                          ? context.appPalette.primaryText
+                          : context.appPalette.mutedText,
+                      fontSize: compact ? 10 : (tvScale ? 16 : 22),
+                      fontWeight: FontWeight.w900,
                     ),
-                    const SizedBox(height: 2),
-                    FittedBox(
-                      fit: BoxFit.scaleDown,
-                      child: Text(
-                        label,
-                        maxLines: 1,
-                        style: TextStyle(
-                          color: active
-                              ? _settingsAccentForeground(context)
-                              : context.appPalette.primaryText,
-                          fontSize: 10,
-                          fontWeight: FontWeight.w900,
-                        ),
-                      ),
-                    ),
-                  ],
-                )
-              : Row(
-                  mainAxisSize: MainAxisSize.min,
-                  children: [
-                    Icon(
-                      icon,
-                      size: 19,
-                      color: active
-                          ? _settingsAccentForeground(context)
-                          : context.appPalette.primaryText,
-                    ),
-                    const SizedBox(width: 8),
-                    Text(
-                      label,
-                      style: TextStyle(
-                        color: active
-                            ? _settingsAccentForeground(context)
-                            : context.appPalette.primaryText,
-                        fontWeight: FontWeight.w900,
-                      ),
-                    ),
-                  ],
+                  ),
                 ),
+              ),
+            ],
+          ),
         ),
       );
     }
 
     return LayoutBuilder(
       builder: (context, constraints) {
-        final compact = constraints.maxWidth < 600;
+        final compact = constraints.maxWidth < 720;
         if (compact) {
           return SizedBox(
-            height: 58,
+            height: 50,
             child: Row(
               children: [
                 for (final area in _SettingsArea.values) ...[
                   if (area != _SettingsArea.values.first)
-                    const SizedBox(width: 5),
+                    const SizedBox(width: 2),
                   Expanded(child: tab(area, compact: true)),
                 ],
               ],
@@ -2324,10 +2623,10 @@ class _SettingsAreaTabs extends StatelessWidget {
           );
         }
         return SizedBox(
-          height: 48,
+          height: tvScale ? 38 : 52,
           child: ListView.separated(
             scrollDirection: Axis.horizontal,
-            padding: const EdgeInsets.symmetric(horizontal: 2, vertical: 2),
+            padding: const EdgeInsets.symmetric(horizontal: 2),
             itemCount: _SettingsArea.values.length,
             separatorBuilder: (_, _) => const SizedBox(width: 8),
             itemBuilder: (context, index) =>
@@ -2339,16 +2638,950 @@ class _SettingsAreaTabs extends StatelessWidget {
   }
 }
 
+class _SettingsResponsiveColumns extends StatelessWidget {
+  const _SettingsResponsiveColumns({
+    required this.left,
+    required this.right,
+    this.leftFlex = 1,
+    this.rightFlex = 1,
+    this.gap = 20,
+  });
+
+  final Widget left;
+  final Widget right;
+  final int leftFlex;
+  final int rightFlex;
+  final double gap;
+  static const double _breakpoint = 800;
+
+  @override
+  Widget build(BuildContext context) => LayoutBuilder(
+    builder: (context, constraints) {
+      if (constraints.maxWidth < _breakpoint) {
+        return Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [left, const SizedBox(height: 18), right],
+        );
+      }
+      return Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Expanded(flex: leftFlex, child: left),
+          SizedBox(width: _usesTvSettingsScale(context) ? gap / 2 : gap),
+          Expanded(flex: rightFlex, child: right),
+        ],
+      );
+    },
+  );
+}
+
+class _SettingsSectionCard extends StatelessWidget {
+  const _SettingsSectionCard({
+    required this.title,
+    required this.subtitle,
+    required this.child,
+    super.key,
+  });
+
+  final String title;
+  final String subtitle;
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) =>
+      _SettingsCardFrame(title: title, subtitle: subtitle, child: child);
+}
+
+class _SettingsCardFrame extends StatelessWidget {
+  const _SettingsCardFrame({
+    required this.title,
+    required this.child,
+    this.subtitle,
+    this.minimumHeight,
+  });
+
+  final String title;
+  final String? subtitle;
+  final double? minimumHeight;
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    final tvScale = _usesTvSettingsScale(context);
+    return _Panel(
+      child: ConstrainedBox(
+        constraints: BoxConstraints(minHeight: minimumHeight ?? 0),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            _AppearanceCardTitle(title),
+            if (subtitle case final detail?) ...[
+              SizedBox(height: tvScale ? 2 : 4),
+              Text(
+                detail,
+                style: TextStyle(
+                  color: context.appPalette.mutedText,
+                  fontSize: tvScale ? 11 : 11,
+                  height: 1.3,
+                ),
+              ),
+            ],
+            SizedBox(height: tvScale ? 5 : 10),
+            DecoratedBox(
+              decoration: BoxDecoration(
+                color: context.appPalette.surface.withValues(alpha: .35),
+                borderRadius: BorderRadius.circular(8),
+                border: Border.all(color: _settingsBorderColor(context, .14)),
+              ),
+              child: _SettingsCardScope(child: child),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _SettingsCardScope extends InheritedWidget {
+  const _SettingsCardScope({required super.child});
+
+  static bool isInset(BuildContext context) =>
+      context.dependOnInheritedWidgetOfExactType<_SettingsCardScope>() != null;
+
+  @override
+  bool updateShouldNotify(_SettingsCardScope oldWidget) => false;
+}
+
+class _AppearanceSettingsLayout extends StatelessWidget {
+  const _AppearanceSettingsLayout({
+    required this.preferences,
+    required this.titlePreference,
+    required this.homeShelves,
+    required this.homeShelfOrder,
+    required this.controller,
+    required this.themeStudioFocusNode,
+    required this.titleLanguageFocusNode,
+    required this.showTitleStyleFocusNode,
+    required this.navigationSizeFocusNode,
+    required this.menuOrderFocusNode,
+    required this.resetFocusNode,
+    required this.featuredFocusNode,
+    required this.posterMetadataFocusNode,
+    required this.continueWatchingFocusNode,
+    required this.displayOptionsFirstFocusNode,
+    required this.inputFeedbackFirstFocusNode,
+    required this.shelfFocusNodes,
+    required this.onOpenThemeStudio,
+    required this.onOpenMenuOrder,
+    required this.onTitleLanguageChanged,
+    required this.onReset,
+    required this.onShelfToggle,
+    required this.onShelfMove,
+  });
+
+  final SettingsPreferences preferences;
+  final TitleLanguagePreference titlePreference;
+  final Set<HomeShelf> homeShelves;
+  final List<HomeShelf> homeShelfOrder;
+  final SettingsPreferencesController controller;
+  final FocusNode themeStudioFocusNode;
+  final FocusNode titleLanguageFocusNode;
+  final FocusNode showTitleStyleFocusNode;
+  final FocusNode navigationSizeFocusNode;
+  final FocusNode menuOrderFocusNode;
+  final FocusNode resetFocusNode;
+  final FocusNode featuredFocusNode;
+  final FocusNode posterMetadataFocusNode;
+  final FocusNode continueWatchingFocusNode;
+  final FocusNode displayOptionsFirstFocusNode;
+  final FocusNode inputFeedbackFirstFocusNode;
+  final Map<HomeShelf, FocusNode> shelfFocusNodes;
+  final VoidCallback onOpenThemeStudio;
+  final VoidCallback onOpenMenuOrder;
+  final ValueChanged<TitleLanguagePreference> onTitleLanguageChanged;
+  final VoidCallback onReset;
+  final ValueChanged<HomeShelf> onShelfToggle;
+  final void Function(HomeShelf shelf, int offset) onShelfMove;
+
+  @override
+  Widget build(BuildContext context) {
+    final mediaSize = MediaQuery.sizeOf(context);
+    final usesTvDashboard =
+        mediaSize.width >= 900 && mediaSize.width > mediaSize.height;
+    Widget paletteDots() => Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        for (final color in const [
+          Color(0xFFFF466C),
+          Color(0xFF6B35D8),
+          Color(0xFF168EE8),
+          Color(0xFF10B7C7),
+          Color(0xFFFFB323),
+        ]) ...[
+          Container(
+            width: usesTvDashboard ? 18 : 18,
+            height: usesTvDashboard ? 18 : 18,
+            decoration: BoxDecoration(color: color, shape: BoxShape.circle),
+          ),
+          if (color != const Color(0xFFFFB323))
+            SizedBox(width: usesTvDashboard ? 4 : 4),
+        ],
+      ],
+    );
+
+    final themeAndDisplay = _AppearanceCard(
+      key: const ValueKey('appearance-theme-display-card'),
+      title: 'Theme & display',
+      minimumHeight: usesTvDashboard ? 188 : null,
+      children: [
+        _AppearanceActionRow(
+          key: const ValueKey('open-theme-studio'),
+          label: 'Theme Studio',
+          icon: Icons.palette_outlined,
+          focusNode: themeStudioFocusNode,
+          autofocus: true,
+          trailing: paletteDots(),
+          showDivider: true,
+          onPressed: onOpenThemeStudio,
+        ),
+        _AppearanceSelectionRow<TitleLanguagePreference>(
+          key: const ValueKey('settings-appearance-title-language'),
+          label: 'Title language',
+          icon: Icons.language_rounded,
+          value: titlePreference,
+          valueLabel: titlePreference.displayName,
+          focusNode: titleLanguageFocusNode,
+          options: [
+            for (final language in TitleLanguagePreference.values)
+              _SettingsOption(value: language, label: language.displayName),
+          ],
+          onSelected: onTitleLanguageChanged,
+          showDivider: true,
+        ),
+        _AppearanceSelectionRow<ShowTitleStyle>(
+          key: const ValueKey('settings-appearance-show-title-style'),
+          label: 'Show title style',
+          icon: Icons.title_rounded,
+          value: preferences.showTitleStyle,
+          valueLabel: preferences.showTitleStyle.displayName,
+          focusNode: showTitleStyleFocusNode,
+          options: [
+            for (final style in ShowTitleStyle.values)
+              _SettingsOption(value: style, label: style.displayName),
+          ],
+          onSelected: controller.setShowTitleStyle,
+        ),
+      ],
+    );
+
+    final navigation = _AppearanceCard(
+      key: const ValueKey('appearance-navigation-card'),
+      title: 'Navigation',
+      minimumHeight: usesTvDashboard ? 188 : null,
+      children: [
+        _AppearanceSelectionRow<NavigationChromeSize>(
+          key: const ValueKey('settings-appearance-navigation-size'),
+          label: 'Navigation size',
+          icon: Icons.open_with_rounded,
+          value: preferences.navigationChromeSize,
+          valueLabel: preferences.navigationChromeSize.displayName,
+          focusNode: navigationSizeFocusNode,
+          options: [
+            for (final size in NavigationChromeSize.values)
+              _SettingsOption(value: size, label: size.displayName),
+          ],
+          onSelected: controller.setNavigationChromeSize,
+          showDivider: true,
+        ),
+        _AppearanceActionRow(
+          key: const ValueKey('settings-appearance-menu-order'),
+          label: 'Menu order',
+          value: 'Customize',
+          icon: Icons.menu_rounded,
+          focusNode: menuOrderFocusNode,
+          showDivider: true,
+          onPressed: onOpenMenuOrder,
+        ),
+        _AppearanceActionRow(
+          key: const ValueKey('settings-appearance-reset'),
+          label: 'Reset appearance and navigation',
+          icon: Icons.refresh_rounded,
+          focusNode: resetFocusNode,
+          showChevron: false,
+          destructive: true,
+          onPressed: onReset,
+        ),
+      ],
+    );
+
+    final homeScreen = _AppearanceCard(
+      key: const ValueKey('appearance-home-screen-card'),
+      title: 'Home screen',
+      minimumHeight: usesTvDashboard ? 386 : null,
+      children: [
+        _AppearanceToggleRow(
+          key: const ValueKey('settings-appearance-featured-hero'),
+          label: 'Featured hero',
+          icon: Icons.star_border_rounded,
+          value: preferences.showHero,
+          focusNode: featuredFocusNode,
+          showDivider: true,
+          onChanged: controller.setShowHero,
+        ),
+        _AppearanceToggleRow(
+          key: const ValueKey('settings-appearance-poster-metadata'),
+          label: 'Poster metadata',
+          icon: Icons.info_outline_rounded,
+          value: preferences.showPosterMetadata,
+          focusNode: posterMetadataFocusNode,
+          showDivider: true,
+          onChanged: controller.setShowPosterMetadata,
+        ),
+        _AppearanceToggleRow(
+          key: const ValueKey('settings-appearance-continue-watching'),
+          label: 'Continue watching',
+          icon: Icons.history_rounded,
+          value: homeShelves.contains(HomeShelf.tracking),
+          focusNode: continueWatchingFocusNode,
+          onChanged: (_) => onShelfToggle(HomeShelf.tracking),
+        ),
+      ],
+    );
+
+    final displayOptions = _AppearanceCard(
+      key: const ValueKey('appearance-display-options-card'),
+      title: 'Display options',
+      children: [
+        _AppearanceSelectionRow<double>(
+          label: 'Interface scale',
+          icon: Icons.zoom_out_map_rounded,
+          value: preferences.interfaceScale,
+          valueLabel: '${(preferences.interfaceScale * 100).round()}%',
+          focusNode: displayOptionsFirstFocusNode,
+          options: [
+            for (final option in const [
+              (.8, '80%'),
+              (.9, '90%'),
+              (1.0, '100%'),
+              (1.1, '110%'),
+              (1.2, '120%'),
+            ])
+              _SettingsOption(value: option.$1, label: option.$2),
+          ],
+          showDivider: true,
+          onSelected: controller.setInterfaceScale,
+        ),
+        _AppearanceSelectionRow<ContentDensity>(
+          label: 'Content density',
+          icon: Icons.view_compact_alt_rounded,
+          value: preferences.contentDensity,
+          valueLabel: preferences.contentDensity.displayName,
+          options: [
+            for (final density in ContentDensity.values)
+              _SettingsOption(value: density, label: density.displayName),
+          ],
+          showDivider: true,
+          onSelected: controller.setContentDensity,
+        ),
+        _AppearanceSelectionRow<double>(
+          label: 'Thumbnail size',
+          icon: Icons.photo_size_select_large_rounded,
+          value: preferences.thumbnailScale,
+          valueLabel: switch (preferences.thumbnailScale) {
+            <= .9 => 'Small',
+            >= 1.1 => 'Large',
+            _ => 'Medium',
+          },
+          options: [
+            for (final option in const [
+              (.85, 'Small'),
+              (1.0, 'Medium'),
+              (1.15, 'Large'),
+            ])
+              _SettingsOption(value: option.$1, label: option.$2),
+          ],
+          showDivider: true,
+          onSelected: controller.setThumbnailScale,
+        ),
+        _AppearanceSelectionRow<HomeLayout>(
+          label: 'Layout style',
+          icon: Icons.dashboard_customize_rounded,
+          value: preferences.homeLayout,
+          valueLabel: preferences.homeLayout.displayName,
+          options: [
+            for (final layout in HomeLayout.values)
+              _SettingsOption(value: layout, label: layout.displayName),
+          ],
+          showDivider: true,
+          onSelected: controller.setHomeLayout,
+        ),
+        _AppearanceSelectionRow<LandingPage>(
+          label: 'Default landing page',
+          icon: Icons.home_work_outlined,
+          value: preferences.defaultLandingPage,
+          valueLabel: preferences.defaultLandingPage.displayName,
+          options: [
+            for (final page in LandingPage.values.where(
+              (page) => switch (page) {
+                LandingPage.home => true,
+                LandingPage.search => preferences.showSearch,
+                LandingPage.myList => preferences.showMyList,
+                LandingPage.discover => preferences.showDiscover,
+                LandingPage.calendar => preferences.showCalendar,
+              },
+            ))
+              _SettingsOption(
+                value: page,
+                label: page.displayName,
+                detail: page.route,
+              ),
+          ],
+          showDivider: true,
+          onSelected: controller.setDefaultLandingPage,
+        ),
+        _AppearanceToggleRow(
+          label: 'Card details',
+          subtitle: 'Show supporting text beneath posters and media cards.',
+          icon: Icons.subtitles_outlined,
+          value: preferences.showCardSubtitles,
+          onChanged: controller.setShowCardSubtitles,
+        ),
+      ],
+    );
+
+    final inputAndFeedback = _AppearanceCard(
+      key: const ValueKey('appearance-input-feedback-card'),
+      title: 'Input & feedback',
+      children: [
+        _AppearanceSelectionRow<bool>(
+          label: 'On-screen keyboard',
+          icon: Icons.keyboard_alt_outlined,
+          value: preferences.useBuiltInKeyboard,
+          valueLabel: preferences.useBuiltInKeyboard ? 'Built-in' : 'Device',
+          focusNode: inputFeedbackFirstFocusNode,
+          options: const [
+            _SettingsOption(value: true, label: 'Built-in'),
+            _SettingsOption(value: false, label: 'Device keyboard'),
+          ],
+          showDivider: true,
+          onSelected: controller.setUseBuiltInKeyboard,
+        ),
+        _AppearanceToggleRow(
+          label: 'Navigation sounds',
+          subtitle: 'Play feedback while moving between controls.',
+          icon: Icons.spatial_audio_off_rounded,
+          value: preferences.navigationSounds,
+          showDivider: true,
+          onChanged: controller.setNavigationSounds,
+        ),
+        _AppearanceToggleRow(
+          label: 'Click sounds',
+          subtitle: 'Play confirmation feedback when selecting an option.',
+          icon: Icons.touch_app_outlined,
+          value: preferences.clickSounds,
+          onChanged: controller.setClickSounds,
+        ),
+      ],
+    );
+
+    final homeShelvesPanel = _AppearanceCard(
+      key: const ValueKey('appearance-home-shelves-card'),
+      title: 'Home shelves',
+      subtitle:
+          'Choose what appears on Home and move favorites toward the top.',
+      children: [
+        for (var index = 0; index < homeShelfOrder.length; index++) ...[
+          _HomeShelfRow(
+            index: index,
+            total: homeShelfOrder.length,
+            shelf: homeShelfOrder[index],
+            enabled: homeShelves.contains(homeShelfOrder[index]),
+            focusNode: shelfFocusNodes[homeShelfOrder[index]]!,
+            onToggle: () => onShelfToggle(homeShelfOrder[index]),
+            onMoveUp: () => onShelfMove(homeShelfOrder[index], -1),
+            onMoveDown: () => onShelfMove(homeShelfOrder[index], 1),
+          ),
+          if (index != homeShelfOrder.length - 1) const SizedBox(height: 6),
+        ],
+      ],
+    );
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        _SettingsResponsiveColumns(
+          leftFlex: 51,
+          rightFlex: 49,
+          gap: usesTvDashboard ? 10 : 20,
+          left: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              themeAndDisplay,
+              SizedBox(height: usesTvDashboard ? 8 : 18),
+              navigation,
+            ],
+          ),
+          right: homeScreen,
+        ),
+        SizedBox(height: usesTvDashboard ? 6 : 12),
+        _SettingsResponsiveColumns(
+          leftFlex: 51,
+          rightFlex: 49,
+          gap: usesTvDashboard ? 10 : 20,
+          left: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              displayOptions,
+              SizedBox(height: usesTvDashboard ? 6 : 12),
+              inputAndFeedback,
+            ],
+          ),
+          right: homeShelvesPanel,
+        ),
+      ],
+    );
+  }
+}
+
+class _AppearanceCard extends StatelessWidget {
+  const _AppearanceCard({
+    required this.title,
+    required this.children,
+    this.subtitle,
+    this.minimumHeight,
+    super.key,
+  });
+
+  final String title;
+  final String? subtitle;
+  final List<Widget> children;
+  final double? minimumHeight;
+
+  @override
+  Widget build(BuildContext context) => _SettingsCardFrame(
+    title: title,
+    subtitle: subtitle,
+    minimumHeight: minimumHeight,
+    child: Column(children: children),
+  );
+}
+
+class _AppearanceCardTitle extends StatelessWidget {
+  const _AppearanceCardTitle(this.title);
+
+  final String title;
+
+  @override
+  Widget build(BuildContext context) {
+    final mediaSize = MediaQuery.sizeOf(context);
+    final tvScale =
+        mediaSize.width >= 900 && mediaSize.width > mediaSize.height;
+    return Text(
+      title,
+      style: TextStyle(
+        color: _settingsPrimaryText(context),
+        fontSize: tvScale ? 18 : 16,
+        fontWeight: FontWeight.w800,
+      ),
+    );
+  }
+}
+
+class _AppearanceActionRow extends StatefulWidget {
+  const _AppearanceActionRow({
+    required this.label,
+    required this.icon,
+    required this.onPressed,
+    this.subtitle,
+    this.value,
+    this.trailing,
+    this.focusNode,
+    this.autofocus = false,
+    this.showDivider = false,
+    this.showChevron = true,
+    this.destructive = false,
+    super.key,
+  });
+
+  final String label;
+  final String? subtitle;
+  final String? value;
+  final Widget? trailing;
+  final IconData icon;
+  final VoidCallback onPressed;
+  final FocusNode? focusNode;
+  final bool autofocus;
+  final bool showDivider;
+  final bool showChevron;
+  final bool destructive;
+
+  @override
+  State<_AppearanceActionRow> createState() => _AppearanceActionRowState();
+}
+
+class _AppearanceActionRowState extends State<_AppearanceActionRow> {
+  bool _focused = false;
+
+  @override
+  Widget build(BuildContext context) {
+    final mediaSize = MediaQuery.sizeOf(context);
+    final tvScale =
+        mediaSize.width >= 900 && mediaSize.width > mediaSize.height;
+    return TvFocusable(
+      focusNode: widget.focusNode,
+      autofocus: widget.autofocus,
+      onFocusChanged: (focused) {
+        if (_focused != focused) setState(() => _focused = focused);
+      },
+      onPressed: widget.onPressed,
+      focusScale: 1.005,
+      borderRadius: BorderRadius.circular(7),
+      child: AnimatedContainer(
+        duration: const Duration(milliseconds: 100),
+        constraints: BoxConstraints(minHeight: tvScale ? 48 : 64),
+        padding: EdgeInsets.symmetric(
+          horizontal: tvScale ? 10 : 13,
+          vertical: tvScale ? 5 : 11,
+        ),
+        decoration: BoxDecoration(
+          color: context.appPalette.surface,
+          border: Border(
+            bottom: BorderSide(
+              color: widget.showDivider
+                  ? _settingsBorderColor(context, .14)
+                  : Colors.transparent,
+            ),
+          ),
+        ),
+        child: Row(
+          children: [
+            Icon(
+              widget.icon,
+              size: tvScale ? 22 : 22,
+              color: widget.destructive
+                  ? context.appPalette.mutedText
+                  : (_focused
+                        ? context.appPalette.accentBright
+                        : _settingsPrimaryText(context)),
+            ),
+            SizedBox(width: tvScale ? 8 : 14),
+            Expanded(
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    widget.label,
+                    maxLines: 2,
+                    overflow: TextOverflow.ellipsis,
+                    style: TextStyle(
+                      color: widget.destructive
+                          ? context.appPalette.mutedText
+                          : _settingsPrimaryText(context),
+                      fontSize: tvScale ? 16 : 14,
+                      fontWeight: FontWeight.w700,
+                    ),
+                  ),
+                  if (widget.subtitle case final subtitle?) ...[
+                    SizedBox(height: tvScale ? 2 : 3),
+                    Text(
+                      subtitle,
+                      maxLines: tvScale ? 2 : 3,
+                      overflow: TextOverflow.ellipsis,
+                      style: TextStyle(
+                        color: context.appPalette.mutedText,
+                        fontSize: tvScale ? 12 : 11,
+                        height: 1.25,
+                      ),
+                    ),
+                  ],
+                ],
+              ),
+            ),
+            if (widget.trailing case final trailing?) ...[
+              SizedBox(width: tvScale ? 6 : 10),
+              trailing,
+            ] else if (widget.value case final value?) ...[
+              SizedBox(width: tvScale ? 6 : 10),
+              Flexible(
+                child: Text(
+                  value,
+                  maxLines: 2,
+                  overflow: TextOverflow.ellipsis,
+                  textAlign: TextAlign.end,
+                  style: TextStyle(
+                    color: context.appPalette.mutedText,
+                    fontSize: tvScale ? 14 : 13,
+                    fontWeight: FontWeight.w600,
+                  ),
+                ),
+              ),
+            ],
+            if (widget.showChevron) ...[
+              SizedBox(width: tvScale ? 5 : 8),
+              Icon(
+                Icons.chevron_right_rounded,
+                size: tvScale ? 22 : 22,
+                color: _settingsPrimaryText(context),
+              ),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _SettingsSupportingText extends StatelessWidget {
+  const _SettingsSupportingText(this.text);
+
+  final String text;
+
+  @override
+  Widget build(BuildContext context) {
+    final tvScale = _usesTvSettingsScale(context);
+    return Container(
+      width: double.infinity,
+      padding: EdgeInsets.symmetric(
+        horizontal: tvScale ? 10 : 13,
+        vertical: tvScale ? 5 : 9,
+      ),
+      decoration: BoxDecoration(
+        color: context.appPalette.surface,
+        border: Border(
+          bottom: BorderSide(color: _settingsBorderColor(context, .14)),
+        ),
+      ),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Icon(
+            Icons.info_outline_rounded,
+            size: tvScale ? 18 : 18,
+            color: context.appPalette.mutedText,
+          ),
+          SizedBox(width: tvScale ? 7 : 14),
+          Expanded(
+            child: Text(
+              text,
+              style: TextStyle(
+                color: context.appPalette.mutedText,
+                fontSize: tvScale ? 12 : 11,
+                height: 1.35,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _AppearanceSelectionRow<T> extends StatelessWidget {
+  const _AppearanceSelectionRow({
+    required this.label,
+    required this.icon,
+    required this.value,
+    required this.valueLabel,
+    required this.options,
+    required this.onSelected,
+    this.focusNode,
+    this.showDivider = false,
+    super.key,
+  });
+
+  final String label;
+  final IconData icon;
+  final T value;
+  final String valueLabel;
+  final List<_SettingsOption<T>> options;
+  final ValueChanged<T> onSelected;
+  final FocusNode? focusNode;
+  final bool showDivider;
+
+  @override
+  Widget build(BuildContext context) => _AppearanceActionRow(
+    label: label,
+    value: valueLabel,
+    icon: icon,
+    focusNode: focusNode,
+    showDivider: showDivider,
+    onPressed: () async {
+      final selected = await showDialog<T>(
+        context: context,
+        barrierDismissible: true,
+        builder: (context) {
+          final tvScale = _usesTvSettingsScale(context);
+          return Dialog(
+            backgroundColor: Colors.transparent,
+            child: Container(
+              width: tvScale ? 430 : 560,
+              padding: EdgeInsets.all(tvScale ? 11 : 22),
+              decoration: BoxDecoration(
+                color: context.appPalette.surface,
+                borderRadius: BorderRadius.circular(14),
+                border: Border.all(
+                  color: context.appPalette.accent.withValues(alpha: .7),
+                ),
+              ),
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    label,
+                    style: Theme.of(context).textTheme.titleLarge?.copyWith(
+                      fontSize: tvScale ? 18 : null,
+                      fontWeight: FontWeight.w800,
+                    ),
+                  ),
+                  SizedBox(height: tvScale ? 7 : 14),
+                  for (var index = 0; index < options.length; index++) ...[
+                    TvFocusable(
+                      autofocus: options[index].value == value,
+                      onPressed: () =>
+                          Navigator.of(context).pop(options[index].value),
+                      borderRadius: BorderRadius.circular(9),
+                      child: Container(
+                        width: double.infinity,
+                        padding: EdgeInsets.symmetric(
+                          horizontal: tvScale ? 9 : 16,
+                          vertical: tvScale ? 6 : 13,
+                        ),
+                        decoration: BoxDecoration(
+                          color: options[index].value == value
+                              ? context.appPalette.accent.withValues(alpha: .25)
+                              : context.appPalette.surfaceRaised,
+                          borderRadius: BorderRadius.circular(9),
+                        ),
+                        child: Row(
+                          children: [
+                            Icon(
+                              options[index].value == value
+                                  ? Icons.radio_button_checked_rounded
+                                  : Icons.radio_button_off_rounded,
+                              color: options[index].value == value
+                                  ? context.appPalette.accentBright
+                                  : context.appPalette.mutedText,
+                            ),
+                            SizedBox(width: tvScale ? 7 : 12),
+                            Expanded(
+                              child: Column(
+                                crossAxisAlignment: CrossAxisAlignment.start,
+                                children: [
+                                  Text(
+                                    options[index].label,
+                                    style: TextStyle(
+                                      color: _settingsPrimaryText(context),
+                                      fontWeight: FontWeight.w900,
+                                    ),
+                                  ),
+                                  if (options[index].detail
+                                      case final detail?) ...[
+                                    const SizedBox(height: 2),
+                                    Text(
+                                      detail,
+                                      style: TextStyle(
+                                        color: context.appPalette.mutedText,
+                                        fontSize: tvScale ? 12 : 11,
+                                      ),
+                                    ),
+                                  ],
+                                ],
+                              ),
+                            ),
+                          ],
+                        ),
+                      ),
+                    ),
+                    if (index != options.length - 1)
+                      SizedBox(height: tvScale ? 4 : 8),
+                  ],
+                ],
+              ),
+            ),
+          );
+        },
+      );
+      if (selected != null) onSelected(selected);
+    },
+  );
+}
+
+class _AppearanceToggleRow extends StatelessWidget {
+  const _AppearanceToggleRow({
+    required this.label,
+    required this.icon,
+    required this.value,
+    required this.onChanged,
+    this.focusNode,
+    this.subtitle,
+    this.showDivider = false,
+    super.key,
+  });
+
+  final String label;
+  final IconData icon;
+  final bool value;
+  final ValueChanged<bool> onChanged;
+  final FocusNode? focusNode;
+  final String? subtitle;
+  final bool showDivider;
+
+  @override
+  Widget build(BuildContext context) {
+    final tvScale = _usesTvSettingsScale(context);
+    return _AppearanceActionRow(
+      label: label,
+      subtitle: subtitle,
+      icon: icon,
+      focusNode: focusNode,
+      showDivider: showDivider,
+      showChevron: false,
+      trailing: AnimatedContainer(
+        duration: const Duration(milliseconds: 130),
+        width: tvScale ? 36 : 48,
+        height: tvScale ? 20 : 26,
+        padding: EdgeInsets.all(tvScale ? 2 : 3),
+        decoration: BoxDecoration(
+          color: value
+              ? context.appPalette.accentBright
+              : context.appPalette.surfaceRaised,
+          borderRadius: BorderRadius.circular(20),
+          border: Border.all(color: _settingsBorderColor(context, .18)),
+        ),
+        child: AnimatedAlign(
+          duration: const Duration(milliseconds: 130),
+          alignment: value ? Alignment.centerRight : Alignment.centerLeft,
+          child: Container(
+            width: tvScale ? 16 : 20,
+            height: tvScale ? 16 : 20,
+            decoration: BoxDecoration(
+              color: value
+                  ? context.appPalette.primaryText
+                  : context.appPalette.mutedText,
+              shape: BoxShape.circle,
+            ),
+          ),
+        ),
+      ),
+      onPressed: () => onChanged(!value),
+    );
+  }
+}
+
 class _SettingsOption<T> {
   const _SettingsOption({
     required this.value,
     required this.label,
     this.detail,
+    this.enabled = true,
   });
 
   final T value;
   final String label;
   final String? detail;
+  final bool enabled;
 }
 
 class _SettingsSelection<T> extends StatelessWidget {
@@ -2358,6 +3591,7 @@ class _SettingsSelection<T> extends StatelessWidget {
     required this.options,
     required this.onSelected,
     this.focusNode,
+    this.showDivider = false,
     super.key,
   });
 
@@ -2366,204 +3600,147 @@ class _SettingsSelection<T> extends StatelessWidget {
   final List<_SettingsOption<T>> options;
   final ValueChanged<T> onSelected;
   final FocusNode? focusNode;
+  final bool showDivider;
 
   @override
   Widget build(BuildContext context) {
     final selected = options.firstWhere((option) => option.value == value);
-    return TvFocusable(
+    return _AppearanceActionRow(
+      label: label,
+      subtitle: selected.detail,
+      value: selected.label,
+      icon: _settingsIconForLabel(label),
       focusNode: focusNode,
+      showDivider: showDivider,
       onPressed: () async {
         final result = await showDialog<T>(
           context: context,
           barrierDismissible: true,
-          builder: (context) => Dialog(
-            backgroundColor: Colors.transparent,
-            child: Container(
-              width: 560,
-              padding: const EdgeInsets.all(22),
-              decoration: BoxDecoration(
-                color: context.appPalette.surface,
-                borderRadius: BorderRadius.circular(14),
-                border: Border.all(
-                  color: context.appPalette.accent.withValues(alpha: .7),
+          builder: (context) {
+            final tvScale = _usesTvSettingsScale(context);
+            return Dialog(
+              backgroundColor: Colors.transparent,
+              child: Container(
+                width: tvScale ? 430 : 560,
+                padding: EdgeInsets.all(tvScale ? 11 : 22),
+                decoration: BoxDecoration(
+                  color: context.appPalette.surface,
+                  borderRadius: BorderRadius.circular(14),
+                  border: Border.all(
+                    color: context.appPalette.accent.withValues(alpha: .7),
+                  ),
                 ),
-              ),
-              child: ConstrainedBox(
-                constraints: BoxConstraints(
-                  maxHeight: MediaQuery.sizeOf(context).height * .78,
-                ),
-                child: Column(
-                  mainAxisSize: MainAxisSize.min,
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    Text(label, style: Theme.of(context).textTheme.titleLarge),
-                    const SizedBox(height: 14),
-                    Flexible(
-                      child: ListView.separated(
-                        shrinkWrap: true,
-                        itemCount: options.length,
-                        separatorBuilder: (_, _) => const SizedBox(height: 8),
-                        itemBuilder: (context, index) {
-                          final option = options[index];
-                          return TvFocusable(
-                            autofocus: option.value == value,
-                            onPressed: () =>
-                                Navigator.of(context).pop(option.value),
-                            borderRadius: BorderRadius.circular(9),
-                            child: Container(
-                              width: double.infinity,
-                              padding: const EdgeInsets.symmetric(
-                                horizontal: 16,
-                                vertical: 13,
-                              ),
-                              decoration: BoxDecoration(
-                                color: option.value == value
-                                    ? context.appPalette.accent.withValues(
-                                        alpha: .28,
-                                      )
-                                    : context.appPalette.surfaceRaised,
-                                borderRadius: BorderRadius.circular(9),
-                              ),
-                              child: Row(
-                                children: [
-                                  Icon(
-                                    option.value == value
-                                        ? Icons.radio_button_checked_rounded
-                                        : Icons.radio_button_off_rounded,
-                                    color: option.value == value
-                                        ? context.appPalette.accentBright
-                                        : context.appPalette.mutedText,
-                                  ),
-                                  const SizedBox(width: 12),
-                                  Expanded(
-                                    child: Column(
-                                      crossAxisAlignment:
-                                          CrossAxisAlignment.start,
-                                      children: [
-                                        Text(
-                                          option.label,
-                                          style: TextStyle(
-                                            color: _settingsPrimaryText(
-                                              context,
-                                            ),
-                                            fontWeight: FontWeight.w900,
-                                          ),
-                                        ),
-                                        if (option.detail
-                                            case final detail?) ...[
-                                          const SizedBox(height: 2),
-                                          Text(
-                                            detail,
-                                            style: TextStyle(
-                                              color:
-                                                  context.appPalette.mutedText,
-                                              fontSize: 11,
-                                            ),
-                                          ),
-                                        ],
-                                      ],
-                                    ),
-                                  ),
-                                ],
-                              ),
-                            ),
-                          );
-                        },
+                child: ConstrainedBox(
+                  constraints: BoxConstraints(
+                    maxHeight: MediaQuery.sizeOf(context).height * .78,
+                  ),
+                  child: Column(
+                    mainAxisSize: MainAxisSize.min,
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        label,
+                        style: Theme.of(context).textTheme.titleLarge?.copyWith(
+                          fontSize: tvScale ? 18 : null,
+                          fontWeight: FontWeight.w800,
+                        ),
                       ),
-                    ),
-                  ],
+                      SizedBox(height: tvScale ? 7 : 14),
+                      Flexible(
+                        child: ListView.separated(
+                          shrinkWrap: true,
+                          itemCount: options.length,
+                          separatorBuilder: (_, _) =>
+                              SizedBox(height: tvScale ? 4 : 8),
+                          itemBuilder: (context, index) {
+                            final option = options[index];
+                            final optionControl = TvFocusable(
+                              autofocus:
+                                  option.enabled && option.value == value,
+                              onPressed: () =>
+                                  Navigator.of(context).pop(option.value),
+                              borderRadius: BorderRadius.circular(9),
+                              child: Container(
+                                width: double.infinity,
+                                padding: EdgeInsets.symmetric(
+                                  horizontal: tvScale ? 9 : 16,
+                                  vertical: tvScale ? 6 : 13,
+                                ),
+                                decoration: BoxDecoration(
+                                  color: option.value == value
+                                      ? context.appPalette.accent.withValues(
+                                          alpha: .28,
+                                        )
+                                      : context.appPalette.surfaceRaised,
+                                  borderRadius: BorderRadius.circular(9),
+                                ),
+                                child: Row(
+                                  children: [
+                                    Icon(
+                                      option.value == value
+                                          ? Icons.radio_button_checked_rounded
+                                          : Icons.radio_button_off_rounded,
+                                      color: option.value == value
+                                          ? context.appPalette.accentBright
+                                          : context.appPalette.mutedText,
+                                    ),
+                                    SizedBox(width: tvScale ? 7 : 12),
+                                    Expanded(
+                                      child: Column(
+                                        crossAxisAlignment:
+                                            CrossAxisAlignment.start,
+                                        children: [
+                                          Text(
+                                            option.label,
+                                            style: TextStyle(
+                                              color: _settingsPrimaryText(
+                                                context,
+                                              ),
+                                              fontWeight: FontWeight.w900,
+                                            ),
+                                          ),
+                                          if (option.detail
+                                              case final detail?) ...[
+                                            const SizedBox(height: 2),
+                                            Text(
+                                              detail,
+                                              style: TextStyle(
+                                                color: context
+                                                    .appPalette
+                                                    .mutedText,
+                                                fontSize: tvScale ? 12 : 11,
+                                              ),
+                                            ),
+                                          ],
+                                        ],
+                                      ),
+                                    ),
+                                  ],
+                                ),
+                              ),
+                            );
+                            if (option.enabled) return optionControl;
+                            return ExcludeFocus(
+                              excluding: true,
+                              child: IgnorePointer(
+                                child: Opacity(
+                                  opacity: .45,
+                                  child: optionControl,
+                                ),
+                              ),
+                            );
+                          },
+                        ),
+                      ),
+                    ],
+                  ),
                 ),
               ),
-            ),
-          ),
+            );
+          },
         );
         if (result != null) onSelected(result);
       },
-      borderRadius: BorderRadius.circular(10),
-      focusScale: 1.01,
-      child: Container(
-        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
-        decoration: BoxDecoration(
-          color: context.appPalette.surface,
-          borderRadius: BorderRadius.circular(10),
-          border: Border.all(color: _settingsBorderColor(context, .1)),
-        ),
-        child: LayoutBuilder(
-          builder: (context, constraints) {
-            final value = Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                Text(
-                  selected.label,
-                  style: TextStyle(
-                    color: _settingsPrimaryText(context),
-                    fontWeight: FontWeight.w900,
-                  ),
-                ),
-                if (selected.detail case final detail?)
-                  Text(
-                    detail,
-                    maxLines: 1,
-                    overflow: TextOverflow.ellipsis,
-                    style: TextStyle(
-                      color: context.appPalette.mutedText,
-                      fontSize: 10,
-                    ),
-                  ),
-              ],
-            );
-            if (constraints.maxWidth < 560) {
-              return Row(
-                children: [
-                  Expanded(
-                    child: Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: [
-                        Text(
-                          label,
-                          style: TextStyle(
-                            color: context.appPalette.mutedText,
-                            fontSize: 10,
-                            fontWeight: FontWeight.w800,
-                          ),
-                        ),
-                        const SizedBox(height: 4),
-                        value,
-                      ],
-                    ),
-                  ),
-                  Icon(
-                    Icons.expand_more_rounded,
-                    color: context.appPalette.accentBright,
-                  ),
-                ],
-              );
-            }
-            return Row(
-              children: [
-                SizedBox(
-                  width: 180,
-                  child: Text(
-                    label,
-                    style: TextStyle(
-                      color: context.appPalette.mutedText,
-                      fontSize: 12,
-                      fontWeight: FontWeight.w800,
-                    ),
-                  ),
-                ),
-                Expanded(child: value),
-                const SizedBox(width: 12),
-                Icon(
-                  Icons.expand_more_rounded,
-                  color: context.appPalette.accentBright,
-                ),
-              ],
-            );
-          },
-        ),
-      ),
     );
   }
 }
@@ -2585,70 +3762,18 @@ class _SettingsNavigationRow extends StatelessWidget {
   final FocusNode? focusNode;
 
   @override
-  Widget build(BuildContext context) => TvFocusable(
+  Widget build(BuildContext context) => _AppearanceActionRow(
+    label: label,
+    subtitle: detail,
+    icon: icon,
     focusNode: focusNode,
     onPressed: onPressed,
-    borderRadius: BorderRadius.circular(10),
-    focusScale: 1.01,
-    child: Container(
-      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
-      decoration: BoxDecoration(
-        color: context.appPalette.surface,
-        borderRadius: BorderRadius.circular(10),
-        border: Border.all(color: _settingsBorderColor(context, .1)),
-      ),
-      child: Row(
-        children: [
-          Container(
-            width: 38,
-            height: 38,
-            decoration: BoxDecoration(
-              color: context.appPalette.accent.withValues(alpha: .15),
-              borderRadius: BorderRadius.circular(9),
-            ),
-            child: Icon(icon, color: context.appPalette.accentBright, size: 21),
-          ),
-          const SizedBox(width: 12),
-          Expanded(
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                Text(
-                  label,
-                  style: TextStyle(
-                    color: _settingsPrimaryText(context),
-                    fontWeight: FontWeight.w900,
-                  ),
-                ),
-                const SizedBox(height: 2),
-                Text(
-                  detail,
-                  maxLines: 2,
-                  overflow: TextOverflow.ellipsis,
-                  style: TextStyle(
-                    color: context.appPalette.mutedText,
-                    fontSize: 11,
-                  ),
-                ),
-              ],
-            ),
-          ),
-          const SizedBox(width: 12),
-          Icon(
-            Icons.chevron_right_rounded,
-            color: context.appPalette.accentBright,
-          ),
-        ],
-      ),
-    ),
   );
 }
 
 class _CustomizationPanel extends StatelessWidget {
   const _CustomizationPanel({
     required this.preferences,
-    required this.showAnonymousUsageCount,
     required this.titlePreference,
     required this.titleLanguageFocusNode,
     required this.showTitleStyleFocusNode,
@@ -2668,10 +3793,17 @@ class _CustomizationPanel extends StatelessWidget {
     required this.onSectionExpandedChanged,
     required this.onOpenThemeStudio,
     required this.onReset,
+    this.visibleSections = const {
+      _CustomizationSection.display,
+      _CustomizationSection.homeNavigation,
+      _CustomizationSection.inputFeedback,
+      _CustomizationSection.closedCaptions,
+      _CustomizationSection.playerControls,
+    },
+    this.showReset = true,
   });
 
   final SettingsPreferences preferences;
-  final bool showAnonymousUsageCount;
   final TitleLanguagePreference titlePreference;
   final FocusNode titleLanguageFocusNode;
   final FocusNode showTitleStyleFocusNode;
@@ -2692,6 +3824,8 @@ class _CustomizationPanel extends StatelessWidget {
   onSectionExpandedChanged;
   final VoidCallback onOpenThemeStudio;
   final VoidCallback onReset;
+  final Set<_CustomizationSection> visibleSections;
+  final bool showReset;
 
   @override
   Widget build(BuildContext context) {
@@ -2707,10 +3841,10 @@ class _CustomizationPanel extends StatelessWidget {
       onPressed: () => onChanged(!value),
     );
 
-    return _Panel(
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
+    final content = Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        if (visibleSections.contains(_CustomizationSection.display))
           _InlineCollapsibleSection(
             key: const ValueKey('customize-section-display'),
             label: 'DISPLAY',
@@ -2812,6 +3946,7 @@ class _CustomizationPanel extends StatelessWidget {
                       ),
                   ],
                   onSelected: onTitleLanguageChanged,
+                  showDivider: true,
                 ),
                 _PreferenceRow(
                   label: 'Show title style',
@@ -2831,7 +3966,10 @@ class _CustomizationPanel extends StatelessWidget {
               ],
             ),
           ),
+        if (visibleSections.contains(_CustomizationSection.homeNavigation) &&
+            visibleSections.contains(_CustomizationSection.display))
           const _PreferenceDivider(),
+        if (visibleSections.contains(_CustomizationSection.homeNavigation))
           _InlineCollapsibleSection(
             key: const ValueKey('customize-section-home-navigation'),
             label: 'HOME & NAVIGATION',
@@ -2867,6 +4005,7 @@ class _CustomizationPanel extends StatelessWidget {
                       ),
                   ],
                   onSelected: controller.setDefaultLandingPage,
+                  showDivider: true,
                 ),
                 _PreferenceRow(
                   label: 'Home content',
@@ -2907,7 +4046,14 @@ class _CustomizationPanel extends StatelessWidget {
               ],
             ),
           ),
+        if (visibleSections.contains(_CustomizationSection.inputFeedback) &&
+            visibleSections.any(
+              (section) =>
+                  section == _CustomizationSection.display ||
+                  section == _CustomizationSection.homeNavigation,
+            ))
           const _PreferenceDivider(),
+        if (visibleSections.contains(_CustomizationSection.inputFeedback))
           _InlineCollapsibleSection(
             key: const ValueKey('customize-section-input-feedback'),
             label: 'INPUT & FEEDBACK',
@@ -2952,66 +4098,25 @@ class _CustomizationPanel extends StatelessWidget {
                     ),
                   ],
                 ),
-                _PreferenceRow(
-                  label: 'Privacy diagnostics',
-                  children: [
-                    toggle(
-                      label: 'Anonymous error reports',
-                      value: preferences.anonymousCrashReportingEnabled,
-                      onChanged: controller.setAnonymousCrashReportingEnabled,
-                    ),
-                  ],
-                ),
-                Padding(
-                  padding: const EdgeInsets.only(top: 2, bottom: 4),
-                  child: Text(
-                    'Off by default. Sends only the app/build, error type and time, '
-                    'Android version, CPU architecture, device class, and a '
-                    'redacted technical trace. No show, episode, '
-                    'account, device ID, source, or URL is sent.',
-                    style: TextStyle(
-                      color: context.appPalette.mutedText,
-                      fontSize: 10,
-                      height: 1.35,
-                    ),
-                  ),
-                ),
-                if (showAnonymousUsageCount) ...[
-                  _PreferenceRow(
-                    label: 'Beta community activity',
-                    children: [
-                      toggle(
-                        label: 'Anonymous live count',
-                        value: preferences.anonymousUsageCountEnabled,
-                        onChanged: controller.setAnonymousUsageCountEnabled,
-                      ),
-                    ],
-                  ),
-                  Padding(
-                    padding: const EdgeInsets.only(top: 2, bottom: 4),
-                    child: Text(
-                      'On by default for Beta builds. Shares only whether this '
-                      'app process is active or has an MPV player open. A paused '
-                      'or loading player can still count as watching. No profile, title, '
-                      'episode, source, device ID, URL, or media information is '
-                      'sent. Ordinary HTTPS delivery and short-lived abuse '
-                      'limits may process your IP address, but it is not stored '
-                      'in the presence record.',
-                      style: TextStyle(
-                        color: context.appPalette.mutedText,
-                        fontSize: 10,
-                        height: 1.35,
-                      ),
-                    ),
-                  ),
-                ],
               ],
             ),
           ),
+        if (visibleSections.contains(_CustomizationSection.closedCaptions) &&
+            visibleSections.any(
+              (section) =>
+                  section == _CustomizationSection.display ||
+                  section == _CustomizationSection.homeNavigation ||
+                  section == _CustomizationSection.inputFeedback,
+            ))
           const _PreferenceDivider(),
+        if (visibleSections.contains(_CustomizationSection.closedCaptions))
           _InlineCollapsibleSection(
             key: const ValueKey('customize-section-closed-captions'),
-            label: 'CLOSED CAPTIONS',
+            semanticId: 'closed-captions',
+            direct: visibleSections.length == 1,
+            label: visibleSections.length == 1
+                ? 'CAPTION OPTIONS'
+                : 'CLOSED CAPTIONS',
             focusNode: closedCaptionsSectionFocusNode,
             firstChildFocusNode: captionTextColorFocusNode,
             expanded: expandedSections.contains(
@@ -3025,62 +4130,72 @@ class _CustomizationPanel extends StatelessWidget {
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
                 const SizedBox(height: 6),
-                _PreferenceRow(
+                _AppearanceSelectionRow<int>(
                   label: 'Text color',
-                  children: [
+                  icon: Icons.format_color_text_rounded,
+                  value: preferences.captionTextColor,
+                  valueLabel: switch (preferences.captionTextColor) {
+                    0xFFFFFF66 => 'Yellow',
+                    0xFF66E7FF => 'Cyan',
+                    _ => 'White',
+                  },
+                  focusNode: captionTextColorFocusNode,
+                  options: [
                     for (final option in const [
                       (0xFFFFFFFF, 'White'),
                       (0xFFFFFF66, 'Yellow'),
                       (0xFF66E7FF, 'Cyan'),
                     ])
-                      _PreferenceChip(
-                        label: option.$2,
-                        selected: preferences.captionTextColor == option.$1,
-                        focusNode: option.$2 == 'White'
-                            ? captionTextColorFocusNode
-                            : null,
-                        swatch: Color(option.$1),
-                        onPressed: () =>
-                            controller.setCaptionTextColor(option.$1),
-                      ),
+                      _SettingsOption(value: option.$1, label: option.$2),
                   ],
+                  showDivider: true,
+                  onSelected: controller.setCaptionTextColor,
                 ),
-                _PreferenceRow(
+                _AppearanceSelectionRow<int>(
                   label: 'Background',
-                  children: [
+                  icon: Icons.format_color_fill_rounded,
+                  value: preferences.captionBackgroundColor,
+                  valueLabel: switch (preferences.captionBackgroundColor) {
+                    0x99000000 => 'Dark',
+                    0xDD000000 => 'Strong',
+                    _ => 'Off',
+                  },
+                  options: [
                     for (final option in const [
                       (0x00000000, 'Off'),
                       (0x99000000, 'Dark'),
                       (0xDD000000, 'Strong'),
                     ])
-                      _PreferenceChip(
-                        label: option.$2,
-                        selected:
-                            preferences.captionBackgroundColor == option.$1,
-                        swatch: Color(option.$1),
-                        onPressed: () =>
-                            controller.setCaptionBackgroundColor(option.$1),
-                      ),
+                      _SettingsOption(value: option.$1, label: option.$2),
                   ],
+                  showDivider: true,
+                  onSelected: controller.setCaptionBackgroundColor,
                 ),
-                _PreferenceRow(
+                _AppearanceSelectionRow<double>(
                   label: 'Text size',
-                  children: [
+                  icon: Icons.text_fields_rounded,
+                  value: preferences.captionTextSize,
+                  valueLabel: '${preferences.captionTextSize.round()}',
+                  options: [
                     for (final size in const [28.0, 34.0, 42.0, 50.0])
-                      _PreferenceChip(
-                        label: '${size.round()}',
-                        selected: preferences.captionTextSize == size,
-                        onPressed: () => controller.setCaptionTextSize(size),
-                      ),
+                      _SettingsOption(value: size, label: '${size.round()}'),
                   ],
+                  onSelected: controller.setCaptionTextSize,
                 ),
               ],
             ),
           ),
+        if (visibleSections.contains(_CustomizationSection.playerControls) &&
+            visibleSections.length > 1)
           const _PreferenceDivider(),
+        if (visibleSections.contains(_CustomizationSection.playerControls))
           _InlineCollapsibleSection(
             key: const ValueKey('customize-section-player-controls'),
-            label: 'PLAYER CONTROLS',
+            semanticId: 'player-controls',
+            direct: visibleSections.length == 1,
+            label: visibleSections.length == 1
+                ? 'PLAYBACK OPTIONS'
+                : 'PLAYER CONTROLS',
             focusNode: playerControlsSectionFocusNode,
             expanded: expandedSections.contains(
               _CustomizationSection.playerControls,
@@ -3095,11 +4210,16 @@ class _CustomizationPanel extends StatelessWidget {
                 _ExternalPlayerDefaultSelection(
                   preferences: preferences,
                   controller: controller,
+                  focusNode: visibleSections.length == 1
+                      ? playerControlsSectionFocusNode
+                      : null,
                 ),
                 const SizedBox(height: 8),
-                _SettingsSelection<PlaybackAudioPreference>(
+                _AppearanceSelectionRow<PlaybackAudioPreference>(
                   label: 'Preferred audio',
+                  icon: Icons.graphic_eq_rounded,
                   value: preferences.preferredAudio,
+                  valueLabel: preferences.preferredAudio.displayName,
                   options: [
                     for (final preference in PlaybackAudioPreference.values)
                       _SettingsOption(
@@ -3108,83 +4228,75 @@ class _CustomizationPanel extends StatelessWidget {
                         detail: preference.description,
                       ),
                   ],
+                  showDivider: true,
                   onSelected: controller.setPreferredAudio,
                 ),
-                const SizedBox(height: 8),
-                _PreferenceRow(
-                  label: 'External player',
-                  children: [
-                    toggle(
-                      label: 'Allow Open externally',
-                      value: preferences.externalPlayerEnabled,
-                      onChanged: controller.setExternalPlayerEnabled,
-                    ),
-                  ],
+                _AppearanceToggleRow(
+                  label: 'Open externally',
+                  subtitle:
+                      'Offer installed video players for compatible, header-free streams.',
+                  icon: Icons.open_in_new_rounded,
+                  value: preferences.externalPlayerEnabled,
+                  showDivider: true,
+                  onChanged: controller.setExternalPlayerEnabled,
                 ),
-                Padding(
-                  padding: const EdgeInsets.only(bottom: 8),
-                  child: Text(
-                    'Adds an Open externally action for compatible streams. '
-                    'Turning this off returns the default to MPV. TetoTV never '
-                    'shares account headers or private-server credentials.',
-                    style: TextStyle(
-                      color: context.appPalette.mutedText,
-                      fontSize: 10,
-                      height: 1.35,
-                    ),
-                  ),
+                const _SettingsSupportingText(
+                  'Adds an Open externally action for compatible streams. '
+                  'Turning this off returns the default to MPV. TetoTV never '
+                  'shares account headers or private-server credentials.',
                 ),
-                _PreferenceRow(
+                _AppearanceSelectionRow<int>(
                   label: 'Rewind',
-                  children: [
+                  icon: Icons.replay_10_rounded,
+                  value: preferences.seekBackSeconds,
+                  valueLabel: '${preferences.seekBackSeconds}s',
+                  options: [
                     for (final seconds in const [5, 10, 15, 30, 60])
-                      _PreferenceChip(
-                        label: '${seconds}s',
-                        selected: preferences.seekBackSeconds == seconds,
-                        onPressed: () => controller.setSeekBackSeconds(seconds),
-                      ),
+                      _SettingsOption(value: seconds, label: '${seconds}s'),
                   ],
+                  showDivider: true,
+                  onSelected: controller.setSeekBackSeconds,
                 ),
-                _PreferenceRow(
+                _AppearanceSelectionRow<int>(
                   label: 'Fast-forward',
-                  children: [
+                  icon: Icons.forward_10_rounded,
+                  value: preferences.seekForwardSeconds,
+                  valueLabel: '${preferences.seekForwardSeconds}s',
+                  options: [
                     for (final seconds in const [5, 10, 15, 30, 60])
-                      _PreferenceChip(
-                        label: '${seconds}s',
-                        selected: preferences.seekForwardSeconds == seconds,
-                        onPressed: () =>
-                            controller.setSeekForwardSeconds(seconds),
-                      ),
+                      _SettingsOption(value: seconds, label: '${seconds}s'),
                   ],
+                  showDivider: true,
+                  onSelected: controller.setSeekForwardSeconds,
                 ),
-                _PreferenceRow(
-                  label: 'Automatic skipping',
-                  children: [
-                    toggle(
-                      label: 'Intros',
-                      value: preferences.autoSkipIntros,
-                      onChanged: controller.setAutoSkipIntros,
-                    ),
-                    toggle(
-                      label: 'Outros',
-                      value: preferences.autoSkipOutros,
-                      onChanged: controller.setAutoSkipOutros,
-                    ),
-                  ],
+                _AppearanceToggleRow(
+                  label: 'Auto-skip intros',
+                  subtitle: 'Skip detected opening segments automatically.',
+                  icon: Icons.skip_next_rounded,
+                  value: preferences.autoSkipIntros,
+                  showDivider: true,
+                  onChanged: controller.setAutoSkipIntros,
                 ),
-                _PreferenceRow(
-                  label: 'Episode information',
-                  children: [
-                    toggle(
-                      label: 'Show filler episode labels',
-                      value: preferences.showFillerIndicators,
-                      onChanged: controller.setShowFillerIndicators,
-                    ),
-                  ],
+                _AppearanceToggleRow(
+                  label: 'Auto-skip outros',
+                  subtitle: 'Skip detected ending segments automatically.',
+                  icon: Icons.last_page_rounded,
+                  value: preferences.autoSkipOutros,
+                  showDivider: true,
+                  onChanged: controller.setAutoSkipOutros,
+                ),
+                _AppearanceToggleRow(
+                  label: 'Filler episode labels',
+                  subtitle:
+                      'Mark episodes identified as anime-original filler.',
+                  icon: Icons.info_outline_rounded,
+                  value: preferences.showFillerIndicators,
+                  onChanged: controller.setShowFillerIndicators,
                 ),
               ],
             ),
           ),
+        if (showReset) ...[
           const SizedBox(height: 4),
           Align(
             alignment: Alignment.centerRight,
@@ -3196,8 +4308,11 @@ class _CustomizationPanel extends StatelessWidget {
             ),
           ),
         ],
-      ),
+      ],
     );
+    return _SettingsCardScope.isInset(context)
+        ? content
+        : _Panel(child: content);
   }
 }
 
@@ -3205,10 +4320,12 @@ class _ExternalPlayerDefaultSelection extends StatefulWidget {
   const _ExternalPlayerDefaultSelection({
     required this.preferences,
     required this.controller,
+    this.focusNode,
   });
 
   final SettingsPreferences preferences;
   final SettingsPreferencesController controller;
+  final FocusNode? focusNode;
 
   @override
   State<_ExternalPlayerDefaultSelection> createState() =>
@@ -3264,11 +4381,17 @@ class _ExternalPlayerDefaultSelectionState
         return Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            _SettingsSelection<String>(
+            _AppearanceSelectionRow<String>(
               key: const ValueKey('settings-default-player'),
               label: 'Default player',
+              icon: Icons.ondemand_video_rounded,
+              focusNode: widget.focusNode,
               value: selectedValue,
+              valueLabel: options
+                  .firstWhere((option) => option.value == selectedValue)
+                  .label,
               options: options,
+              showDivider: true,
               onSelected: (value) {
                 if (value == _mpvValue) {
                   unawaited(
@@ -3293,42 +4416,17 @@ class _ExternalPlayerDefaultSelectionState
                 );
               },
             ),
-            Padding(
-              padding: const EdgeInsets.only(top: 6),
-              child: Text(
-                snapshot.connectionState == ConnectionState.waiting
-                    ? 'Checking installed video players…'
-                    : 'External apps can only receive safe, header-free streams. '
-                          'Private Plex and Jellyfin sessions stay in MPV.',
-                style: TextStyle(
-                  color: context.appPalette.mutedText,
-                  fontSize: 10,
-                  height: 1.35,
-                ),
-              ),
+            _SettingsSupportingText(
+              snapshot.connectionState == ConnectionState.waiting
+                  ? 'Checking installed video players…'
+                  : 'External apps can only receive safe, header-free streams. '
+                        'Private Plex and Jellyfin sessions stay in MPV.',
             ),
           ],
         );
       },
     );
   }
-}
-
-class _MiniSectionLabel extends StatelessWidget {
-  const _MiniSectionLabel(this.label);
-
-  final String label;
-
-  @override
-  Widget build(BuildContext context) => Text(
-    label,
-    style: TextStyle(
-      color: context.appPalette.accentBright,
-      fontSize: 9,
-      fontWeight: FontWeight.w900,
-      letterSpacing: 1.1,
-    ),
-  );
 }
 
 class _InlineCollapsibleSection extends StatefulWidget {
@@ -3340,6 +4438,8 @@ class _InlineCollapsibleSection extends StatefulWidget {
     required this.onExpandedChanged,
     this.focusNode,
     this.firstChildFocusNode,
+    this.semanticId,
+    this.direct = false,
   });
 
   final String label;
@@ -3348,6 +4448,8 @@ class _InlineCollapsibleSection extends StatefulWidget {
   final ValueChanged<bool> onExpandedChanged;
   final FocusNode? focusNode;
   final FocusNode? firstChildFocusNode;
+  final String? semanticId;
+  final bool direct;
 
   @override
   State<_InlineCollapsibleSection> createState() =>
@@ -3426,7 +4528,12 @@ class _InlineCollapsibleSectionState extends State<_InlineCollapsibleSection> {
 
   @override
   Widget build(BuildContext context) {
-    final id = widget.label.toLowerCase().replaceAll(RegExp('[^a-z0-9]+'), '-');
+    if (widget.direct) {
+      return Semantics(container: true, child: widget.child);
+    }
+    final id =
+        widget.semanticId ??
+        widget.label.toLowerCase().replaceAll(RegExp('[^a-z0-9]+'), '-');
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
@@ -3440,35 +4547,61 @@ class _InlineCollapsibleSectionState extends State<_InlineCollapsibleSection> {
             key: ValueKey('inline-section-toggle-$id'),
             focusNode: _headerFocusNode,
             onPressed: _toggle,
-            focusScale: 1.01,
+            focusScale: 1.005,
             borderRadius: BorderRadius.circular(8),
             child: Container(
               width: double.infinity,
-              height: 36,
-              padding: const EdgeInsets.symmetric(horizontal: 10),
+              constraints: BoxConstraints(
+                minHeight: _usesTvSettingsScale(context) ? 48 : 64,
+              ),
+              padding: EdgeInsets.symmetric(
+                horizontal: _usesTvSettingsScale(context) ? 10 : 13,
+                vertical: _usesTvSettingsScale(context) ? 5 : 10,
+              ),
               decoration: BoxDecoration(
-                color: context.appPalette.surfaceRaised,
+                color: context.appPalette.surface,
                 borderRadius: BorderRadius.circular(8),
-                border: Border.all(color: _settingsBorderColor(context, .08)),
+                border: Border.all(color: _settingsBorderColor(context, .14)),
               ),
               child: Row(
                 children: [
-                  Expanded(child: _MiniSectionLabel(widget.label)),
-                  Text(
-                    widget.expanded ? 'COLLAPSE' : 'EXPAND',
-                    style: TextStyle(
-                      color: context.appPalette.mutedText,
-                      fontSize: 8,
-                      fontWeight: FontWeight.w900,
-                      letterSpacing: .7,
+                  Icon(
+                    _settingsIconForLabel(widget.label),
+                    size: _usesTvSettingsScale(context) ? 22 : 22,
+                    color: _settingsPrimaryText(context),
+                  ),
+                  SizedBox(width: _usesTvSettingsScale(context) ? 8 : 14),
+                  Expanded(
+                    child: Column(
+                      mainAxisSize: MainAxisSize.min,
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text(
+                          _settingsDisplayLabel(widget.label),
+                          style: TextStyle(
+                            color: _settingsPrimaryText(context),
+                            fontSize: _usesTvSettingsScale(context) ? 16 : 14,
+                            fontWeight: FontWeight.w700,
+                          ),
+                        ),
+                        const SizedBox(height: 3),
+                        Text(
+                          widget.expanded
+                              ? 'Options shown'
+                              : 'Open to view and change these options',
+                          style: TextStyle(
+                            color: context.appPalette.mutedText,
+                            fontSize: _usesTvSettingsScale(context) ? 12 : 11,
+                          ),
+                        ),
+                      ],
                     ),
                   ),
-                  const SizedBox(width: 5),
                   Icon(
                     widget.expanded
                         ? Icons.keyboard_arrow_up_rounded
                         : Icons.keyboard_arrow_down_rounded,
-                    size: 19,
+                    size: 22,
                     color: context.appPalette.accentBright,
                   ),
                 ],
@@ -3482,7 +4615,14 @@ class _InlineCollapsibleSectionState extends State<_InlineCollapsibleSection> {
           alignment: Alignment.topCenter,
           child: ExcludeFocus(
             excluding: !widget.expanded,
-            child: widget.expanded ? widget.child : const SizedBox.shrink(),
+            child: widget.expanded
+                ? Padding(
+                    padding: EdgeInsets.only(
+                      top: _usesTvSettingsScale(context) ? 4 : 8,
+                    ),
+                    child: widget.child,
+                  )
+                : const SizedBox.shrink(),
           ),
         ),
       ],
@@ -3495,7 +4635,9 @@ class _PreferenceDivider extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) => Padding(
-    padding: const EdgeInsets.symmetric(vertical: 10),
+    padding: EdgeInsets.symmetric(
+      vertical: _usesTvSettingsScale(context) ? 5 : 10,
+    ),
     child: Divider(color: _settingsBorderColor(context, .07), height: 1),
   );
 }
@@ -3525,66 +4667,44 @@ class _StreamingSourcesPanel extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Container(
-      width: double.infinity,
-      padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 10),
-      decoration: BoxDecoration(
-        color: context.appPalette.surface,
-        borderRadius: BorderRadius.circular(12),
-        border: Border.all(color: _settingsBorderColor(context, .07)),
-      ),
-      child: LayoutBuilder(
-        builder: (context, constraints) {
-          final sources = Wrap(
-            spacing: 8,
-            runSpacing: 8,
-            children: [
-              _PreferenceChip(
-                label:
-                    'DEBRID ${preferences.debridStreamsEnabled ? 'ON' : 'OFF'}',
-                selected: preferences.debridStreamsEnabled,
-                focusNode: debridFocusNode,
-                onPressed: () =>
-                    onDebridChanged(!preferences.debridStreamsEnabled),
-              ),
-              _PreferenceChip(
-                label: 'WEB ${preferences.webStreamsEnabled ? 'ON' : 'OFF'}',
-                selected: preferences.webStreamsEnabled,
-                focusNode: webFocusNode,
-                onPressed: () => onWebChanged(!preferences.webStreamsEnabled),
-              ),
-              _PreferenceChip(
-                key: const ValueKey('settings-direct-torrent-toggle'),
-                label:
-                    'DIRECT PEER ${preferences.directTorrentStreamingEnabled ? 'ON' : 'OFF'}',
-                selected: preferences.directTorrentStreamingEnabled,
-                focusNode: directTorrentFocusNode,
-                onPressed: () => onDirectTorrentChanged(
-                  !preferences.directTorrentStreamingEnabled,
-                ),
-              ),
-            ],
-          );
-          final marketplace = _TvTextButton(
-            label: 'Manage sources',
-            icon: Icons.hub_rounded,
-            focusNode: marketplaceFocusNode,
-            onPressed: onMarketplace,
-          );
-          if (constraints.maxWidth < 620) {
-            return Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [sources, const SizedBox(height: 10), marketplace],
-            );
-          }
-          return Row(
-            children: [
-              Expanded(child: sources),
-              marketplace,
-            ],
-          );
-        },
-      ),
+    return Column(
+      children: [
+        _AppearanceToggleRow(
+          label: 'Debrid streams',
+          subtitle: 'Use cached and resolved streams from your linked service.',
+          icon: Icons.cloud_download_outlined,
+          value: preferences.debridStreamsEnabled,
+          focusNode: debridFocusNode,
+          showDivider: true,
+          onChanged: onDebridChanged,
+        ),
+        _AppearanceToggleRow(
+          label: 'Web streams',
+          subtitle: 'Include streams supplied by installed web addons.',
+          icon: Icons.language_rounded,
+          value: preferences.webStreamsEnabled,
+          focusNode: webFocusNode,
+          showDivider: true,
+          onChanged: onWebChanged,
+        ),
+        _AppearanceToggleRow(
+          key: const ValueKey('settings-direct-torrent-toggle'),
+          label: 'Direct peer streaming',
+          subtitle: 'Play torrent releases directly without a debrid service.',
+          icon: Icons.public_rounded,
+          value: preferences.directTorrentStreamingEnabled,
+          focusNode: directTorrentFocusNode,
+          showDivider: true,
+          onChanged: onDirectTorrentChanged,
+        ),
+        _AppearanceActionRow(
+          label: 'Manage sources',
+          subtitle: 'Install, remove, and organize streaming addons.',
+          icon: Icons.hub_rounded,
+          focusNode: marketplaceFocusNode,
+          onPressed: onMarketplace,
+        ),
+      ],
     );
   }
 }
@@ -3610,71 +4730,68 @@ class _StreamRankingPanel extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return _Panel(
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          const _MiniSectionLabel('STREAM ORDER'),
-          const SizedBox(height: 7),
-          _SettingsSelection<DebridStreamSort>(
-            key: const ValueKey('settings-debrid-stream-sort'),
-            focusNode: debridSortFocusNode,
-            label: 'Debrid results',
-            value: preferences.debridStreamSort,
-            options: [
-              for (final value in DebridStreamSort.values)
-                _SettingsOption(
-                  value: value,
-                  label: value.displayName,
-                  detail: value.description,
-                ),
-            ],
-            onSelected: onDebridSortSelected,
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        _SettingsSelection<DebridStreamSort>(
+          key: const ValueKey('settings-debrid-stream-sort'),
+          focusNode: debridSortFocusNode,
+          label: 'Debrid results',
+          value: preferences.debridStreamSort,
+          options: [
+            for (final value in DebridStreamSort.values)
+              _SettingsOption(
+                value: value,
+                label: value.displayName,
+                detail: value.description,
+              ),
+          ],
+          onSelected: onDebridSortSelected,
+          showDivider: true,
+        ),
+        _SettingsSelection<StreamSourcePriority>(
+          key: const ValueKey('settings-stream-source-priority'),
+          focusNode: sourcePriorityFocusNode,
+          label: 'Source priority',
+          value: preferences.streamSourcePriority,
+          options: [
+            for (final value in StreamSourcePriority.values)
+              _SettingsOption(
+                value: value,
+                label: value.displayName,
+                detail: value.description,
+              ),
+          ],
+          onSelected: onSourcePrioritySelected,
+          showDivider: true,
+        ),
+        _SettingsSelection<WebStreamQualityPreference>(
+          key: const ValueKey('settings-web-stream-quality'),
+          focusNode: webQualityFocusNode,
+          label: 'Preferred Web quality',
+          value: preferences.webStreamQuality,
+          options: [
+            for (final value in WebStreamQualityPreference.values)
+              _SettingsOption(
+                value: value,
+                label: value.displayName,
+                detail: value.description,
+              ),
+          ],
+          onSelected: onWebQualitySelected,
+          showDivider: true,
+        ),
+        const SizedBox(height: 5),
+        Text(
+          'Preferences change ranking only. Other usable streams remain '
+          'available for manual choice and automatic failover.',
+          style: TextStyle(
+            color: context.appPalette.mutedText,
+            fontSize: _usesTvSettingsScale(context) ? 13 : 11,
+            height: 1.35,
           ),
-          const SizedBox(height: 8),
-          _SettingsSelection<StreamSourcePriority>(
-            key: const ValueKey('settings-stream-source-priority'),
-            focusNode: sourcePriorityFocusNode,
-            label: 'Source priority',
-            value: preferences.streamSourcePriority,
-            options: [
-              for (final value in StreamSourcePriority.values)
-                _SettingsOption(
-                  value: value,
-                  label: value.displayName,
-                  detail: value.description,
-                ),
-            ],
-            onSelected: onSourcePrioritySelected,
-          ),
-          const SizedBox(height: 8),
-          _SettingsSelection<WebStreamQualityPreference>(
-            key: const ValueKey('settings-web-stream-quality'),
-            focusNode: webQualityFocusNode,
-            label: 'Preferred Web quality',
-            value: preferences.webStreamQuality,
-            options: [
-              for (final value in WebStreamQualityPreference.values)
-                _SettingsOption(
-                  value: value,
-                  label: value.displayName,
-                  detail: value.description,
-                ),
-            ],
-            onSelected: onWebQualitySelected,
-          ),
-          const SizedBox(height: 5),
-          Text(
-            'Preferences change ranking only. Other usable streams remain '
-            'available for manual choice and automatic failover.',
-            style: TextStyle(
-              color: context.appPalette.mutedText,
-              fontSize: 10,
-              height: 1.35,
-            ),
-          ),
-        ],
-      ),
+        ),
+      ],
     );
   }
 }
@@ -3716,94 +4833,88 @@ class _AutoPickSourcePanel extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return _Panel(
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          const _MiniSectionLabel('AUTO PICK SOURCE'),
-          const SizedBox(height: 7),
-          _PreferenceRow(
-            label: 'Automatic selection',
-            children: [
-              _PreferenceChip(
-                key: const ValueKey('settings-auto-pick-source-enabled'),
-                label: preferences.autoPickSourceEnabled ? 'ON' : 'OFF',
-                selected: preferences.autoPickSourceEnabled,
-                focusNode: enabledFocusNode,
-                onPressed: () =>
-                    onEnabledChanged(!preferences.autoPickSourceEnabled),
-              ),
-            ],
+    final content = Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        _AppearanceToggleRow(
+          key: const ValueKey('settings-auto-pick-source-enabled'),
+          label: 'Automatic selection',
+          subtitle: 'Choose the highest-ranked playable source automatically.',
+          icon: Icons.auto_awesome_outlined,
+          value: preferences.autoPickSourceEnabled,
+          focusNode: enabledFocusNode,
+          onChanged: onEnabledChanged,
+        ),
+        if (preferences.autoPickSourceEnabled) ...[
+          const SizedBox(height: 3),
+          _PriorityListEditor<AutoPickSourcePriority>(
+            key: const ValueKey('settings-auto-pick-source-priority'),
+            label: 'Source priority',
+            description: 'TetoTV tries each source class from top to bottom.',
+            values: preferences.autoPickSourcePriority,
+            sectionFocusNode: sourceSectionFocusNode,
+            rowFocusNodes: sourceRowFocusNodes,
+            expanded: sourceExpanded,
+            onExpandedChanged: onSourceExpandedChanged,
+            valueLabel: (value) => value.displayName,
+            valueDescription: (value) => value.description,
+            valueId: (value) => value.name,
+            onMove: onSourceMoved,
           ),
-          if (preferences.autoPickSourceEnabled) ...[
-            const SizedBox(height: 3),
-            _PriorityListEditor<AutoPickSourcePriority>(
-              key: const ValueKey('settings-auto-pick-source-priority'),
-              label: 'Source priority',
-              description: 'TetoTV tries each source class from top to bottom.',
-              values: preferences.autoPickSourcePriority,
-              sectionFocusNode: sourceSectionFocusNode,
-              rowFocusNodes: sourceRowFocusNodes,
-              expanded: sourceExpanded,
-              onExpandedChanged: onSourceExpandedChanged,
-              valueLabel: (value) => value.displayName,
-              valueDescription: (value) => value.description,
-              valueId: (value) => value.name,
-              onMove: onSourceMoved,
-            ),
-            const SizedBox(height: 8),
-            _PriorityListEditor<AutoPickQuality>(
-              key: const ValueKey('settings-auto-pick-quality-priority'),
-              label: 'Quality priority',
-              description:
-                  'The first available quality in this order is selected.',
-              values: preferences.autoPickQualityPriority,
-              sectionFocusNode: qualitySectionFocusNode,
-              rowFocusNodes: qualityRowFocusNodes,
-              expanded: qualityExpanded,
-              onExpandedChanged: onQualityExpandedChanged,
-              valueLabel: (value) => value.displayName,
-              valueDescription: (value) => switch (value) {
-                AutoPickQuality.any => '',
-                _ => 'Preferred before lower-ranked qualities',
-              },
-              valueId: (value) => value.name,
-              onMove: onQualityMoved,
-            ),
-            const SizedBox(height: 8),
-            _SettingsSelection<AutoPickAudio>(
-              key: const ValueKey('settings-auto-pick-audio'),
-              focusNode: audioFocusNode,
-              label: 'Strict audio',
-              value: preferences.autoPickAudio,
-              options: [
-                for (final value in AutoPickAudio.values)
-                  _SettingsOption(
-                    value: value,
-                    label: value.displayName,
-                    detail: value.description,
-                  ),
-              ],
-              onSelected: onAudioSelected,
-            ),
-          ],
-          const SizedBox(height: 5),
-          Text(
-            preferences.autoPickSourceEnabled
-                ? 'Priorities are tried from top to bottom. The audio rule '
-                      'still filters candidates; if none play, the complete '
-                      'source picker opens instead.'
-                : 'Off by default. Episodes continue to open the full source '
-                      'picker until you enable this.',
-            style: TextStyle(
-              color: context.appPalette.mutedText,
-              fontSize: 10,
-              height: 1.35,
-            ),
+          const SizedBox(height: 8),
+          _PriorityListEditor<AutoPickQuality>(
+            key: const ValueKey('settings-auto-pick-quality-priority'),
+            label: 'Quality priority',
+            description:
+                'The first available quality in this order is selected.',
+            values: preferences.autoPickQualityPriority,
+            sectionFocusNode: qualitySectionFocusNode,
+            rowFocusNodes: qualityRowFocusNodes,
+            expanded: qualityExpanded,
+            onExpandedChanged: onQualityExpandedChanged,
+            valueLabel: (value) => value.displayName,
+            valueDescription: (value) => switch (value) {
+              AutoPickQuality.any => '',
+              _ => 'Preferred before lower-ranked qualities',
+            },
+            valueId: (value) => value.name,
+            onMove: onQualityMoved,
+          ),
+          const SizedBox(height: 8),
+          _SettingsSelection<AutoPickAudio>(
+            key: const ValueKey('settings-auto-pick-audio'),
+            focusNode: audioFocusNode,
+            label: 'Strict audio',
+            value: preferences.autoPickAudio,
+            options: [
+              for (final value in AutoPickAudio.values)
+                _SettingsOption(
+                  value: value,
+                  label: value.displayName,
+                  detail: value.description,
+                ),
+            ],
+            onSelected: onAudioSelected,
+            showDivider: true,
           ),
         ],
-      ),
+        const SizedBox(height: 5),
+        Text(
+          preferences.autoPickSourceEnabled
+              ? 'Priorities are tried from top to bottom. The audio rule '
+                    'still filters candidates; if none play, the complete '
+                    'source picker opens instead.'
+              : 'Off by default. Episodes continue to open the full source '
+                    'picker until you enable this.',
+          style: TextStyle(
+            color: context.appPalette.mutedText,
+            fontSize: _usesTvSettingsScale(context) ? 13 : 11,
+            height: 1.35,
+          ),
+        ),
+      ],
     );
+    return content;
   }
 }
 
@@ -3855,7 +4966,7 @@ class _PriorityListEditor<T> extends StatelessWidget {
                 '$description Select a row or use its arrows to reorder it.',
                 style: TextStyle(
                   color: context.appPalette.mutedText,
-                  fontSize: 10,
+                  fontSize: _usesTvSettingsScale(context) ? 13 : 11,
                   height: 1.3,
                 ),
               ),
@@ -3906,6 +5017,7 @@ class _PriorityListRow<T> extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final tvScale = _usesTvSettingsScale(context);
     final primaryOffset = index == 0 ? 1 : -1;
     final primaryAction = index == 0 ? 'later' : 'earlier';
     return Semantics(
@@ -3914,13 +5026,13 @@ class _PriorityListRow<T> extends StatelessWidget {
       child: Row(
         children: [
           SizedBox(
-            width: 24,
+            width: tvScale ? 24 : 24,
             child: Text(
               '${index + 1}',
               textAlign: TextAlign.center,
               style: TextStyle(
                 color: context.appPalette.mutedText,
-                fontSize: 10,
+                fontSize: tvScale ? 12 : 11,
                 fontWeight: FontWeight.w800,
               ),
             ),
@@ -3937,10 +5049,10 @@ class _PriorityListRow<T> extends StatelessWidget {
                 focusScale: 1.01,
                 borderRadius: BorderRadius.circular(8),
                 child: Container(
-                  constraints: const BoxConstraints(minHeight: 42),
-                  padding: const EdgeInsets.symmetric(
-                    horizontal: 12,
-                    vertical: 6,
+                  constraints: BoxConstraints(minHeight: tvScale ? 48 : 64),
+                  padding: EdgeInsets.symmetric(
+                    horizontal: tvScale ? 10 : 13,
+                    vertical: tvScale ? 5 : 11,
                   ),
                   decoration: BoxDecoration(
                     color: context.appPalette.surfaceRaised,
@@ -3966,18 +5078,19 @@ class _PriorityListRow<T> extends StatelessWidget {
                               overflow: TextOverflow.ellipsis,
                               style: TextStyle(
                                 color: _settingsPrimaryText(context),
-                                fontSize: 11,
+                                fontSize: tvScale ? 16 : 14,
                                 fontWeight: FontWeight.w800,
                               ),
                             ),
                             if (description.isNotEmpty)
                               Text(
                                 description,
-                                maxLines: 1,
+                                maxLines: 2,
                                 overflow: TextOverflow.ellipsis,
                                 style: TextStyle(
                                   color: context.appPalette.mutedText,
-                                  fontSize: 9,
+                                  fontSize: tvScale ? 12 : 11,
+                                  height: 1.25,
                                 ),
                               ),
                           ],
@@ -3988,7 +5101,7 @@ class _PriorityListRow<T> extends StatelessWidget {
                           'FIRST',
                           style: TextStyle(
                             color: context.appPalette.accentBright,
-                            fontSize: 8,
+                            fontSize: tvScale ? 9 : 9,
                             fontWeight: FontWeight.w900,
                             letterSpacing: .7,
                           ),
@@ -4027,42 +5140,74 @@ class _PreferenceRow extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Padding(
-      padding: const EdgeInsets.symmetric(vertical: 5),
+    final tvScale = _usesTvSettingsScale(context);
+    return Container(
+      constraints: BoxConstraints(minHeight: tvScale ? 48 : 64),
+      margin: const EdgeInsets.symmetric(vertical: 3),
+      padding: EdgeInsets.symmetric(
+        horizontal: tvScale ? 10 : 13,
+        vertical: tvScale ? 5 : 10,
+      ),
+      decoration: BoxDecoration(
+        color: context.appPalette.surface,
+        borderRadius: BorderRadius.circular(8),
+        border: Border.all(color: _settingsBorderColor(context, .14)),
+      ),
       child: LayoutBuilder(
         builder: (context, constraints) {
-          final options = Wrap(spacing: 7, runSpacing: 7, children: children);
-          if (constraints.maxWidth < 560) {
-            return Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Text(
-                  label,
-                  style: TextStyle(
-                    color: context.appPalette.mutedText,
-                    fontSize: 11,
-                    fontWeight: FontWeight.w800,
-                  ),
+          final options = Wrap(
+            alignment: WrapAlignment.end,
+            spacing: 7,
+            runSpacing: 7,
+            children: children,
+          );
+          final title = Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Icon(
+                _settingsIconForLabel(label),
+                size: tvScale ? 22 : 21,
+                color: _settingsPrimaryText(context),
+              ),
+              SizedBox(width: tvScale ? 8 : 13),
+              Flexible(
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      label,
+                      maxLines: 2,
+                      overflow: TextOverflow.ellipsis,
+                      style: TextStyle(
+                        color: _settingsPrimaryText(context),
+                        fontSize: tvScale ? 16 : 14,
+                        fontWeight: FontWeight.w700,
+                      ),
+                    ),
+                  ],
                 ),
-                const SizedBox(height: 7),
-                options,
+              ),
+            ],
+          );
+          if (constraints.maxWidth < 680) {
+            return Column(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                title,
+                SizedBox(height: tvScale ? 5 : 10),
+                Align(alignment: Alignment.centerRight, child: options),
               ],
             );
           }
           return Row(
             children: [
-              SizedBox(
-                width: 180,
-                child: Text(
-                  label,
-                  style: TextStyle(
-                    color: context.appPalette.mutedText,
-                    fontSize: 11,
-                    fontWeight: FontWeight.w800,
-                  ),
-                ),
+              Expanded(flex: 4, child: title),
+              SizedBox(width: tvScale ? 8 : 16),
+              Expanded(
+                flex: 6,
+                child: Align(alignment: Alignment.centerRight, child: options),
               ),
-              Expanded(child: options),
             ],
           );
         },
@@ -4078,59 +5223,55 @@ class _PreferenceChip extends StatelessWidget {
     required this.selected,
     required this.onPressed,
     this.focusNode,
-    this.swatch,
   });
 
   final String label;
   final bool selected;
   final VoidCallback onPressed;
   final FocusNode? focusNode;
-  final Color? swatch;
 
   @override
   Widget build(BuildContext context) {
+    final tvScale = _usesTvSettingsScale(context);
     return TvFocusable(
       focusNode: focusNode,
       onPressed: onPressed,
-      focusScale: 1.04,
-      borderRadius: BorderRadius.circular(7),
-      child: Container(
-        height: 31,
-        padding: const EdgeInsets.symmetric(horizontal: 11),
+      focusScale: 1.025,
+      borderRadius: BorderRadius.circular(8),
+      child: AnimatedContainer(
+        duration: const Duration(milliseconds: 120),
+        height: tvScale ? 30 : 36,
+        padding: EdgeInsets.symmetric(horizontal: tvScale ? 8 : 11),
         decoration: BoxDecoration(
           color: selected
-              ? context.appPalette.accent
+              ? context.appPalette.accent.withValues(alpha: .36)
               : context.appPalette.surfaceRaised,
-          borderRadius: BorderRadius.circular(7),
+          borderRadius: BorderRadius.circular(8),
           border: Border.all(
             color: selected
                 ? context.appPalette.accentBright
-                : _settingsBorderColor(context, .1),
+                : _settingsBorderColor(context, .16),
+            width: selected ? 1.5 : 1,
           ),
         ),
         child: Row(
           mainAxisSize: MainAxisSize.min,
           children: [
-            if (swatch case final color?) ...[
-              Container(
-                width: 12,
-                height: 12,
-                decoration: BoxDecoration(
-                  color: color,
-                  borderRadius: BorderRadius.circular(3),
-                  border: Border.all(color: _settingsBorderColor(context, .54)),
+            Flexible(
+              child: FittedBox(
+                fit: BoxFit.scaleDown,
+                alignment: Alignment.centerLeft,
+                child: Text(
+                  label,
+                  maxLines: 1,
+                  style: TextStyle(
+                    color: selected
+                        ? _settingsPrimaryText(context)
+                        : _settingsPrimaryText(context),
+                    fontSize: tvScale ? 11 : 11,
+                    fontWeight: FontWeight.w800,
+                  ),
                 ),
-              ),
-              const SizedBox(width: 6),
-            ],
-            Text(
-              label,
-              style: TextStyle(
-                color: selected
-                    ? _settingsAccentForeground(context)
-                    : _settingsPrimaryText(context),
-                fontSize: 10,
-                fontWeight: FontWeight.w800,
               ),
             ),
           ],
@@ -4190,140 +5331,118 @@ class _DeveloperUpdatePanel extends StatelessWidget {
     final buildNumber = versionParts.length > 1
         ? versionParts.sublist(1).join('+')
         : 'Not reported';
-    return _Panel(
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Row(
-            children: [
-              Icon(
-                state.developerMode
-                    ? Icons.developer_mode_rounded
-                    : Icons.new_releases_rounded,
-                color: context.appPalette.accentBright,
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        _SettingsPanelSummary(
+          title: state.developerMode
+              ? 'Developer update tools'
+              : 'Update channel',
+          subtitle: state.developerMode
+              ? 'Switch channels or inspect signed release history. Android only installs the same or a higher build code.'
+              : 'Choose Public or Beta. Beta builds may be less stable.',
+          icon: state.developerMode
+              ? Icons.developer_mode_rounded
+              : Icons.new_releases_rounded,
+          status: state.developerMode
+              ? const _StatusPill(connected: true, label: 'HISTORY ENABLED')
+              : null,
+        ),
+        _SettingsSelection<AppUpdateChannel>(
+          label: 'Update channel',
+          value: state.updateChannel,
+          focusNode: channelFocusNode,
+          options: [
+            for (final channel in AppUpdateChannel.values)
+              _SettingsOption(
+                value: channel,
+                label: channel.displayName,
+                detail: channel.description,
               ),
-              const SizedBox(width: 10),
-              Expanded(
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    Text(
-                      state.developerMode
-                          ? 'Developer update tools'
-                          : 'Update channel',
-                      style: Theme.of(context).textTheme.titleMedium,
-                    ),
-                    Text(
-                      state.developerMode
-                          ? 'Switch channels or inspect signed release history. Android only installs the same or a higher build code.'
-                          : 'Choose Public or Beta. Beta builds may be less stable.',
-                      style: TextStyle(
-                        color: context.appPalette.mutedText,
-                        fontSize: 10,
-                      ),
-                    ),
-                  ],
-                ),
-              ),
-              if (state.developerMode)
-                const _StatusPill(connected: true, label: 'HISTORY ENABLED'),
-            ],
-          ),
-          const SizedBox(height: 10),
-          _SettingsSelection<AppUpdateChannel>(
-            label: 'Update channel',
-            value: state.updateChannel,
-            focusNode: channelFocusNode,
-            options: [
-              for (final channel in AppUpdateChannel.values)
-                _SettingsOption(
-                  value: channel,
-                  label: channel.displayName,
-                  detail: channel.description,
-                ),
-            ],
-            onSelected: onChannelSelected,
-          ),
-          if (state.developerMode) ...[
-            const SizedBox(height: 10),
-            Divider(color: _settingsBorderColor(context, .08), height: 1),
-            const SizedBox(height: 10),
-            if (state.releaseHistory.isNotEmpty)
-              _SettingsSelection<AppReleaseInfo>(
-                label: 'Choose a signed release',
-                value: state.releaseHistory.first,
-                focusNode: releaseHistoryFocusNode,
-                options: [
-                  for (final release in state.releaseHistory)
-                    _SettingsOption(
-                      value: release,
-                      label: appReleaseDisplayLabel(
-                        release,
-                        state.updateChannel,
-                      ),
-                      detail: _releaseCompatibilityDetail(release),
-                    ),
-                ],
-                onSelected: onReleaseSelected,
-              )
-            else
-              _TvTextButton(
-                key: const ValueKey('release-history-refresh'),
-                label: state.releaseHistoryLoading
-                    ? 'Loading releases…'
-                    : 'Load release history',
-                icon: Icons.history_rounded,
-                focusNode: releaseHistoryFocusNode,
-                onPressed: state.isBusy || state.releaseHistoryLoading
-                    ? null
-                    : onRefreshHistory,
-              ),
-            const SizedBox(height: 7),
-            Text(
-              'Developer mode cannot bypass Android downgrade protection. A '
-              'lower build cannot replace this installation; uninstalling '
-              'first erases local app data. Equal-build channel counterparts '
-              'remain supported when package, signer, SDK, and ABI checks pass.',
-              style: TextStyle(
-                color: context.appPalette.mutedText,
-                fontSize: 10,
-              ),
-            ),
           ],
-          const SizedBox(height: 10),
-          Wrap(
-            spacing: 18,
-            runSpacing: 6,
-            children: [
-              Text(
-                'Installed version: $versionName'
-                '${installedReleaseDate == null ? '' : ' • $installedReleaseDate'}',
-                style: TextStyle(
-                  color: context.appPalette.primaryText,
-                  fontSize: 11,
-                  fontWeight: FontWeight.w800,
-                ),
-              ),
-              Text(
-                'Build: $buildNumber',
-                style: TextStyle(
-                  color: context.appPalette.mutedText,
-                  fontSize: 11,
-                ),
-              ),
-              if (state.latestVersion case final latest?)
-                Text(
-                  'Latest ${state.updateChannel.displayName}: '
-                  '${_releaseLabelForVersion(state, latest)}',
-                  style: TextStyle(
-                    color: context.appPalette.mutedText,
-                    fontSize: 11,
+          onSelected: onChannelSelected,
+          showDivider: state.developerMode,
+        ),
+        if (state.developerMode) ...[
+          if (state.releaseHistory.isNotEmpty)
+            _SettingsSelection<AppReleaseInfo>(
+              label: 'Choose a compatible signed release',
+              value: state.releaseHistory.first,
+              focusNode: releaseHistoryFocusNode,
+              options: [
+                for (final release in state.releaseHistory)
+                  _SettingsOption(
+                    value: release,
+                    label: appReleaseDisplayLabel(release, state.updateChannel),
+                    detail: _releaseCompatibilityDetail(release),
+                    enabled: !isKnownAndroidVersionDowngrade(
+                      currentVersion: state.currentVersion,
+                      releaseVersionCode: release.androidVersionCode,
+                    ),
                   ),
-                ),
-            ],
+              ],
+              onSelected: onReleaseSelected,
+              showDivider: true,
+            )
+          else
+            _SettingsPanelActionRow(
+              key: const ValueKey('release-history-refresh'),
+              label: state.releaseHistoryLoading
+                  ? 'Loading releases…'
+                  : 'Load release history',
+              subtitle:
+                  'Fetch the signed release list for the selected update channel.',
+              icon: Icons.history_rounded,
+              focusNode: releaseHistoryFocusNode,
+              onPressed: state.isBusy || state.releaseHistoryLoading
+                  ? null
+                  : onRefreshHistory,
+            ),
+          SizedBox(height: _usesTvSettingsScale(context) ? 4 : 7),
+          Text(
+            'Entries marked Blocked by Android remain visible for reference '
+            'but cannot be selected. Android cannot replace this installation '
+            'with a lower build code; Developer Mode cannot bypass that rule. '
+            'A same-or-higher-code rebuild can roll back while preserving data.',
+            style: TextStyle(
+              color: context.appPalette.mutedText,
+              fontSize: _usesTvSettingsScale(context) ? 11 : 10,
+            ),
           ),
         ],
-      ),
+        SizedBox(height: _usesTvSettingsScale(context) ? 5 : 10),
+        Wrap(
+          spacing: _usesTvSettingsScale(context) ? 10 : 18,
+          runSpacing: _usesTvSettingsScale(context) ? 3 : 6,
+          children: [
+            Text(
+              'Installed version: $versionName'
+              '${installedReleaseDate == null ? '' : ' • $installedReleaseDate'}',
+              style: TextStyle(
+                color: context.appPalette.primaryText,
+                fontSize: _usesTvSettingsScale(context) ? 12 : 11,
+                fontWeight: FontWeight.w800,
+              ),
+            ),
+            Text(
+              'Build: $buildNumber',
+              style: TextStyle(
+                color: context.appPalette.mutedText,
+                fontSize: _usesTvSettingsScale(context) ? 12 : 11,
+              ),
+            ),
+            if (state.latestVersion case final latest?)
+              Text(
+                'Latest ${state.updateChannel.displayName}: '
+                '${_releaseLabelForVersion(state, latest)}',
+                style: TextStyle(
+                  color: context.appPalette.mutedText,
+                  fontSize: _usesTvSettingsScale(context) ? 12 : 11,
+                ),
+              ),
+          ],
+        ),
+      ],
     );
   }
 }
@@ -4368,152 +5487,165 @@ class _AppUpdatePanel extends StatelessWidget {
       AppUpdatePhase.ready => 'Install update',
       _ => 'Check for updates',
     };
-    return _Panel(
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Row(
+    final tvScale = _usesTvSettingsScale(context);
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        Padding(
+          padding: EdgeInsets.symmetric(
+            horizontal: tvScale ? 10 : 13,
+            vertical: tvScale ? 6 : 11,
+          ),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
             children: [
-              Container(
-                width: 44,
-                height: 44,
-                decoration: BoxDecoration(
-                  color: context.appPalette.accent.withValues(alpha: .18),
-                  borderRadius: BorderRadius.circular(9),
-                ),
-                child: Icon(
-                  Icons.system_update_rounded,
-                  color: context.appPalette.accentBright,
-                ),
-              ),
-              const SizedBox(width: 12),
-              Expanded(
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    Wrap(
-                      spacing: 10,
-                      runSpacing: 6,
-                      crossAxisAlignment: WrapCrossAlignment.center,
+              Row(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Icon(
+                    Icons.system_update_rounded,
+                    color: context.appPalette.accentBright,
+                    size: tvScale ? 22 : 22,
+                  ),
+                  SizedBox(width: tvScale ? 8 : 14),
+                  Expanded(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
                       children: [
-                        Text(
-                          'TetoTV ${state.currentVersion}'
-                          '${currentReleaseDate == null ? '' : ' • $currentReleaseDate'}',
-                          key: const ValueKey('app-update-version-and-date'),
-                          style: Theme.of(context).textTheme.titleLarge,
+                        Wrap(
+                          spacing: 10,
+                          runSpacing: 6,
+                          crossAxisAlignment: WrapCrossAlignment.center,
+                          children: [
+                            Text(
+                              'TetoTV ${state.currentVersion}'
+                              '${currentReleaseDate == null ? '' : ' • $currentReleaseDate'}',
+                              key: const ValueKey(
+                                'app-update-version-and-date',
+                              ),
+                              style: TextStyle(
+                                color: _settingsPrimaryText(context),
+                                fontSize: tvScale ? 16 : 14,
+                                fontWeight: FontWeight.w700,
+                              ),
+                            ),
+                            if (showSeparateLatestRelease)
+                              Text(
+                                'Latest ${appReleaseDisplayLabel(latestRelease, state.updateChannel)}',
+                                key: const ValueKey(
+                                  'app-update-latest-version-and-date',
+                                ),
+                                style: TextStyle(
+                                  color: context.appPalette.mutedText,
+                                  fontSize: tvScale ? 12 : 11,
+                                  fontWeight: FontWeight.w800,
+                                ),
+                              ),
+                            _StatusPill(
+                              connected: true,
+                              label: 'SECURE UPDATES READY',
+                            ),
+                          ],
                         ),
-                        if (showSeparateLatestRelease)
-                          Text(
-                            'Latest ${appReleaseDisplayLabel(latestRelease, state.updateChannel)}',
-                            key: const ValueKey(
-                              'app-update-latest-version-and-date',
-                            ),
-                            style: TextStyle(
-                              color: context.appPalette.mutedText,
-                              fontSize: 11,
-                              fontWeight: FontWeight.w800,
-                            ),
+                        const SizedBox(height: 3),
+                        Text(
+                          'Signed releases download securely from the official TetoTV repository.',
+                          style: TextStyle(
+                            color: context.appPalette.mutedText,
+                            fontSize: tvScale ? 12 : 11,
+                            height: 1.25,
                           ),
-                        _StatusPill(
-                          connected: true,
-                          label: 'SECURE UPDATES READY',
                         ),
                       ],
                     ),
-                    const SizedBox(height: 3),
-                    Text(
-                      'Signed releases download securely from the official '
-                      'TetoTV repository.',
-                      style: Theme.of(context).textTheme.bodyMedium,
-                    ),
-                  ],
-                ),
-              ),
-            ],
-          ),
-          const SizedBox(height: 10),
-          Text(
-            status,
-            maxLines: 2,
-            overflow: TextOverflow.ellipsis,
-            style: TextStyle(
-              color: state.phase == AppUpdatePhase.error
-                  ? const Color(0xFFFF929B)
-                  : context.appPalette.mutedText,
-              fontSize: 10,
-            ),
-          ),
-          if (state.release?.notes.trim().isNotEmpty == true) ...[
-            const SizedBox(height: 8),
-            Container(
-              width: double.infinity,
-              padding: const EdgeInsets.all(10),
-              decoration: BoxDecoration(
-                color: _settingsPageBackground(context).withValues(alpha: .35),
-                borderRadius: BorderRadius.circular(9),
-                border: Border.all(color: _settingsBorderColor(context, .07)),
-              ),
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Text(
-                    'WHAT’S NEW',
-                    style: TextStyle(
-                      color: context.appPalette.accentBright,
-                      fontSize: 10,
-                      fontWeight: FontWeight.w900,
-                    ),
-                  ),
-                  const SizedBox(height: 4),
-                  Text(
-                    state.release!.notes.trim(),
-                    maxLines: 8,
-                    overflow: TextOverflow.ellipsis,
-                    style: const TextStyle(fontSize: 11, height: 1.35),
                   ),
                 ],
               ),
-            ),
-          ],
-          const SizedBox(height: 8),
-          Align(
-            key: const ValueKey('app-update-actions'),
-            alignment: Alignment.centerRight,
-            child: Wrap(
-              spacing: 7,
-              runSpacing: 7,
-              children: [
-                _TvTextButton(
-                  label: state.automaticUpdates
-                      ? 'Automatic: ON'
-                      : 'Automatic: OFF',
-                  icon: state.automaticUpdates
-                      ? Icons.autorenew_rounded
-                      : Icons.update_disabled_rounded,
-                  onPressed: state.isBusy ? null : onToggleAutomatic,
-                  focusNode: automaticFocusNode,
+              SizedBox(height: tvScale ? 5 : 10),
+              Text(
+                status,
+                maxLines: 2,
+                overflow: TextOverflow.ellipsis,
+                style: TextStyle(
+                  color: state.phase == AppUpdatePhase.error
+                      ? const Color(0xFFFF929B)
+                      : context.appPalette.mutedText,
+                  fontSize: tvScale ? 12 : 11,
+                  height: 1.25,
                 ),
-                _TvTextButton(
-                  label: checkLabel,
-                  icon: state.downloadedPath == null
-                      ? Icons.refresh_rounded
-                      : Icons.install_mobile_rounded,
-                  onPressed: state.isBusy ? null : onCheckOrInstall,
-                  focusNode: checkFocusNode,
+              ),
+              if (state.release?.notes.trim().isNotEmpty == true) ...[
+                SizedBox(height: tvScale ? 5 : 10),
+                Divider(color: _settingsBorderColor(context, .14), height: 1),
+                SizedBox(height: tvScale ? 5 : 10),
+                Text(
+                  'WHAT’S NEW',
+                  style: TextStyle(
+                    color: context.appPalette.accentBright,
+                    fontSize: tvScale ? 12 : 11,
+                    fontWeight: FontWeight.w900,
+                  ),
+                ),
+                const SizedBox(height: 4),
+                Text(
+                  state.release!.notes.trim(),
+                  maxLines: 8,
+                  overflow: TextOverflow.ellipsis,
+                  style: TextStyle(fontSize: tvScale ? 12 : 11, height: 1.35),
                 ),
               ],
-            ),
+            ],
           ),
-          if (state.phase == AppUpdatePhase.downloading) ...[
-            const SizedBox(height: 8),
-            LinearProgressIndicator(
+        ),
+        LayoutBuilder(
+          key: const ValueKey('app-update-actions'),
+          builder: (context, constraints) {
+            final automatic = _SettingsPanelActionRow(
+              label: state.automaticUpdates
+                  ? 'Automatic: ON'
+                  : 'Automatic: OFF',
+              subtitle:
+                  'Download signed updates automatically when a newer build is available.',
+              icon: state.automaticUpdates
+                  ? Icons.autorenew_rounded
+                  : Icons.update_disabled_rounded,
+              onPressed: state.isBusy ? null : onToggleAutomatic,
+              focusNode: automaticFocusNode,
+              showDivider: !tvScale,
+            );
+            final check = _SettingsPanelActionRow(
+              label: checkLabel,
+              subtitle:
+                  'Check this channel and open Android’s installer when the package is ready.',
+              icon: state.downloadedPath == null
+                  ? Icons.refresh_rounded
+                  : Icons.install_mobile_rounded,
+              onPressed: state.isBusy ? null : onCheckOrInstall,
+              focusNode: checkFocusNode,
+            );
+            if (!tvScale) {
+              return Column(children: [automatic, check]);
+            }
+            return Row(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Expanded(child: automatic),
+                const SizedBox(width: 8),
+                Expanded(child: check),
+              ],
+            );
+          },
+        ),
+        if (state.phase == AppUpdatePhase.downloading)
+          Padding(
+            padding: const EdgeInsets.fromLTRB(16, 8, 16, 14),
+            child: LinearProgressIndicator(
               value: state.progress > 0 ? state.progress : null,
               color: context.appPalette.accentBright,
               backgroundColor: const Color(0xFF2A2A2A),
             ),
-          ],
-        ],
-      ),
+          ),
+      ],
     );
   }
 }
@@ -4535,68 +5667,6 @@ String _releaseLabelForVersion(AppUpdateState state, String version) {
   return release == null
       ? state.updateChannel.versionLabel(version)
       : appReleaseDisplayLabel(release, state.updateChannel);
-}
-
-class _HomeShelfOrganizer extends StatelessWidget {
-  const _HomeShelfOrganizer({
-    required this.order,
-    required this.enabled,
-    required this.focusNodes,
-    required this.sectionFocusNode,
-    required this.expanded,
-    required this.onExpandedChanged,
-    required this.onToggle,
-    required this.onMove,
-  });
-
-  final List<HomeShelf> order;
-  final Set<HomeShelf> enabled;
-  final Map<HomeShelf, FocusNode> focusNodes;
-  final FocusNode sectionFocusNode;
-  final bool expanded;
-  final ValueChanged<bool> onExpandedChanged;
-  final ValueChanged<HomeShelf> onToggle;
-  final void Function(HomeShelf shelf, int offset) onMove;
-
-  @override
-  Widget build(BuildContext context) {
-    return _Panel(
-      child: _InlineCollapsibleSection(
-        key: const ValueKey('customize-section-home-shelves'),
-        label: 'HOME SHELVES',
-        focusNode: sectionFocusNode,
-        expanded: expanded,
-        onExpandedChanged: onExpandedChanged,
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            const SizedBox(height: 6),
-            Text(
-              'Choose what appears on Home and move favorites toward the top.',
-              style: TextStyle(
-                color: context.appPalette.mutedText,
-                fontSize: 10,
-              ),
-            ),
-            const SizedBox(height: 10),
-            for (var index = 0; index < order.length; index++) ...[
-              _HomeShelfRow(
-                index: index,
-                total: order.length,
-                shelf: order[index],
-                enabled: enabled.contains(order[index]),
-                focusNode: focusNodes[order[index]]!,
-                onToggle: () => onToggle(order[index]),
-                onMoveUp: () => onMove(order[index], -1),
-                onMoveDown: () => onMove(order[index], 1),
-              ),
-              if (index != order.length - 1) const SizedBox(height: 6),
-            ],
-          ],
-        ),
-      ),
-    );
-  }
 }
 
 class _TopNavigationOrganizer extends StatelessWidget {
@@ -4703,13 +5773,14 @@ class _TopNavigationRow extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final tvScale = _usesTvSettingsScale(context);
     final id = destination.name;
     final isSettings = settingsPlacement != null;
     final settingsInProfileMenu =
         settingsPlacement == SettingsEntryPlacement.profileMenu;
     final visibilityControl = Container(
-      height: 38,
-      padding: const EdgeInsets.symmetric(horizontal: 12),
+      height: tvScale ? 48 : 48,
+      padding: EdgeInsets.symmetric(horizontal: tvScale ? 10 : 12),
       decoration: BoxDecoration(
         color: visible
             ? context.appPalette.accent.withValues(alpha: .28)
@@ -4731,12 +5802,12 @@ class _TopNavigationRow extends StatelessWidget {
                 : (visible
                       ? Icons.visibility_rounded
                       : Icons.visibility_off_rounded),
-            size: 17,
+            size: tvScale ? 20 : 19,
             color: visible
                 ? _settingsPrimaryText(context)
                 : context.appPalette.mutedText,
           ),
-          const SizedBox(width: 9),
+          SizedBox(width: tvScale ? 6 : 9),
           Expanded(
             child: Text(
               destination.displayName,
@@ -4746,7 +5817,7 @@ class _TopNavigationRow extends StatelessWidget {
                 color: visible
                     ? _settingsPrimaryText(context)
                     : context.appPalette.mutedText,
-                fontSize: 11,
+                fontSize: tvScale ? 15 : 13,
                 fontWeight: FontWeight.w800,
               ),
             ),
@@ -4759,7 +5830,7 @@ class _TopNavigationRow extends StatelessWidget {
               color: visible
                   ? context.appPalette.accentBright
                   : context.appPalette.mutedText,
-              fontSize: 8,
+              fontSize: tvScale ? 9 : 9,
               fontWeight: FontWeight.w900,
               letterSpacing: .7,
             ),
@@ -4776,13 +5847,13 @@ class _TopNavigationRow extends StatelessWidget {
       child: Row(
         children: [
           SizedBox(
-            width: 24,
+            width: tvScale ? 24 : 24,
             child: Text(
               '${index + 1}',
               textAlign: TextAlign.center,
               style: TextStyle(
                 color: context.appPalette.mutedText,
-                fontSize: 10,
+                fontSize: tvScale ? 12 : 11,
                 fontWeight: FontWeight.w800,
               ),
             ),
@@ -4841,16 +5912,17 @@ class _HomeShelfRow extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final tvScale = _usesTvSettingsScale(context);
     return Row(
       children: [
         SizedBox(
-          width: 24,
+          width: tvScale ? 24 : 24,
           child: Text(
             '${index + 1}',
             textAlign: TextAlign.center,
             style: TextStyle(
               color: context.appPalette.mutedText,
-              fontSize: 10,
+              fontSize: tvScale ? 11 : 10,
               fontWeight: FontWeight.w800,
             ),
           ),
@@ -4860,11 +5932,11 @@ class _HomeShelfRow extends StatelessWidget {
           child: TvFocusable(
             focusNode: focusNode,
             onPressed: onToggle,
-            focusScale: 1.01,
+            focusScale: 1.005,
             borderRadius: BorderRadius.circular(8),
             child: Container(
-              height: 38,
-              padding: const EdgeInsets.symmetric(horizontal: 12),
+              constraints: BoxConstraints(minHeight: tvScale ? 48 : 54),
+              padding: EdgeInsets.symmetric(horizontal: tvScale ? 10 : 12),
               decoration: BoxDecoration(
                 color: enabled
                     ? context.appPalette.accent.withValues(alpha: .28)
@@ -4882,12 +5954,12 @@ class _HomeShelfRow extends StatelessWidget {
                     enabled
                         ? Icons.visibility_rounded
                         : Icons.visibility_off_rounded,
-                    size: 17,
+                    size: tvScale ? 20 : 20,
                     color: enabled
                         ? _settingsPrimaryText(context)
                         : context.appPalette.mutedText,
                   ),
-                  const SizedBox(width: 9),
+                  SizedBox(width: tvScale ? 6 : 9),
                   Expanded(
                     child: Text(
                       shelf.displayName,
@@ -4897,7 +5969,7 @@ class _HomeShelfRow extends StatelessWidget {
                         color: enabled
                             ? _settingsPrimaryText(context)
                             : context.appPalette.mutedText,
-                        fontSize: 11,
+                        fontSize: tvScale ? 15 : 14,
                         fontWeight: FontWeight.w800,
                       ),
                     ),
@@ -4908,7 +5980,7 @@ class _HomeShelfRow extends StatelessWidget {
                       color: enabled
                           ? context.appPalette.accentBright
                           : context.appPalette.mutedText,
-                      fontSize: 8,
+                      fontSize: tvScale ? 9 : 9,
                       fontWeight: FontWeight.w900,
                       letterSpacing: .7,
                     ),
@@ -4949,11 +6021,17 @@ class _ShelfOrderButton extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final size = _usesTvSettingsScale(context) ? 36.0 : 40.0;
+    final iconSize = _usesTvSettingsScale(context) ? 20.0 : 20.0;
     if (onPressed == null) {
       return SizedBox(
-        width: 38,
-        height: 38,
-        child: Icon(icon, color: _settingsBorderColor(context, .24), size: 19),
+        width: size,
+        height: size,
+        child: Icon(
+          icon,
+          color: _settingsBorderColor(context, .24),
+          size: iconSize,
+        ),
       );
     }
     return Semantics(
@@ -4963,14 +6041,14 @@ class _ShelfOrderButton extends StatelessWidget {
         onPressed: onPressed!,
         borderRadius: BorderRadius.circular(8),
         child: Container(
-          width: 38,
-          height: 38,
+          width: size,
+          height: size,
           alignment: Alignment.center,
           decoration: BoxDecoration(
             color: context.appPalette.surfaceRaised,
             borderRadius: BorderRadius.circular(8),
           ),
-          child: Icon(icon, size: 19),
+          child: Icon(icon, size: iconSize),
         ),
       ),
     );
@@ -4990,60 +6068,188 @@ class _SectionHeader extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final heading = Row(
-      mainAxisSize: MainAxisSize.min,
-      children: [
-        Icon(icon, size: 16, color: context.appPalette.accentBright),
-        const SizedBox(width: 7),
-        Flexible(
-          child: Text(
-            title,
-            maxLines: 1,
-            overflow: TextOverflow.ellipsis,
-            style: TextStyle(
-              color: _settingsPrimaryText(context),
-              fontSize: 11,
-              fontWeight: FontWeight.w900,
-              letterSpacing: 1.1,
-            ),
-          ),
-        ),
-      ],
-    );
-    if (MediaQuery.sizeOf(context).width < 600) {
-      return Column(
+    final tvScale = _usesTvSettingsScale(context);
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 3),
+      child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          heading,
-          const SizedBox(height: 3),
+          Row(
+            children: [
+              Icon(
+                icon,
+                size: tvScale ? 20 : 21,
+                color: context.appPalette.accentBright,
+              ),
+              SizedBox(width: tvScale ? 6 : 10),
+              Expanded(
+                child: Text(
+                  _settingsDisplayLabel(title),
+                  maxLines: 2,
+                  overflow: TextOverflow.ellipsis,
+                  style: TextStyle(
+                    color: _settingsPrimaryText(context),
+                    fontSize: tvScale ? 18 : 16,
+                    fontWeight: FontWeight.w800,
+                  ),
+                ),
+              ),
+            ],
+          ),
+          SizedBox(height: tvScale ? 3 : 5),
           Padding(
-            padding: const EdgeInsets.only(left: 23),
+            padding: EdgeInsets.only(left: tvScale ? 26 : 31),
             child: Text(
               subtitle,
-              maxLines: 2,
+              maxLines: 3,
               overflow: TextOverflow.ellipsis,
               style: TextStyle(
                 color: context.appPalette.mutedText,
-                fontSize: 10,
+                fontSize: tvScale ? 12 : 11,
+                height: 1.25,
               ),
             ),
           ),
         ],
-      );
-    }
-    return Row(
-      children: [
-        heading,
-        const SizedBox(width: 10),
-        Expanded(
-          child: Text(
-            subtitle,
-            maxLines: 1,
-            overflow: TextOverflow.ellipsis,
-            style: TextStyle(color: context.appPalette.mutedText, fontSize: 11),
-          ),
+      ),
+    );
+  }
+}
+
+class _SettingsPanelSummary extends StatelessWidget {
+  const _SettingsPanelSummary({
+    required this.title,
+    required this.subtitle,
+    required this.icon,
+    this.status,
+    this.error,
+    this.errorKey,
+    this.iconColor,
+  });
+
+  final String title;
+  final String subtitle;
+  final IconData icon;
+  final Widget? status;
+  final String? error;
+  final Key? errorKey;
+  final Color? iconColor;
+
+  @override
+  Widget build(BuildContext context) {
+    final tvScale = _usesTvSettingsScale(context);
+    return Container(
+      constraints: BoxConstraints(minHeight: tvScale ? 48 : 64),
+      padding: EdgeInsets.symmetric(
+        horizontal: tvScale ? 10 : 13,
+        vertical: tvScale ? 5 : 11,
+      ),
+      decoration: BoxDecoration(
+        color: context.appPalette.surface,
+        border: Border(
+          bottom: BorderSide(color: _settingsBorderColor(context, .14)),
         ),
-      ],
+      ),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Icon(
+            icon,
+            size: tvScale ? 22 : 22,
+            color: iconColor ?? _settingsPrimaryText(context),
+          ),
+          SizedBox(width: tvScale ? 8 : 14),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  title,
+                  maxLines: 2,
+                  overflow: TextOverflow.ellipsis,
+                  style: TextStyle(
+                    color: _settingsPrimaryText(context),
+                    fontSize: tvScale ? 16 : 14,
+                    fontWeight: FontWeight.w700,
+                  ),
+                ),
+                SizedBox(height: tvScale ? 2 : 3),
+                Text(
+                  subtitle,
+                  maxLines: tvScale ? 3 : 4,
+                  overflow: TextOverflow.ellipsis,
+                  style: TextStyle(
+                    color: context.appPalette.mutedText,
+                    fontSize: tvScale ? 12 : 11,
+                    height: 1.25,
+                  ),
+                ),
+                if (error case final message?) ...[
+                  const SizedBox(height: 5),
+                  Text(
+                    message,
+                    key: errorKey,
+                    maxLines: 3,
+                    overflow: TextOverflow.ellipsis,
+                    style: TextStyle(
+                      color: const Color(0xFFFF929B),
+                      fontSize: tvScale ? 12 : 11,
+                      height: 1.25,
+                    ),
+                  ),
+                ],
+              ],
+            ),
+          ),
+          if (status case final trailing?) ...[
+            SizedBox(width: tvScale ? 6 : 10),
+            trailing,
+          ],
+        ],
+      ),
+    );
+  }
+}
+
+class _SettingsPanelActionRow extends StatelessWidget {
+  const _SettingsPanelActionRow({
+    required this.label,
+    required this.icon,
+    required this.onPressed,
+    this.subtitle,
+    this.focusNode,
+    this.showDivider = false,
+    this.showChevron = false,
+    this.destructive = false,
+    super.key,
+  });
+
+  final String label;
+  final String? subtitle;
+  final IconData icon;
+  final VoidCallback? onPressed;
+  final FocusNode? focusNode;
+  final bool showDivider;
+  final bool showChevron;
+  final bool destructive;
+
+  @override
+  Widget build(BuildContext context) {
+    final enabled = onPressed != null;
+    final row = _AppearanceActionRow(
+      label: label,
+      subtitle: subtitle,
+      icon: icon,
+      focusNode: enabled ? focusNode : null,
+      showDivider: showDivider,
+      showChevron: showChevron,
+      destructive: destructive,
+      onPressed: onPressed ?? () {},
+    );
+    if (enabled) return row;
+    return ExcludeFocus(
+      excluding: true,
+      child: IgnorePointer(child: Opacity(opacity: .5, child: row)),
     );
   }
 }
@@ -5058,89 +6264,63 @@ class _LegalNoticesPanel extends StatelessWidget {
   final FocusNode licenseFocusNode;
 
   @override
-  Widget build(BuildContext context) {
-    return _Panel(
-      child: LayoutBuilder(
-        builder: (context, constraints) {
-          const notice =
-              'TetoTV is an independent, unofficial client. It is not '
-              'affiliated with or endorsed by AniList, MAL, debrid '
-              'services, addon authors, or media rights holders. Users add '
-              'and are responsible for their own services and repositories.';
-          const attribution = '重音テト © 線 / 小山乃舞世 / TWINDRILL';
-          final copy = Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Text(
-                notice,
-                style: TextStyle(
-                  color: context.appPalette.mutedText,
-                  fontSize: 10,
-                  height: 1.35,
-                ),
+  Widget build(BuildContext context) => Column(
+    crossAxisAlignment: CrossAxisAlignment.stretch,
+    children: [
+      Padding(
+        padding: EdgeInsets.symmetric(
+          horizontal: _usesTvSettingsScale(context) ? 10 : 13,
+          vertical: _usesTvSettingsScale(context) ? 6 : 11,
+        ),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              'TetoTV is an independent, unofficial client. It is not affiliated with or endorsed by AniList, MAL, debrid services, addon authors, or media rights holders. Users add and are responsible for their own services and repositories.',
+              style: TextStyle(
+                color: context.appPalette.mutedText,
+                fontSize: _usesTvSettingsScale(context) ? 12 : 11,
+                height: 1.35,
               ),
-              SizedBox(height: 7),
-              Text(
-                attribution,
-                style: TextStyle(
-                  color: _settingsPrimaryText(context),
-                  fontSize: 10,
-                  fontWeight: FontWeight.w800,
-                ),
+            ),
+            const SizedBox(height: 7),
+            Text(
+              '重音テト © 線 / 小山乃舞世 / TWINDRILL',
+              style: TextStyle(
+                color: _settingsPrimaryText(context),
+                fontSize: _usesTvSettingsScale(context) ? 12 : 11,
+                fontWeight: FontWeight.w800,
               ),
-              SizedBox(height: 7),
-              Text(
-                'Development disclosure: TetoTV includes code created and '
-                'reviewed with AI-assisted development tools. Releases are '
-                'tested and maintained by the project owner.',
-                style: TextStyle(
-                  color: context.appPalette.mutedText,
-                  fontSize: 10,
-                  height: 1.35,
-                ),
+            ),
+            const SizedBox(height: 7),
+            Text(
+              'Development disclosure: TetoTV includes code created and reviewed with AI-assisted development tools. Releases are tested and maintained by the project owner.',
+              style: TextStyle(
+                color: context.appPalette.mutedText,
+                fontSize: _usesTvSettingsScale(context) ? 12 : 11,
+                height: 1.35,
               ),
-            ],
-          );
-          final actions = Wrap(
-            spacing: 8,
-            runSpacing: 8,
-            alignment: WrapAlignment.end,
-            children: [
-              _TvTextButton(
-                label: 'Privacy & data',
-                icon: Icons.privacy_tip_rounded,
-                focusNode: privacyFocusNode,
-                onPressed: () => context.push('/settings/privacy'),
-              ),
-              _TvTextButton(
-                label: 'Third-party notices',
-                icon: Icons.description_rounded,
-                focusNode: licenseFocusNode,
-                onPressed: () => context.push('/settings/notices'),
-              ),
-            ],
-          );
-          if (constraints.maxWidth < 620) {
-            return Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                copy,
-                const SizedBox(height: 12),
-                Align(alignment: Alignment.centerRight, child: actions),
-              ],
-            );
-          }
-          return Row(
-            children: [
-              Expanded(child: copy),
-              const SizedBox(width: 18),
-              actions,
-            ],
-          );
-        },
+            ),
+          ],
+        ),
       ),
-    );
-  }
+      _AppearanceActionRow(
+        label: 'Privacy & data',
+        subtitle: 'Review what TetoTV stores, processes, and shares.',
+        icon: Icons.privacy_tip_outlined,
+        focusNode: privacyFocusNode,
+        showDivider: true,
+        onPressed: () => context.push('/settings/privacy'),
+      ),
+      _AppearanceActionRow(
+        label: 'Third-party notices',
+        subtitle: 'Read attribution and open-source license notices.',
+        icon: Icons.description_outlined,
+        focusNode: licenseFocusNode,
+        onPressed: () => context.push('/settings/notices'),
+      ),
+    ],
+  );
 }
 
 class _CommunityPanels extends StatelessWidget {
@@ -5170,14 +6350,22 @@ class _CommunityPanels extends StatelessWidget {
       builder: (context, constraints) {
         if (constraints.maxWidth < 900) {
           return Column(
-            children: [discord, const SizedBox(height: 8), donation],
+            children: [
+              discord,
+              Divider(color: _settingsBorderColor(context, .14), height: 1),
+              donation,
+            ],
           );
         }
         return Row(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
             Expanded(child: discord),
-            const SizedBox(width: 10),
+            SizedBox(
+              width: 1,
+              height: _usesTvSettingsScale(context) ? 132 : 160,
+              child: ColoredBox(color: _settingsBorderColor(context, .14)),
+            ),
             Expanded(child: donation),
           ],
         );
@@ -5205,8 +6393,8 @@ class _DiscordCommunityPanel extends StatelessWidget {
       focusNode: qrFocusNode,
       showHint: false,
       child: Container(
-        width: 132,
-        height: 132,
+        width: _usesTvSettingsScale(context) ? 96 : 132,
+        height: _usesTvSettingsScale(context) ? 96 : 132,
         padding: const EdgeInsets.all(8),
         decoration: BoxDecoration(
           color: Colors.white,
@@ -5233,17 +6421,28 @@ class _DiscordCommunityPanel extends StatelessWidget {
       children: [
         Text(
           'Join the TetoTV Discord',
-          style: Theme.of(context).textTheme.titleLarge,
+          style: TextStyle(
+            color: _settingsPrimaryText(context),
+            fontSize: _usesTvSettingsScale(context) ? 16 : 14,
+            fontWeight: FontWeight.w700,
+          ),
         ),
         const SizedBox(height: 5),
         Text(
           'Scan the code with your phone, or select the invite below to copy it.',
-          style: TextStyle(color: context.appPalette.mutedText, fontSize: 11),
+          style: TextStyle(
+            color: context.appPalette.mutedText,
+            fontSize: _usesTvSettingsScale(context) ? 12 : 11,
+            height: 1.25,
+          ),
         ),
         const SizedBox(height: 10),
-        TvFocusable(
+        _SettingsPanelActionRow(
+          label: 'Copy Discord invite',
+          subtitle: inviteUrl,
+          icon: Icons.copy_rounded,
           focusNode: focusNode,
-          borderRadius: BorderRadius.circular(10),
+          showChevron: false,
           onPressed: () async {
             await Clipboard.setData(const ClipboardData(text: inviteUrl));
             if (!context.mounted) return;
@@ -5251,33 +6450,11 @@ class _DiscordCommunityPanel extends StatelessWidget {
               const SnackBar(content: Text('Discord invite copied.')),
             );
           },
-          child: Container(
-            padding: const EdgeInsets.symmetric(horizontal: 13, vertical: 11),
-            color: context.appPalette.selectableSurface,
-            child: Row(
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                Icon(
-                  Icons.copy_rounded,
-                  size: 18,
-                  color: context.appPalette.accentBright,
-                ),
-                SizedBox(width: 8),
-                Flexible(
-                  child: Text(
-                    inviteUrl,
-                    maxLines: 1,
-                    overflow: TextOverflow.ellipsis,
-                    style: TextStyle(fontWeight: FontWeight.w800),
-                  ),
-                ),
-              ],
-            ),
-          ),
         ),
       ],
     );
-    return _Panel(
+    return Padding(
+      padding: EdgeInsets.all(_usesTvSettingsScale(context) ? 8 : 13),
       child: LayoutBuilder(
         builder: (context, constraints) {
           if (constraints.maxWidth < 380) {
@@ -5285,7 +6462,7 @@ class _DiscordCommunityPanel extends StatelessWidget {
               crossAxisAlignment: CrossAxisAlignment.center,
               children: [
                 qr,
-                const SizedBox(height: 14),
+                SizedBox(height: _usesTvSettingsScale(context) ? 8 : 14),
                 Align(alignment: Alignment.centerLeft, child: copy),
               ],
             );
@@ -5293,7 +6470,7 @@ class _DiscordCommunityPanel extends StatelessWidget {
           return Row(
             children: [
               qr,
-              const SizedBox(width: 18),
+              SizedBox(width: _usesTvSettingsScale(context) ? 10 : 18),
               Expanded(child: copy),
             ],
           );
@@ -5358,78 +6535,48 @@ class _DiscordPresencePanel extends StatelessWidget {
         : state.enabled && !state.connected
         ? onRetry
         : onToggle;
-
-    final copy = Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      mainAxisSize: MainAxisSize.min,
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
-        Row(
+        _SettingsPanelSummary(
+          title: state.linked ? 'Discord account linked' : 'Discord account',
+          subtitle:
+              'Optional. When enabled, Discord can show the anime title, episode, playing or paused state, and playback timer. TetoTV never asks for or stores your Discord password.',
+          icon: Icons.sports_esports_rounded,
+          iconColor: const Color(0xFFB7BCFF),
+          status: _StatusPill(connected: state.connected, label: statusLabel),
+          error: state.error,
+        ),
+        Column(
+          key: const ValueKey('discord-presence-actions'),
+          crossAxisAlignment: CrossAxisAlignment.stretch,
           children: [
-            const Icon(
-              Icons.sports_esports_rounded,
-              color: Color(0xFFB7BCFF),
-              size: 24,
+            _SettingsPanelActionRow(
+              label: state.busy ? 'Please wait…' : primaryLabel,
+              subtitle: !state.linked
+                  ? 'Authorize TetoTV through Discord’s secure account-linking flow.'
+                  : state.enabled
+                  ? 'Control whether your current playback appears on Discord.'
+                  : 'Turn Rich Presence back on for this linked account.',
+              icon: primaryIcon,
+              focusNode: primaryFocusNode,
+              showDivider: state.linked,
+              showChevron: !state.linked,
+              onPressed: primaryAction,
             ),
-            const SizedBox(width: 10),
-            Expanded(
-              child: Text(
-                'Discord Rich Presence',
-                style: Theme.of(context).textTheme.titleLarge,
+            if (state.linked)
+              _SettingsPanelActionRow(
+                label: 'Unlink Discord',
+                subtitle:
+                    'Remove this Discord connection from TetoTV on this device.',
+                icon: Icons.link_off_rounded,
+                focusNode: unlinkFocusNode,
+                destructive: true,
+                onPressed: state.busy ? null : onUnlink,
               ),
-            ),
-            _StatusPill(connected: state.connected, label: statusLabel),
           ],
         ),
-        const SizedBox(height: 7),
-        Text(
-          'Optional. When enabled, Discord can show the anime title, episode, '
-          'playing or paused state, and playback timer. TetoTV never asks for '
-          'or stores your Discord password.',
-          style: TextStyle(color: context.appPalette.mutedText, fontSize: 11),
-        ),
-        if (state.error case final error?) ...[
-          const SizedBox(height: 8),
-          Text(
-            error,
-            style: const TextStyle(color: Color(0xFFFF929B), fontSize: 11),
-          ),
-        ],
       ],
-    );
-    final actions = Wrap(
-      spacing: 8,
-      runSpacing: 8,
-      alignment: WrapAlignment.end,
-      children: [
-        _TvTextButton(
-          label: state.busy ? 'Please wait…' : primaryLabel,
-          icon: primaryIcon,
-          focusNode: primaryFocusNode,
-          onPressed: primaryAction,
-        ),
-        if (state.linked)
-          _TvTextButton(
-            label: 'Unlink Discord',
-            icon: Icons.link_off_rounded,
-            focusNode: unlinkFocusNode,
-            onPressed: state.busy ? null : onUnlink,
-          ),
-      ],
-    );
-
-    return _Panel(
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          copy,
-          const SizedBox(height: 12),
-          Align(
-            key: const ValueKey('discord-presence-actions'),
-            alignment: Alignment.centerRight,
-            child: actions,
-          ),
-        ],
-      ),
     );
   }
 }
@@ -5450,8 +6597,8 @@ class _DonationPanel extends StatelessWidget {
       focusNode: qrFocusNode,
       showHint: false,
       child: Container(
-        width: 132,
-        height: 132,
+        width: _usesTvSettingsScale(context) ? 96 : 132,
+        height: _usesTvSettingsScale(context) ? 96 : 132,
         padding: const EdgeInsets.all(8),
         decoration: BoxDecoration(
           color: Colors.white,
@@ -5476,17 +6623,31 @@ class _DonationPanel extends StatelessWidget {
       crossAxisAlignment: CrossAxisAlignment.start,
       mainAxisSize: MainAxisSize.min,
       children: [
-        Text('Support TetoTV', style: Theme.of(context).textTheme.titleLarge),
+        Text(
+          'Support TetoTV',
+          style: TextStyle(
+            color: _settingsPrimaryText(context),
+            fontSize: _usesTvSettingsScale(context) ? 16 : 14,
+            fontWeight: FontWeight.w700,
+          ),
+        ),
         const SizedBox(height: 5),
         Text(
           'Donations are optional. Scan with your phone to open the official '
           'TetoTV Ko-fi page, or select the link below to copy it.',
-          style: TextStyle(color: context.appPalette.mutedText, fontSize: 11),
+          style: TextStyle(
+            color: context.appPalette.mutedText,
+            fontSize: _usesTvSettingsScale(context) ? 12 : 11,
+            height: 1.25,
+          ),
         ),
         const SizedBox(height: 10),
-        TvFocusable(
+        _SettingsPanelActionRow(
+          label: 'Copy Ko-fi link',
+          subtitle: donationUrl,
+          icon: Icons.volunteer_activism_rounded,
           focusNode: focusNode,
-          borderRadius: BorderRadius.circular(10),
+          showChevron: false,
           onPressed: () async {
             await Clipboard.setData(const ClipboardData(text: donationUrl));
             if (!context.mounted) return;
@@ -5494,33 +6655,11 @@ class _DonationPanel extends StatelessWidget {
               const SnackBar(content: Text('Ko-fi donation link copied.')),
             );
           },
-          child: Container(
-            padding: const EdgeInsets.symmetric(horizontal: 13, vertical: 11),
-            color: context.appPalette.selectableSurface,
-            child: Row(
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                Icon(
-                  Icons.volunteer_activism_rounded,
-                  size: 18,
-                  color: context.appPalette.accentBright,
-                ),
-                SizedBox(width: 8),
-                Flexible(
-                  child: Text(
-                    donationUrl,
-                    maxLines: 1,
-                    overflow: TextOverflow.ellipsis,
-                    style: TextStyle(fontWeight: FontWeight.w800),
-                  ),
-                ),
-              ],
-            ),
-          ),
         ),
       ],
     );
-    return _Panel(
+    return Padding(
+      padding: EdgeInsets.all(_usesTvSettingsScale(context) ? 8 : 13),
       child: LayoutBuilder(
         builder: (context, constraints) {
           if (constraints.maxWidth < 380) {
@@ -5528,7 +6667,7 @@ class _DonationPanel extends StatelessWidget {
               crossAxisAlignment: CrossAxisAlignment.center,
               children: [
                 qr,
-                const SizedBox(height: 14),
+                SizedBox(height: _usesTvSettingsScale(context) ? 8 : 14),
                 Align(alignment: Alignment.centerLeft, child: copy),
               ],
             );
@@ -5536,7 +6675,7 @@ class _DonationPanel extends StatelessWidget {
           return Row(
             children: [
               qr,
-              const SizedBox(width: 18),
+              SizedBox(width: _usesTvSettingsScale(context) ? 10 : 18),
               Expanded(child: copy),
             ],
           );
@@ -5564,66 +6703,19 @@ class _ServiceAccountHeader extends StatelessWidget {
   final Widget action;
 
   @override
-  Widget build(BuildContext context) {
-    final summary = Row(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        Container(
-          width: 48,
-          height: 48,
-          decoration: BoxDecoration(
-            gradient: LinearGradient(
-              colors: gradient,
-              begin: Alignment.topLeft,
-              end: Alignment.bottomRight,
-            ),
-            borderRadius: BorderRadius.circular(10),
-          ),
-          child: Icon(icon, color: context.appPalette.background, size: 24),
-        ),
-        const SizedBox(width: 12),
-        Expanded(
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Wrap(
-                spacing: 10,
-                runSpacing: 6,
-                crossAxisAlignment: WrapCrossAlignment.center,
-                children: [
-                  Text(title, style: Theme.of(context).textTheme.titleLarge),
-                  status,
-                ],
-              ),
-              const SizedBox(height: 3),
-              Text(description, style: Theme.of(context).textTheme.bodyMedium),
-            ],
-          ),
-        ),
-      ],
-    );
-    return LayoutBuilder(
-      builder: (context, constraints) {
-        if (constraints.maxWidth < 620) {
-          return Column(
-            crossAxisAlignment: CrossAxisAlignment.stretch,
-            children: [
-              summary,
-              const SizedBox(height: 12),
-              Align(alignment: Alignment.centerRight, child: action),
-            ],
-          );
-        }
-        return Row(
-          children: [
-            Expanded(child: summary),
-            const SizedBox(width: 12),
-            action,
-          ],
-        );
-      },
-    );
-  }
+  Widget build(BuildContext context) => Column(
+    crossAxisAlignment: CrossAxisAlignment.stretch,
+    children: [
+      _SettingsPanelSummary(
+        title: title,
+        subtitle: description,
+        icon: icon,
+        status: status,
+        iconColor: Color.lerp(gradient.first, gradient.last, .5),
+      ),
+      action,
+    ],
+  );
 }
 
 class _RealDebridPanel extends StatelessWidget {
@@ -5642,56 +6734,60 @@ class _RealDebridPanel extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final account = state.account;
-    return _Panel(
-      child: Column(
-        children: [
-          _ServiceAccountHeader(
-            icon: Icons.cloud_download_rounded,
-            gradient: [
-              context.appPalette.accent,
-              context.appPalette.secondaryAccent,
-            ],
-            title: 'Real-Debrid',
-            status: _StatusPill(
-              connected: account != null,
-              label: account == null
-                  ? state.hasSavedToken
-                        ? 'RECONNECTING'
-                        : 'NOT CONNECTED'
-                  : account.isPremium
-                  ? 'PREMIUM'
-                  : account.type.toUpperCase(),
-            ),
-            description: account == null
-                ? 'Authorize securely with Real-Debrid on your phone or computer.'
-                : 'Connected as ${account.username}. Cached torrents will '
-                      'resolve almost instantly.',
-            action: account == null
-                ? _TvTextButton(
-                    label: 'Connect by QR',
-                    icon: Icons.qr_code_rounded,
-                    onPressed: onDeviceConnect,
-                    focusNode: connectFocusNode,
-                  )
-                : _TvTextButton(
-                    label: 'Disconnect',
-                    icon: Icons.link_off_rounded,
-                    onPressed: onDisconnect,
-                    focusNode: connectFocusNode,
-                  ),
+    return Column(
+      children: [
+        _ServiceAccountHeader(
+          icon: Icons.cloud_download_rounded,
+          gradient: [
+            context.appPalette.accent,
+            context.appPalette.secondaryAccent,
+          ],
+          title: 'Real-Debrid',
+          status: _StatusPill(
+            connected: account != null,
+            label: account == null
+                ? state.hasSavedToken
+                      ? 'RECONNECTING'
+                      : 'NOT CONNECTED'
+                : account.isPremium
+                ? 'PREMIUM'
+                : account.type.toUpperCase(),
           ),
-          if (state.errorMessage case final error?) ...[
-            const SizedBox(height: 10),
-            Align(
-              alignment: Alignment.centerLeft,
-              child: Text(
-                error,
-                style: const TextStyle(color: Color(0xFFFF929B)),
+          description: account == null
+              ? 'Authorize securely with Real-Debrid on your phone or computer.'
+              : 'Connected as ${account.username}. Cached torrents will '
+                    'resolve almost instantly.',
+          action: account == null
+              ? _SettingsPanelActionRow(
+                  label: 'Connect by QR',
+                  subtitle: 'Open the secure device authorization flow.',
+                  icon: Icons.qr_code_rounded,
+                  onPressed: onDeviceConnect,
+                  focusNode: connectFocusNode,
+                )
+              : _SettingsPanelActionRow(
+                  label: 'Disconnect',
+                  subtitle: 'Remove the saved Real-Debrid connection.',
+                  icon: Icons.link_off_rounded,
+                  onPressed: onDisconnect,
+                  focusNode: connectFocusNode,
+                ),
+        ),
+        if (state.errorMessage case final error?) ...[
+          const SizedBox(height: 10),
+          Align(
+            alignment: Alignment.centerLeft,
+            child: Text(
+              error,
+              style: TextStyle(
+                color: const Color(0xFFFF929B),
+                fontSize: _usesTvSettingsScale(context) ? 13 : 11,
+                height: 1.3,
               ),
             ),
-          ],
+          ),
         ],
-      ),
+      ],
     );
   }
 }
@@ -5720,79 +6816,71 @@ class _TorBoxPanel extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final account = state.account;
-    return _Panel(
-      child: Column(
-        children: [
-          _ServiceAccountHeader(
-            icon: Icons.cloud_circle_rounded,
-            gradient: [
-              context.appPalette.accent,
-              context.appPalette.accentBright,
-            ],
-            title: 'TorBox',
-            status: _StatusPill(
-              connected: account != null,
-              label: account == null
-                  ? state.hasSavedToken
-                        ? 'RECONNECTING'
-                        : 'NOT CONNECTED'
-                  : account.planName.toUpperCase(),
-            ),
-            description: account == null
-                ? 'Authorize with a QR code, or enter a TorBox API token below.'
-                : 'Connected as ${account.email}. Torrent files are resolved '
-                      'and streamed through TorBox only.',
-            action: account == null
-                ? _TvTextButton(
-                    label: 'Connect by QR',
-                    icon: Icons.qr_code_rounded,
-                    onPressed: onDeviceConnect,
-                    focusNode: actionFocusNode,
-                  )
-                : _TvTextButton(
-                    label: 'Disconnect',
-                    icon: Icons.link_off_rounded,
-                    onPressed: onDisconnect,
-                    focusNode: actionFocusNode,
-                  ),
+    return Column(
+      children: [
+        _ServiceAccountHeader(
+          icon: Icons.cloud_circle_rounded,
+          gradient: [
+            context.appPalette.accent,
+            context.appPalette.accentBright,
+          ],
+          title: 'TorBox',
+          status: _StatusPill(
+            connected: account != null,
+            label: account == null
+                ? state.hasSavedToken
+                      ? 'RECONNECTING'
+                      : 'NOT CONNECTED'
+                : account.planName.toUpperCase(),
           ),
-          if (state.errorMessage case final error?) ...[
-            const SizedBox(height: 10),
-            Align(
-              alignment: Alignment.centerLeft,
-              child: Text(
-                error,
-                style: const TextStyle(color: Color(0xFFFF929B)),
+          description: account == null
+              ? 'Authorize with a QR code, or enter a TorBox API token below.'
+              : 'Connected as ${account.email}. Torrent files are resolved '
+                    'and streamed through TorBox only.',
+          action: account == null
+              ? _SettingsPanelActionRow(
+                  label: 'Connect by QR',
+                  subtitle: 'Open TorBox device authorization.',
+                  icon: Icons.qr_code_rounded,
+                  onPressed: onDeviceConnect,
+                  focusNode: actionFocusNode,
+                  showDivider: true,
+                )
+              : _SettingsPanelActionRow(
+                  label: 'Disconnect',
+                  subtitle: 'Remove the saved TorBox connection.',
+                  icon: Icons.link_off_rounded,
+                  onPressed: onDisconnect,
+                  focusNode: actionFocusNode,
+                ),
+        ),
+        if (state.errorMessage case final error?) ...[
+          const SizedBox(height: 10),
+          Align(
+            alignment: Alignment.centerLeft,
+            child: Text(
+              error,
+              style: TextStyle(
+                color: const Color(0xFFFF929B),
+                fontSize: _usesTvSettingsScale(context) ? 13 : 11,
+                height: 1.3,
               ),
             ),
-          ],
-          if (account == null) ...[
-            const SizedBox(height: 10),
-            Divider(color: _settingsBorderColor(context, .08), height: 1),
-            const SizedBox(height: 10),
-            _ResponsiveTokenRow(
-              title: 'TorBox API token',
-              input: TvTextInput(
-                focusNode: tokenFocusNode,
-                controller: tokenController,
-                labelText: 'Personal API token',
-                hintText: 'Select to open the TV keyboard',
-                keyboardTitle: 'Enter TorBox token',
-                obscureText: true,
-                onSubmitted: (_) => onSave(),
-              ),
-              action: _TvTextButton(
-                label: state.isLoading ? 'Checking…' : 'Save & verify',
-                icon: state.isLoading
-                    ? Icons.sync_rounded
-                    : Icons.verified_user_rounded,
-                onPressed: state.isLoading ? null : onSave,
-                focusNode: saveFocusNode,
-              ),
-            ),
-          ],
+          ),
         ],
-      ),
+        if (account == null) ...[
+          _SettingsTokenEditor(
+            title: 'TorBox API token',
+            labelText: 'Personal API token',
+            keyboardTitle: 'Enter TorBox token',
+            controller: tokenController,
+            tokenFocusNode: tokenFocusNode,
+            saveFocusNode: saveFocusNode,
+            isLoading: state.isLoading,
+            onSave: onSave,
+          ),
+        ],
+      ],
     );
   }
 }
@@ -5843,67 +6931,155 @@ class _ApiKeyDebridPanel extends StatelessWidget {
   final FocusNode saveFocusNode;
 
   @override
-  Widget build(BuildContext context) => _Panel(
-    child: Column(
-      children: [
-        _ServiceAccountHeader(
-          icon: icon,
-          gradient: gradient,
-          title: title,
-          status: _StatusPill(
-            connected: connected,
-            label: connected
-                ? connectedLabel
-                : hasSavedToken
-                ? 'RECONNECTING'
-                : 'NOT CONNECTED',
-          ),
-          description: description,
-          action: _TvTextButton(
-            label: connected ? 'Disconnect' : connectLabel,
-            icon: connected ? Icons.link_off_rounded : connectIcon,
-            onPressed: connected ? onDisconnect : onConnect,
-            focusNode: actionFocusNode,
+  Widget build(BuildContext context) => Column(
+    children: [
+      _ServiceAccountHeader(
+        icon: icon,
+        gradient: gradient,
+        title: title,
+        status: _StatusPill(
+          connected: connected,
+          label: connected
+              ? connectedLabel
+              : hasSavedToken
+              ? 'RECONNECTING'
+              : 'NOT CONNECTED',
+        ),
+        description: description,
+        action: _SettingsPanelActionRow(
+          label: connected ? 'Disconnect' : connectLabel,
+          subtitle: connected
+              ? 'Remove this saved debrid connection.'
+              : 'Open the provider authorization flow.',
+          icon: connected ? Icons.link_off_rounded : connectIcon,
+          onPressed: connected ? onDisconnect : onConnect,
+          focusNode: actionFocusNode,
+          showDivider: !connected,
+        ),
+      ),
+      if (errorMessage case final error?) ...[
+        const SizedBox(height: 10),
+        Align(
+          alignment: Alignment.centerLeft,
+          child: Text(
+            error,
+            style: TextStyle(
+              color: const Color(0xFFFF929B),
+              fontSize: _usesTvSettingsScale(context) ? 13 : 11,
+              height: 1.3,
+            ),
           ),
         ),
-        if (errorMessage case final error?) ...[
-          const SizedBox(height: 10),
-          Align(
-            alignment: Alignment.centerLeft,
-            child: Text(
-              error,
-              style: const TextStyle(color: Color(0xFFFF929B)),
-            ),
-          ),
-        ],
-        if (!connected) ...[
-          const SizedBox(height: 10),
-          Divider(color: _settingsBorderColor(context, .08), height: 1),
-          const SizedBox(height: 10),
-          _ResponsiveTokenRow(
-            title: tokenTitle,
-            input: TvTextInput(
-              focusNode: tokenFocusNode,
-              controller: tokenController,
-              labelText: 'Personal API key',
-              hintText: 'Select to open the TV keyboard',
-              keyboardTitle: keyboardTitle,
-              obscureText: true,
-              onSubmitted: (_) => onSave(),
-            ),
-            action: _TvTextButton(
-              label: isLoading ? 'Checking…' : 'Save & verify',
-              icon: isLoading
-                  ? Icons.sync_rounded
-                  : Icons.verified_user_rounded,
-              onPressed: isLoading ? null : onSave,
-              focusNode: saveFocusNode,
-            ),
-          ),
-        ],
       ],
-    ),
+      if (!connected) ...[
+        _SettingsTokenEditor(
+          title: tokenTitle,
+          labelText: 'Personal API key',
+          keyboardTitle: keyboardTitle,
+          controller: tokenController,
+          tokenFocusNode: tokenFocusNode,
+          saveFocusNode: saveFocusNode,
+          isLoading: isLoading,
+          onSave: onSave,
+        ),
+      ],
+    ],
   );
+}
+
+class _SettingsTokenEditor extends StatelessWidget {
+  const _SettingsTokenEditor({
+    required this.title,
+    required this.labelText,
+    required this.keyboardTitle,
+    required this.controller,
+    required this.tokenFocusNode,
+    required this.saveFocusNode,
+    required this.isLoading,
+    required this.onSave,
+    this.onSubmitted,
+    this.error,
+  });
+
+  final String title;
+  final String labelText;
+  final String keyboardTitle;
+  final TextEditingController controller;
+  final FocusNode tokenFocusNode;
+  final FocusNode saveFocusNode;
+  final bool isLoading;
+  final VoidCallback onSave;
+  final ValueChanged<String>? onSubmitted;
+  final String? error;
+
+  @override
+  Widget build(BuildContext context) {
+    final tvScale = _usesTvSettingsScale(context);
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        Container(
+          color: context.appPalette.surface,
+          padding: EdgeInsets.symmetric(
+            horizontal: tvScale ? 10 : 13,
+            vertical: tvScale ? 6 : 11,
+          ),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Row(
+                children: [
+                  Icon(
+                    Icons.key_rounded,
+                    size: tvScale ? 22 : 22,
+                    color: _settingsPrimaryText(context),
+                  ),
+                  SizedBox(width: tvScale ? 8 : 14),
+                  Expanded(
+                    child: Text(
+                      title,
+                      style: TextStyle(
+                        color: _settingsPrimaryText(context),
+                        fontSize: tvScale ? 16 : 14,
+                        fontWeight: FontWeight.w700,
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+              SizedBox(height: tvScale ? 6 : 9),
+              TvTextInput(
+                focusNode: tokenFocusNode,
+                controller: controller,
+                labelText: labelText,
+                hintText: 'Select to open the TV keyboard',
+                keyboardTitle: keyboardTitle,
+                obscureText: true,
+                onSubmitted: onSubmitted ?? (_) => onSave(),
+              ),
+              if (error case final message?) ...[
+                SizedBox(height: tvScale ? 5 : 8),
+                Text(
+                  message,
+                  style: TextStyle(
+                    color: const Color(0xFFFF8DA0),
+                    fontSize: tvScale ? 12 : 11,
+                  ),
+                ),
+              ],
+            ],
+          ),
+        ),
+        _SettingsPanelActionRow(
+          label: isLoading ? 'Checking…' : 'Save & verify',
+          subtitle: 'Validate and save this credential securely.',
+          icon: isLoading ? Icons.sync_rounded : Icons.verified_user_rounded,
+          focusNode: saveFocusNode,
+          onPressed: isLoading ? null : onSave,
+        ),
+      ],
+    );
+  }
 }
 
 class _LocalProfilesPanel extends StatelessWidget {
@@ -5921,99 +7097,34 @@ class _LocalProfilesPanel extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final active = state.activeProfile;
-    return _Panel(
-      child: LayoutBuilder(
-        builder: (context, constraints) {
-          final summary = Row(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Container(
-                width: 42,
-                height: 42,
-                decoration: BoxDecoration(
-                  color: context.appPalette.secondaryAccent.withValues(
-                    alpha: .14,
-                  ),
-                  borderRadius: BorderRadius.circular(9),
-                ),
-                child: Icon(
-                  Icons.person_outline_rounded,
-                  color: context.appPalette.secondaryAccent,
-                ),
-              ),
-              const SizedBox(width: 10),
-              Expanded(
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    Row(
-                      children: [
-                        Expanded(
-                          child: Text(
-                            'Local profiles',
-                            style: Theme.of(context).textTheme.titleLarge,
-                          ),
-                        ),
-                        _StatusPill(
-                          connected: active != null,
-                          label: active == null ? 'OPTIONAL' : 'ACTIVE',
-                        ),
-                      ],
-                    ),
-                    const SizedBox(height: 4),
-                    Text(
-                      active == null
-                          ? 'Use TetoTV without AniList or MAL by creating a name stored only on this device.'
-                          : 'Using ${active.displayName}. This name appears in the profile switcher and Watch Party.',
-                      style: Theme.of(context).textTheme.bodyMedium,
-                    ),
-                    const SizedBox(height: 4),
-                    Text(
-                      'History and settings are currently shared between profiles; tracker credentials stay separate.',
-                      style: TextStyle(
-                        color: context.appPalette.mutedText,
-                        fontSize: 11,
-                      ),
-                    ),
-                    if (state.error case final error?) ...[
-                      const SizedBox(height: 5),
-                      Text(
-                        error,
-                        key: const ValueKey('local-profiles-error'),
-                        style: const TextStyle(color: Color(0xFFFF8DA0)),
-                      ),
-                    ],
-                  ],
-                ),
-              ),
-            ],
-          );
-          final action = _TvTextButton(
-            key: const ValueKey('manage-local-profiles'),
-            label: state.isLoading ? 'Loading…' : 'Manage',
-            icon: Icons.manage_accounts_outlined,
-            focusNode: focusNode,
-            onPressed: state.isLoading ? null : () => _openManager(context),
-          );
-          if (constraints.maxWidth < 620) {
-            return Column(
-              crossAxisAlignment: CrossAxisAlignment.stretch,
-              children: [
-                summary,
-                const SizedBox(height: 12),
-                Align(alignment: Alignment.centerRight, child: action),
-              ],
-            );
-          }
-          return Row(
-            children: [
-              Expanded(child: summary),
-              const SizedBox(width: 12),
-              action,
-            ],
-          );
-        },
-      ),
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        _SettingsPanelSummary(
+          title: 'Local profiles',
+          subtitle: active == null
+              ? 'Use TetoTV without AniList or MAL by creating a name stored only on this device. History and settings are shared; tracker credentials stay separate.'
+              : 'Using ${active.displayName}. This name appears in the profile switcher and Watch Party. History and settings are shared; tracker credentials stay separate.',
+          icon: Icons.person_outline_rounded,
+          iconColor: context.appPalette.secondaryAccent,
+          status: _StatusPill(
+            connected: active != null,
+            label: active == null ? 'OPTIONAL' : 'ACTIVE',
+          ),
+          error: state.error,
+          errorKey: const ValueKey('local-profiles-error'),
+        ),
+        _SettingsPanelActionRow(
+          key: const ValueKey('manage-local-profiles'),
+          label: state.isLoading ? 'Loading…' : 'Manage',
+          subtitle:
+              'Create, switch, or remove names stored locally on this device.',
+          icon: Icons.manage_accounts_outlined,
+          focusNode: focusNode,
+          showChevron: true,
+          onPressed: state.isLoading ? null : () => _openManager(context),
+        ),
+      ],
     );
   }
 }
@@ -6205,10 +7316,10 @@ class _LocalProfilesDialogState extends ConsumerState<_LocalProfilesDialog> {
       child: Dialog(
         key: const ValueKey('local-profiles-dialog'),
         backgroundColor: Colors.transparent,
-        insetPadding: const EdgeInsets.all(20),
+        insetPadding: EdgeInsets.all(_usesTvSettingsScale(context) ? 10 : 20),
         child: ConstrainedBox(
           constraints: BoxConstraints(
-            maxWidth: 760,
+            maxWidth: _usesTvSettingsScale(context) ? 560 : 760,
             maxHeight: MediaQuery.sizeOf(context).height * .86,
           ),
           child: DecoratedBox(
@@ -6220,7 +7331,7 @@ class _LocalProfilesDialogState extends ConsumerState<_LocalProfilesDialog> {
               ),
             ),
             child: SingleChildScrollView(
-              padding: const EdgeInsets.all(20),
+              padding: EdgeInsets.all(_usesTvSettingsScale(context) ? 10 : 20),
               child: Column(
                 mainAxisSize: MainAxisSize.min,
                 crossAxisAlignment: CrossAxisAlignment.start,
@@ -6233,12 +7344,12 @@ class _LocalProfilesDialogState extends ConsumerState<_LocalProfilesDialog> {
                         icon: Icons.arrow_back_rounded,
                         onPressed: () => Navigator.of(context).pop(),
                       ),
-                      const SizedBox(width: 10),
+                      SizedBox(width: _usesTvSettingsScale(context) ? 6 : 10),
                       Icon(
                         Icons.person_outline_rounded,
                         color: context.appPalette.secondaryAccent,
                       ),
-                      const SizedBox(width: 9),
+                      SizedBox(width: _usesTvSettingsScale(context) ? 5 : 9),
                       Expanded(
                         child: Text(
                           'Local profiles',
@@ -6253,10 +7364,10 @@ class _LocalProfilesDialogState extends ConsumerState<_LocalProfilesDialog> {
                     style: TextStyle(color: context.appPalette.mutedText),
                   ),
                   if (state.profiles.isEmpty) ...[
-                    const SizedBox(height: 16),
+                    SizedBox(height: _usesTvSettingsScale(context) ? 8 : 16),
                     const Text('No local profiles yet.'),
                   ] else ...[
-                    const SizedBox(height: 14),
+                    SizedBox(height: _usesTvSettingsScale(context) ? 7 : 14),
                     for (final profile in state.profiles) ...[
                       _LocalProfileRow(
                         profile: profile,
@@ -6266,12 +7377,12 @@ class _LocalProfilesDialogState extends ConsumerState<_LocalProfilesDialog> {
                         onActivate: () => _activate(profile),
                         onDelete: () => _delete(profile),
                       ),
-                      const SizedBox(height: 8),
+                      SizedBox(height: _usesTvSettingsScale(context) ? 4 : 8),
                     ],
                   ],
-                  const SizedBox(height: 10),
+                  SizedBox(height: _usesTvSettingsScale(context) ? 5 : 10),
                   Divider(color: _settingsBorderColor(context, .10), height: 1),
-                  const SizedBox(height: 14),
+                  SizedBox(height: _usesTvSettingsScale(context) ? 7 : 14),
                   _ResponsiveTokenRow(
                     title: 'New local profile',
                     input: TvTextInput(
@@ -6296,7 +7407,7 @@ class _LocalProfilesDialogState extends ConsumerState<_LocalProfilesDialog> {
                     ),
                   ),
                   if (_message ?? state.error case final message?) ...[
-                    const SizedBox(height: 10),
+                    SizedBox(height: _usesTvSettingsScale(context) ? 5 : 10),
                     Text(
                       message,
                       key: const ValueKey('local-profiles-dialog-message'),
@@ -6337,7 +7448,10 @@ class _LocalProfileRow extends StatelessWidget {
   @override
   Widget build(BuildContext context) => Container(
     key: ValueKey('local-profile-row-${profile.id}'),
-    padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
+    padding: EdgeInsets.symmetric(
+      horizontal: _usesTvSettingsScale(context) ? 8 : 12,
+      vertical: _usesTvSettingsScale(context) ? 5 : 10,
+    ),
     decoration: BoxDecoration(
       color: context.appPalette.background.withValues(alpha: .62),
       borderRadius: BorderRadius.circular(9),
@@ -6451,104 +7565,59 @@ class _TrackingPanelState extends State<_TrackingPanel> {
 
   @override
   Widget build(BuildContext context) {
-    return _Panel(
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Row(
-            children: [
-              Container(
-                width: 42,
-                height: 42,
-                decoration: BoxDecoration(
-                  color: widget.color.withValues(alpha: .14),
-                  borderRadius: BorderRadius.circular(9),
-                ),
-                child: Icon(
-                  Icons.playlist_add_check_rounded,
-                  color: widget.color,
-                ),
-              ),
-              const SizedBox(width: 10),
-              Expanded(
-                child: Text(
-                  widget.provider.displayName,
-                  maxLines: 1,
-                  overflow: TextOverflow.ellipsis,
-                  style: Theme.of(context).textTheme.titleLarge,
-                ),
-              ),
-              const SizedBox(width: 8),
-              _StatusPill(
-                connected: widget.username != null,
-                label: widget.username != null ? 'CONNECTED' : 'NOT CONNECTED',
-              ),
-            ],
+    final connected = widget.username != null;
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        _SettingsPanelSummary(
+          title: widget.provider.displayName,
+          subtitle: connected
+              ? 'Connected as ${widget.username}.'
+              : widget.description,
+          icon: Icons.playlist_add_check_rounded,
+          iconColor: widget.color,
+          status: _StatusPill(
+            connected: connected,
+            label: connected ? 'CONNECTED' : 'NOT CONNECTED',
           ),
-          const SizedBox(height: 7),
-          Text(
-            widget.username == null
-                ? widget.description
-                : 'Connected as ${widget.username}.',
-            style: Theme.of(context).textTheme.bodyMedium,
+          error: connected ? widget.error : null,
+        ),
+        _SettingsPanelActionRow(
+          label: connected ? 'Add profile' : 'Connect by QR',
+          subtitle: connected
+              ? 'Authorize another ${widget.provider.displayName} profile.'
+              : 'Open the secure account-pairing flow on another device.',
+          icon: connected
+              ? Icons.person_add_alt_1_rounded
+              : Icons.qr_code_rounded,
+          focusNode: widget.focusNode,
+          showDivider: true,
+          showChevron: true,
+          onPressed: widget.onConnect,
+        ),
+        if (connected)
+          _SettingsPanelActionRow(
+            label: 'Disconnect',
+            subtitle:
+                'Remove this ${widget.provider.displayName} connection from TetoTV.',
+            icon: Icons.link_off_rounded,
+            destructive: true,
+            onPressed: widget.onDisconnect,
           ),
-          const SizedBox(height: 8),
-          Align(
-            alignment: Alignment.centerRight,
-            child: Wrap(
-              spacing: 8,
-              runSpacing: 8,
-              children: [
-                _TvTextButton(
-                  label: widget.username == null
-                      ? 'Connect by QR'
-                      : 'Add profile',
-                  icon: widget.username == null
-                      ? Icons.qr_code_rounded
-                      : Icons.person_add_alt_1_rounded,
-                  onPressed: widget.onConnect,
-                  focusNode: widget.focusNode,
-                ),
-                if (widget.username != null)
-                  _TvTextButton(
-                    label: 'Disconnect',
-                    icon: Icons.link_off_rounded,
-                    onPressed: widget.onDisconnect,
-                  ),
-              ],
-            ),
+        if (!connected)
+          _SettingsTokenEditor(
+            title: 'Manual API token',
+            labelText: 'Personal Access Token',
+            keyboardTitle: 'Enter ${widget.provider.displayName} token',
+            controller: _tokenController,
+            tokenFocusNode: widget.tokenFocusNode,
+            saveFocusNode: widget.saveFocusNode,
+            isLoading: _saving || widget.isLoading,
+            onSave: _saveToken,
+            onSubmitted: _saveToken,
+            error: _inputError ?? widget.error,
           ),
-          if (widget.username == null) ...[
-            const SizedBox(height: 8),
-            Divider(color: _settingsBorderColor(context, .08), height: 1),
-            const SizedBox(height: 8),
-            _ResponsiveTokenRow(
-              title: 'Manual API token',
-              input: TvTextInput(
-                controller: _tokenController,
-                focusNode: widget.tokenFocusNode,
-                labelText: 'Personal Access Token',
-                hintText: 'Select to open the TV keyboard',
-                keyboardTitle: 'Enter ${widget.provider.displayName} token',
-                obscureText: true,
-                onSubmitted: _saveToken,
-              ),
-              action: _TvTextButton(
-                label: _saving || widget.isLoading
-                    ? 'Checking…'
-                    : 'Save & verify',
-                icon: Icons.verified_user_rounded,
-                focusNode: widget.saveFocusNode,
-                onPressed: _saving || widget.isLoading ? null : _saveToken,
-              ),
-            ),
-            if (_inputError ?? widget.error case final message?) ...[
-              const SizedBox(height: 10),
-              Text(message, style: const TextStyle(color: Color(0xFFFF8DA0))),
-            ],
-          ],
-        ],
-      ),
+      ],
     );
   }
 }
@@ -6560,22 +7629,22 @@ class _StreamingPrivacyPanel extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return _Panel(
+    final tvScale = _usesTvSettingsScale(context);
+    return Container(
+      constraints: BoxConstraints(minHeight: tvScale ? 48 : 64),
+      padding: EdgeInsets.symmetric(
+        horizontal: tvScale ? 10 : 13,
+        vertical: tvScale ? 5 : 11,
+      ),
+      color: context.appPalette.surface,
       child: Row(
         children: [
-          Container(
-            width: 42,
-            height: 42,
-            decoration: BoxDecoration(
-              color: context.appPalette.accent.withValues(alpha: .14),
-              borderRadius: BorderRadius.circular(9),
-            ),
-            child: Icon(
-              Icons.verified_user_rounded,
-              color: context.appPalette.accentBright,
-            ),
+          Icon(
+            Icons.verified_user_rounded,
+            size: tvScale ? 22 : 22,
+            color: _settingsPrimaryText(context),
           ),
-          const SizedBox(width: 10),
+          SizedBox(width: tvScale ? 8 : 14),
           Expanded(
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
@@ -6584,9 +7653,13 @@ class _StreamingPrivacyPanel extends StatelessWidget {
                   preferences.directTorrentStreamingEnabled
                       ? 'Direct peer streaming enabled'
                       : 'Protected streaming paths',
-                  style: Theme.of(context).textTheme.titleLarge,
+                  style: TextStyle(
+                    color: _settingsPrimaryText(context),
+                    fontSize: tvScale ? 16 : 14,
+                    fontWeight: FontWeight.w700,
+                  ),
                 ),
-                const SizedBox(height: 3),
+                SizedBox(height: tvScale ? 2 : 3),
                 Text(
                   preferences.directTorrentStreamingEnabled
                       ? 'Torrent releases can play without a debrid account. '
@@ -6595,16 +7668,23 @@ class _StreamingPrivacyPanel extends StatelessWidget {
                       : 'Torrents are only played through the debrid service '
                             'you connect. Installed web addons run without '
                             'access to account tokens or device files.',
-                  style: Theme.of(context).textTheme.bodyMedium,
+                  maxLines: tvScale ? 3 : 4,
+                  overflow: TextOverflow.ellipsis,
+                  style: TextStyle(
+                    color: context.appPalette.mutedText,
+                    fontSize: tvScale ? 12 : 11,
+                    height: 1.25,
+                  ),
                 ),
               ],
             ),
           ),
-          const SizedBox(width: 12),
+          SizedBox(width: tvScale ? 7 : 12),
           Icon(
             preferences.directTorrentStreamingEnabled
                 ? Icons.public_rounded
                 : Icons.lock_rounded,
+            size: tvScale ? 22 : 22,
             color: context.appPalette.accentBright,
           ),
         ],
@@ -6678,12 +7758,42 @@ class _Panel extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final inset = _SettingsCardScope.isInset(context);
     return Container(
-      padding: const EdgeInsets.all(14),
+      padding: EdgeInsets.all(
+        inset
+            ? (_usesTvSettingsScale(context) ? 6 : 12)
+            : (_usesTvSettingsScale(context) ? 8 : 14),
+      ),
       decoration: BoxDecoration(
-        color: context.appPalette.surface,
-        borderRadius: BorderRadius.circular(9),
-        border: Border.all(color: _settingsBorderColor(context, .10)),
+        gradient: LinearGradient(
+          begin: Alignment.topLeft,
+          end: Alignment.bottomRight,
+          colors: [
+            inset
+                ? context.appPalette.surfaceRaised
+                : context.appPalette.surface,
+            Color.alphaBlend(
+              context.appPalette.accent.withValues(alpha: inset ? .04 : .025),
+              inset
+                  ? context.appPalette.surfaceRaised
+                  : context.appPalette.surface,
+            ),
+          ],
+        ),
+        borderRadius: BorderRadius.circular(10),
+        border: Border.all(
+          color: _settingsBorderColor(context, inset ? .14 : .18),
+        ),
+        boxShadow: inset
+            ? const []
+            : [
+                BoxShadow(
+                  color: Colors.black.withValues(alpha: .22),
+                  blurRadius: _usesTvSettingsScale(context) ? 9 : 18,
+                  offset: Offset(0, _usesTvSettingsScale(context) ? 4 : 8),
+                ),
+              ],
       ),
       child: child,
     );
@@ -6783,127 +7893,46 @@ class _StorageResetPanelState extends State<_StorageResetPanel> {
   }
 
   @override
-  Widget build(BuildContext context) {
-    return _Panel(
-      child: LayoutBuilder(
-        builder: (context, constraints) {
-          final compact = constraints.maxWidth < 620;
-          final clear = _StorageAction(
-            key: const ValueKey('storage-clear-cache'),
-            focusNode: widget.clearCacheFocusNode,
-            icon: Icons.cleaning_services_rounded,
-            title: _clearingCache ? 'Clearing cache…' : 'Clear cache',
-            detail:
-                'Removes temporary images, playback cache, and downloaded update leftovers. Accounts, settings, history, and sources stay saved.',
-            accent: context.appPalette.secondaryAccent,
-            enabled: !_clearingCache && !_resetting,
-            onPressed: _clearCache,
-          );
-          final reset = _StorageAction(
-            key: const ValueKey('storage-reset-app'),
-            focusNode: widget.resetAppFocusNode,
-            icon: Icons.delete_forever_rounded,
-            title: _resetting ? 'Resetting TetoTV…' : 'Reset TetoTV',
-            detail:
-                'Erases every account, preference, source, and watch-history item. The app closes and starts at first-time setup.',
-            accent: context.appPalette.accentBright,
-            enabled: !_clearingCache && !_resetting,
-            onPressed: _confirmReset,
-          );
-          if (compact) {
-            return Column(
-              crossAxisAlignment: CrossAxisAlignment.stretch,
-              children: [clear, const SizedBox(height: 10), reset],
-            );
-          }
-          return Row(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Expanded(child: clear),
-              const SizedBox(width: 10),
-              Expanded(child: reset),
-            ],
-          );
-        },
-      ),
-    );
-  }
-}
-
-class _StorageAction extends StatelessWidget {
-  const _StorageAction({
-    required this.focusNode,
-    required this.icon,
-    required this.title,
-    required this.detail,
-    required this.accent,
-    required this.enabled,
-    required this.onPressed,
-    super.key,
-  });
-
-  final FocusNode focusNode;
-  final IconData icon;
-  final String title;
-  final String detail;
-  final Color accent;
-  final bool enabled;
-  final VoidCallback onPressed;
-
-  @override
-  Widget build(BuildContext context) {
-    return TvFocusable(
-      focusNode: focusNode,
-      onPressed: enabled ? onPressed : () {},
-      borderRadius: BorderRadius.circular(9),
-      focusScale: 1.01,
-      child: Container(
-        constraints: const BoxConstraints(minHeight: 112),
-        padding: const EdgeInsets.all(14),
-        decoration: BoxDecoration(
-          color: context.appPalette.surfaceRaised,
-          borderRadius: BorderRadius.circular(9),
-          border: Border.all(color: accent.withValues(alpha: .45)),
-        ),
-        child: Row(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Icon(
-              icon,
-              color: enabled ? accent : context.appPalette.mutedText,
-              size: 24,
-            ),
-            const SizedBox(width: 12),
-            Expanded(
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Text(
-                    title,
-                    style: TextStyle(
-                      color: enabled
-                          ? _settingsPrimaryText(context)
-                          : context.appPalette.mutedText,
-                      fontWeight: FontWeight.w900,
-                    ),
-                  ),
-                  const SizedBox(height: 6),
-                  Text(
-                    detail,
-                    style: TextStyle(
-                      color: context.appPalette.mutedText,
-                      fontSize: 11,
-                      height: 1.25,
-                    ),
-                  ),
-                ],
-              ),
-            ),
-          ],
-        ),
-      ),
-    );
-  }
+  Widget build(BuildContext context) => LayoutBuilder(
+    builder: (context, constraints) {
+      final compact = !_usesTvSettingsScale(context);
+      final enabled = !_clearingCache && !_resetting;
+      final clear = _SettingsPanelActionRow(
+        key: const ValueKey('storage-clear-cache'),
+        focusNode: widget.clearCacheFocusNode,
+        icon: Icons.cleaning_services_rounded,
+        label: _clearingCache ? 'Clearing cache…' : 'Clear cache',
+        subtitle:
+            'Remove temporary images, playback cache, and update leftovers. Accounts and settings stay saved.',
+        showDivider: compact,
+        onPressed: enabled ? _clearCache : null,
+      );
+      final reset = _SettingsPanelActionRow(
+        key: const ValueKey('storage-reset-app'),
+        focusNode: widget.resetAppFocusNode,
+        icon: Icons.delete_forever_rounded,
+        label: _resetting ? 'Resetting TetoTV…' : 'Reset TetoTV',
+        subtitle:
+            'Erase accounts, preferences, sources, and history, then return to first-time setup.',
+        destructive: true,
+        onPressed: enabled ? _confirmReset : null,
+      );
+      if (compact) {
+        return Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [clear, reset],
+        );
+      }
+      return Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Expanded(child: clear),
+          const SizedBox(width: 8),
+          Expanded(child: reset),
+        ],
+      );
+    },
+  );
 }
 
 class _ResetWarningDialog extends StatelessWidget {
@@ -6982,8 +8011,8 @@ class _ResetDialogFrame extends StatelessWidget {
   Widget build(BuildContext context) => Dialog(
     backgroundColor: Colors.transparent,
     child: Container(
-      width: 620,
-      padding: const EdgeInsets.all(22),
+      width: _usesTvSettingsScale(context) ? 460 : 620,
+      padding: EdgeInsets.all(_usesTvSettingsScale(context) ? 11 : 22),
       decoration: BoxDecoration(
         color: context.appPalette.surface,
         borderRadius: BorderRadius.circular(14),
@@ -6995,19 +8024,25 @@ class _ResetDialogFrame extends StatelessWidget {
         children: [
           Row(
             children: [
-              Icon(icon, color: context.appPalette.accentBright, size: 28),
-              const SizedBox(width: 12),
+              Icon(
+                icon,
+                color: context.appPalette.accentBright,
+                size: _usesTvSettingsScale(context) ? 20 : 28,
+              ),
+              SizedBox(width: _usesTvSettingsScale(context) ? 7 : 12),
               Expanded(
                 child: Text(
                   title,
-                  style: Theme.of(context).textTheme.titleLarge,
+                  style: Theme.of(context).textTheme.titleLarge?.copyWith(
+                    fontSize: _usesTvSettingsScale(context) ? 18 : null,
+                  ),
                 ),
               ),
             ],
           ),
-          const SizedBox(height: 14),
+          SizedBox(height: _usesTvSettingsScale(context) ? 7 : 14),
           Text(message, style: TextStyle(color: context.appPalette.mutedText)),
-          const SizedBox(height: 20),
+          SizedBox(height: _usesTvSettingsScale(context) ? 10 : 20),
           LayoutBuilder(
             builder: (context, constraints) {
               if (constraints.maxWidth < 480) {
@@ -7015,7 +8050,10 @@ class _ResetDialogFrame extends StatelessWidget {
                   crossAxisAlignment: CrossAxisAlignment.stretch,
                   children: [
                     for (var index = 0; index < actions.length; index++) ...[
-                      if (index > 0) const SizedBox(height: 10),
+                      if (index > 0)
+                        SizedBox(
+                          height: _usesTvSettingsScale(context) ? 5 : 10,
+                        ),
                       actions[index],
                     ],
                   ],
@@ -7024,7 +8062,8 @@ class _ResetDialogFrame extends StatelessWidget {
               return Row(
                 children: [
                   for (var index = 0; index < actions.length; index++) ...[
-                    if (index > 0) const SizedBox(width: 10),
+                    if (index > 0)
+                      SizedBox(width: _usesTvSettingsScale(context) ? 5 : 10),
                     Expanded(child: actions[index]),
                   ],
                 ],
@@ -7059,8 +8098,13 @@ class _DialogAction extends StatelessWidget {
     onPressed: onPressed,
     borderRadius: BorderRadius.circular(9),
     child: Container(
-      constraints: const BoxConstraints(minHeight: 52),
-      padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 12),
+      constraints: BoxConstraints(
+        minHeight: _usesTvSettingsScale(context) ? 36 : 52,
+      ),
+      padding: EdgeInsets.symmetric(
+        horizontal: _usesTvSettingsScale(context) ? 8 : 14,
+        vertical: _usesTvSettingsScale(context) ? 6 : 12,
+      ),
       decoration: BoxDecoration(
         color: dangerous
             ? context.appPalette.accent
@@ -7070,8 +8114,8 @@ class _DialogAction extends StatelessWidget {
       child: Row(
         mainAxisAlignment: MainAxisAlignment.center,
         children: [
-          Icon(icon, size: 19),
-          const SizedBox(width: 8),
+          Icon(icon, size: _usesTvSettingsScale(context) ? 16 : 19),
+          SizedBox(width: _usesTvSettingsScale(context) ? 5 : 8),
           Flexible(
             child: Text(
               label,
@@ -7088,20 +8132,101 @@ class _DialogAction extends StatelessWidget {
 bool _usesDefaultSettingsPalette(BuildContext context) =>
     context.appPalette == AppThemePalette.defaults;
 
-Color _settingsPageBackground(BuildContext context) =>
-    _usesDefaultSettingsPalette(context)
-    ? Colors.black
-    : context.appPalette.background;
+bool _usesTvSettingsScale(BuildContext context) {
+  final size = MediaQuery.sizeOf(context);
+  return size.width >= 900 && size.width > size.height;
+}
+
+String _settingsDisplayLabel(String value) {
+  final trimmed = value.trim();
+  if (trimmed.isEmpty || trimmed != trimmed.toUpperCase()) return trimmed;
+  const preserved = <String, String>{
+    'api': 'API',
+    'app': 'App',
+    'discord': 'Discord',
+    'mpv': 'MPV',
+    'plex': 'Plex',
+    'qr': 'QR',
+    'tv': 'TV',
+  };
+  return trimmed
+      .toLowerCase()
+      .split(RegExp(r'\s+'))
+      .map((word) {
+        final special = preserved[word];
+        if (special != null) return special;
+        return '${word[0].toUpperCase()}${word.substring(1)}';
+      })
+      .join(' ');
+}
+
+IconData _settingsIconForLabel(String value) {
+  final label = value.toLowerCase();
+  if (label.contains('caption') || label.contains('subtitle')) {
+    return Icons.closed_caption_outlined;
+  }
+  if (label.contains('text color') || label.contains('theme')) {
+    return Icons.palette_outlined;
+  }
+  if (label.contains('background')) return Icons.format_color_fill_rounded;
+  if (label.contains('text size') || label.contains('scale')) {
+    return Icons.format_size_rounded;
+  }
+  if (label.contains('audio')) return Icons.audiotrack_rounded;
+  if (label.contains('external')) return Icons.open_in_new_rounded;
+  if (label.contains('player')) return Icons.play_circle_outline_rounded;
+  if (label.contains('rewind')) return Icons.replay_rounded;
+  if (label.contains('forward')) return Icons.forward_rounded;
+  if (label.contains('skip') || label.contains('intro')) {
+    return Icons.skip_next_rounded;
+  }
+  if (label.contains('episode') || label.contains('filler')) {
+    return Icons.info_outline_rounded;
+  }
+  if (label.contains('debrid') || label.contains('cloud')) {
+    return Icons.cloud_outlined;
+  }
+  if (label.contains('torrent')) return Icons.download_for_offline_outlined;
+  if (label.contains('source') || label.contains('quality')) {
+    return Icons.tune_rounded;
+  }
+  if (label.contains('language')) return Icons.language_rounded;
+  if (label.contains('tracking') || label.contains('provider')) {
+    return Icons.sync_rounded;
+  }
+  if (label.contains('notification')) return Icons.notifications_outlined;
+  if (label.contains('profile')) return Icons.person_outline_rounded;
+  if (label.contains('download')) return Icons.download_rounded;
+  if (label.contains('privacy') || label.contains('secure')) {
+    return Icons.shield_outlined;
+  }
+  if (label.contains('navigation') || label.contains('menu')) {
+    return Icons.menu_rounded;
+  }
+  if (label.contains('home') || label.contains('landing')) {
+    return Icons.home_outlined;
+  }
+  if (label.contains('card') || label.contains('thumbnail')) {
+    return Icons.view_module_outlined;
+  }
+  if (label.contains('keyboard') || label.contains('input')) {
+    return Icons.keyboard_outlined;
+  }
+  if (label.contains('sound')) return Icons.volume_up_outlined;
+  if (label.contains('update')) return Icons.system_update_alt_rounded;
+  if (label.contains('storage') || label.contains('cache')) {
+    return Icons.storage_rounded;
+  }
+  if (label.contains('legal') || label.contains('license')) {
+    return Icons.description_outlined;
+  }
+  return Icons.tune_rounded;
+}
 
 Color _settingsPrimaryText(BuildContext context) =>
     _usesDefaultSettingsPalette(context)
     ? Colors.white
     : context.appPalette.primaryText;
-
-Color _settingsAccentForeground(BuildContext context) =>
-    _usesDefaultSettingsPalette(context)
-    ? Colors.white
-    : contrastForeground(context.appPalette.accent);
 
 Color _settingsDisabledActionSurface(BuildContext context) =>
     _usesDefaultSettingsPalette(context)
@@ -7139,8 +8264,12 @@ class _StatusPill extends StatelessWidget {
     final color = connected
         ? const Color(0xFF67D49B)
         : context.appPalette.mutedText;
+    final tvScale = _usesTvSettingsScale(context);
     return Container(
-      padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 5),
+      padding: EdgeInsets.symmetric(
+        horizontal: tvScale ? 8 : 10,
+        vertical: tvScale ? 4 : 5,
+      ),
       decoration: BoxDecoration(
         color: color.withValues(alpha: .12),
         borderRadius: BorderRadius.circular(999),
@@ -7149,7 +8278,7 @@ class _StatusPill extends StatelessWidget {
         label,
         style: TextStyle(
           color: color,
-          fontSize: 10,
+          fontSize: tvScale ? 10 : 10,
           fontWeight: FontWeight.w800,
           letterSpacing: 1,
         ),
@@ -7186,8 +8315,8 @@ class _TvIconButton extends StatelessWidget {
     child: ColoredBox(
       color: context.appPalette.surface,
       child: Padding(
-        padding: const EdgeInsets.all(10),
-        child: Icon(icon, size: 20),
+        padding: EdgeInsets.all(_usesTvSettingsScale(context) ? 6 : 10),
+        child: Icon(icon, size: _usesTvSettingsScale(context) ? 17 : 20),
       ),
     ),
   );
@@ -7210,24 +8339,39 @@ class _TvTextButton extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final enabled = onPressed != null;
+    final tvScale = _usesTvSettingsScale(context);
     return TvFocusable(
       onPressed: onPressed ?? () {},
       focusNode: focusNode,
       borderRadius: BorderRadius.circular(8),
-      child: Container(
-        color: enabled
-            ? context.appPalette.accent
-            : _settingsDisabledActionSurface(context),
-        padding: const EdgeInsets.symmetric(horizontal: 13, vertical: 10),
+      focusScale: 1.015,
+      child: AnimatedContainer(
+        duration: const Duration(milliseconds: 100),
+        constraints: BoxConstraints(minHeight: tvScale ? 36 : 44),
+        decoration: BoxDecoration(
+          color: enabled
+              ? context.appPalette.surfaceRaised
+              : _settingsDisabledActionSurface(context),
+          borderRadius: BorderRadius.circular(8),
+          border: Border.all(
+            color: enabled
+                ? _settingsBorderColor(context, .2)
+                : _settingsBorderColor(context, .08),
+          ),
+        ),
+        padding: EdgeInsets.symmetric(
+          horizontal: tvScale ? 9 : 12,
+          vertical: tvScale ? 6 : 9,
+        ),
         child: Row(
           mainAxisSize: MainAxisSize.min,
           children: [
             Icon(
               icon,
               color: enabled
-                  ? _settingsAccentForeground(context)
+                  ? context.appPalette.accentBright
                   : _settingsDisabledText(context),
-              size: 19,
+              size: tvScale ? 17 : 18,
             ),
             const SizedBox(width: 8),
             Flexible(
@@ -7237,8 +8381,10 @@ class _TvTextButton extends StatelessWidget {
                 overflow: TextOverflow.ellipsis,
                 style: Theme.of(context).textTheme.labelLarge?.copyWith(
                   color: enabled
-                      ? _settingsAccentForeground(context)
+                      ? _settingsPrimaryText(context)
                       : _settingsDisabledText(context),
+                  fontSize: tvScale ? 12 : 12,
+                  fontWeight: FontWeight.w800,
                 ),
               ),
             ),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: 'none'
 # Public and Beta artifacts built from the same source use one monotonically
 # increasing Android versionCode. The project default carries the Beta display
 # version; the Public universal APK overrides the build name to the 1.x line.
-version: 2.0.47+410024
+version: 2.0.48+410025
 
 environment:
   sdk: ^3.12.2

--- a/test/accounts_focus_test.dart
+++ b/test/accounts_focus_test.dart
@@ -52,7 +52,7 @@ void main() {
       expect(find.byKey(const ValueKey('main-navigation')), findsNothing);
       expect(
         FocusManager.instance.primaryFocus?.debugLabel,
-        'accounts.area.customize',
+        'accounts.customization.first',
       );
       await tester.sendKeyEvent(LogicalKeyboardKey.arrowLeft);
       await tester.pump();
@@ -61,13 +61,13 @@ void main() {
       await tester.pump();
       expect(
         FocusManager.instance.primaryFocus?.debugLabel,
-        'accounts.area.customize',
+        'accounts.customization.first',
       );
       expect(tester.takeException(), isNull);
     });
   }
 
-  testWidgets('D-pad reaches Home shelves and switches to streaming', (
+  testWidgets('D-pad traverses Appearance and switches to Services', (
     tester,
   ) async {
     FlutterSecureStorage.setMockInitialValues({});
@@ -85,38 +85,48 @@ void main() {
 
     expect(
       FocusManager.instance.primaryFocus?.debugLabel,
-      'accounts.area.customize',
+      'accounts.customization.first',
+    );
+    await tester.sendKeyEvent(LogicalKeyboardKey.arrowRight);
+    await tester.pump();
+    expect(
+      FocusManager.instance.primaryFocus?.debugLabel,
+      'accounts.customization.home-content.featured',
     );
     await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
     await tester.pump();
     expect(
       FocusManager.instance.primaryFocus?.debugLabel,
-      'accounts.customization.toggle-all',
+      'accounts.customization.home-content.poster-metadata',
     );
     await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
     await tester.pump();
     expect(
       FocusManager.instance.primaryFocus?.debugLabel,
-      'accounts.section.home-shelves',
-    );
-    await tester.sendKeyEvent(LogicalKeyboardKey.enter);
-    await tester.pumpAndSettle();
-    await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
-    await tester.pump();
-    expect(
-      FocusManager.instance.primaryFocus?.debugLabel,
-      'accounts.shelf.tracking',
+      'accounts.customization.home-content.continue-watching',
     );
     await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
     await tester.pump();
     expect(
       FocusManager.instance.primaryFocus?.debugLabel,
-      'accounts.shelf.history',
+      'accounts.shelf.${HomeShelf.values.first.name}',
+    );
+    await tester.sendKeyEvent(LogicalKeyboardKey.arrowUp);
+    await tester.pump();
+    expect(
+      FocusManager.instance.primaryFocus?.debugLabel,
+      'accounts.customization.home-content.continue-watching',
+    );
+    await tester.sendKeyEvent(LogicalKeyboardKey.arrowLeft);
+    await tester.pump();
+    expect(
+      FocusManager.instance.primaryFocus?.debugLabel,
+      'accounts.show-title-style',
     );
     await tester.sendKeyEvent(LogicalKeyboardKey.arrowUp);
     await tester.sendKeyEvent(LogicalKeyboardKey.arrowUp);
     await tester.sendKeyEvent(LogicalKeyboardKey.arrowUp);
-    await tester.sendKeyEvent(LogicalKeyboardKey.arrowUp);
+    await tester.sendKeyEvent(LogicalKeyboardKey.arrowRight);
     await tester.sendKeyEvent(LogicalKeyboardKey.arrowRight);
     await tester.sendKeyEvent(LogicalKeyboardKey.enter);
     await tester.pumpAndSettle();
@@ -147,6 +157,97 @@ void main() {
   });
 
   testWidgets(
+    'TV Settings keep the rail and use the polished two-column tabs',
+    (tester) async {
+      FlutterSecureStorage.setMockInitialValues({});
+      tester.view.physicalSize = const Size(960, 540);
+      tester.view.devicePixelRatio = 1;
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [isTelevisionProvider.overrideWithValue(true)],
+          child: const MaterialApp(home: TvShortcuts(child: AccountsScreen())),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.byKey(const ValueKey('main-nav-settings')), findsOneWidget);
+      expect(
+        find.byKey(const ValueKey('settings-area-downloads')),
+        findsNothing,
+      );
+      expect(find.text('Settings'), findsNothing);
+      expect(find.text('APPEARANCE'), findsNothing);
+      expect(find.text('Expand all'), findsNothing);
+      expect(find.text('Collapse all'), findsNothing);
+      expect(
+        find.byKey(const ValueKey('customize-toggle-all-sections')),
+        findsNothing,
+      );
+
+      final appearanceTab = find.byKey(
+        const ValueKey('settings-area-appearance'),
+      );
+      expect(
+        find.descendant(
+          of: appearanceTab,
+          matching: find.byIcon(Icons.palette_rounded),
+        ),
+        findsNothing,
+      );
+      final appearanceLabel = find.descendant(
+        of: appearanceTab,
+        matching: find.text('Appearance'),
+      );
+      expect(tester.widget<Text>(appearanceLabel).style?.fontSize, 16);
+      final activeTabSurfaces = tester
+          .widgetList<AnimatedContainer>(
+            find.descendant(
+              of: appearanceTab,
+              matching: find.byType(AnimatedContainer),
+            ),
+          )
+          .where(
+            (widget) =>
+                widget.decoration is BoxDecoration &&
+                (widget.decoration! as BoxDecoration).gradient != null,
+          );
+      expect(activeTabSurfaces, isEmpty);
+
+      expect(find.text('Theme & display'), findsOneWidget);
+      expect(find.text('Navigation'), findsWidgets);
+      expect(find.text('Home screen'), findsOneWidget);
+      expect(find.text('Theme Studio'), findsOneWidget);
+      expect(find.text('Title language'), findsOneWidget);
+      expect(find.text('Show title style'), findsOneWidget);
+      expect(find.text('Menu order'), findsOneWidget);
+      expect(find.text('Featured hero'), findsOneWidget);
+      expect(find.text('Poster metadata'), findsOneWidget);
+      expect(find.text('Continue watching'), findsWidgets);
+
+      final themeCard = tester.getRect(
+        find.byKey(const ValueKey('appearance-theme-display-card')),
+      );
+      final navigationCard = tester.getRect(
+        find.byKey(const ValueKey('appearance-navigation-card')),
+      );
+      final homeCard = tester.getRect(
+        find.byKey(const ValueKey('appearance-home-screen-card')),
+      );
+      expect(homeCard.left, greaterThan(themeCard.right));
+      expect((homeCard.top - themeCard.top).abs(), lessThan(3));
+      expect(navigationCard.top, greaterThan(themeCard.bottom));
+      expect(
+        FocusManager.instance.primaryFocus?.debugLabel,
+        'accounts.customization.first',
+      );
+      expect(tester.takeException(), isNull);
+    },
+  );
+
+  testWidgets(
     'Settings option rows exit Left through the active Settings rail item',
     (tester) async {
       FlutterSecureStorage.setMockInitialValues({});
@@ -165,66 +266,12 @@ void main() {
       );
       await tester.pumpAndSettle();
 
-      final displayToggle = find.byKey(
-        const ValueKey('inline-section-toggle-display'),
-      );
-      await tester.tap(displayToggle);
-      await tester.pumpAndSettle();
-
-      // This chip deliberately owns an anonymous TvFocusable node. It covers
-      // Settings controls which are not part of the screen's explicit graph.
-      final smallChip = find
-          .ancestor(
-            of: find.text('Small').first,
-            matching: find.byType(TvFocusable),
-          )
-          .first;
-      await tester.tap(smallChip);
-      await tester.pumpAndSettle();
-      final mediumChip = find
-          .ancestor(
-            of: find.text('Medium').first,
-            matching: find.byType(TvFocusable),
-          )
-          .first;
-      await tester.tap(mediumChip);
-      await tester.pumpAndSettle();
-      final smallFocus = tester
-          .widget<FocusableActionDetector>(
-            find.descendant(
-              of: smallChip,
-              matching: find.byType(FocusableActionDetector),
-            ),
-          )
-          .focusNode!;
-      final mediumFocus = tester
-          .widget<FocusableActionDetector>(
-            find.descendant(
-              of: mediumChip,
-              matching: find.byType(FocusableActionDetector),
-            ),
-          )
-          .focusNode!;
-      expect(mediumFocus.hasFocus, isTrue);
-
-      // LEFT still moves normally inside a Settings option row.
-      await tester.sendKeyEvent(LogicalKeyboardKey.arrowLeft);
-      await tester.pump();
-      expect(smallFocus.hasFocus, isTrue);
       expect(
         FocusManager.instance.primaryFocus?.debugLabel,
-        'TV mouse/D-pad control',
+        'accounts.customization.first',
       );
-
-      for (var press = 0; press < 8; press++) {
-        if (FocusManager.instance.primaryFocus?.debugLabel ==
-            'top-level.active-navigation') {
-          break;
-        }
-        await tester.sendKeyEvent(LogicalKeyboardKey.arrowLeft);
-        await tester.pump();
-      }
-
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowLeft);
+      await tester.pump();
       expect(
         FocusManager.instance.primaryFocus?.debugLabel,
         'top-level.active-navigation',
@@ -248,7 +295,7 @@ void main() {
       await tester.pump();
       expect(
         FocusManager.instance.primaryFocus?.debugLabel,
-        'accounts.area.customize',
+        'accounts.customization.first',
       );
       expect(tester.takeException(), isNull);
     },
@@ -272,11 +319,12 @@ void main() {
       ),
     );
     await tester.pumpAndSettle();
-    await tester.tap(find.text('Streaming'));
+    await tester.tap(find.text('Services'));
     await tester.pumpAndSettle();
 
     final toggle = find.byKey(
       const ValueKey('settings-auto-pick-source-enabled'),
+      skipOffstage: false,
     );
     expect(toggle, findsOneWidget);
     expect(
@@ -288,6 +336,8 @@ void main() {
       findsNothing,
     );
 
+    await tester.ensureVisible(toggle);
+    await tester.pumpAndSettle();
     await tester.tap(toggle);
     await tester.pumpAndSettle();
 
@@ -378,25 +428,19 @@ void main() {
     await tester.pumpAndSettle();
     expect(
       FocusManager.instance.primaryFocus?.debugLabel,
-      'accounts.streaming.offline-downloads',
-    );
-    await tester.sendKeyEvent(LogicalKeyboardKey.arrowRight);
-    await tester.pumpAndSettle();
-    expect(
-      FocusManager.instance.primaryFocus?.debugLabel,
-      'accounts.streaming.download-manager',
+      'accounts.streaming.local-media',
     );
     await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
     await tester.pumpAndSettle();
     expect(
       FocusManager.instance.primaryFocus?.debugLabel,
-      'accounts.streaming.local-media',
+      'accounts.streaming.watch-together',
     );
     await tester.sendKeyEvent(LogicalKeyboardKey.arrowUp);
     await tester.pumpAndSettle();
     expect(
       FocusManager.instance.primaryFocus?.debugLabel,
-      'accounts.streaming.download-manager',
+      'accounts.streaming.local-media',
     );
 
     await tester.tap(
@@ -443,18 +487,23 @@ void main() {
       const ProviderScope(child: MaterialApp(home: AccountsScreen())),
     );
     await tester.pumpAndSettle();
-    await tester.tap(find.text('Streaming'));
+    await tester.tap(find.text('Services'));
     await tester.pumpAndSettle();
 
-    for (final prefix in const ['DEBRID', 'WEB', 'DIRECT PEER']) {
-      final label = find.byWidgetPredicate(
+    for (final debugLabel in const [
+      'accounts.streaming.debrid',
+      'accounts.streaming.web',
+      'accounts.streaming.direct-torrent',
+    ]) {
+      final focusableFinder = find.byWidgetPredicate(
         (widget) =>
-            widget is Text &&
-            RegExp('^$prefix (ON|OFF)\$').hasMatch(widget.data ?? ''),
+            widget is TvFocusable && widget.focusNode?.debugLabel == debugLabel,
+        skipOffstage: false,
       );
-      final focusable = tester.widget<TvFocusable>(
-        find.ancestor(of: label, matching: find.byType(TvFocusable)).first,
-      );
+      expect(focusableFinder, findsOneWidget);
+      await tester.ensureVisible(focusableFinder);
+      await tester.pumpAndSettle();
+      final focusable = tester.widget<TvFocusable>(focusableFinder);
       focusable.focusNode!.requestFocus();
       await tester.pump();
       await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
@@ -462,7 +511,7 @@ void main() {
       expect(
         FocusManager.instance.primaryFocus?.debugLabel,
         'accounts.streaming.debrid-sort',
-        reason: '$prefix should enter the ranking controls below sources.',
+        reason: '$debugLabel should enter the ranking controls below sources.',
       );
     }
     expect(tester.takeException(), isNull);
@@ -486,18 +535,33 @@ void main() {
         ),
       );
       await tester.pumpAndSettle();
-      await tester.tap(find.text('Streaming'));
+      expect(
+        find.byKey(const ValueKey('settings-area-downloads')),
+        findsNothing,
+      );
+      expect(
+        find.byKey(const ValueKey('main-nav-settings')),
+        findsOneWidget,
+        reason: 'Settings must keep the persistent TV navigation rail visible.',
+      );
+      await tester.tap(find.text('Services'));
       await tester.pumpAndSettle();
 
       final toggle = find.byKey(
         const ValueKey('settings-offline-downloads-toggle'),
+        skipOffstage: false,
       );
       expect(toggle, findsOneWidget);
       expect(
-        find.byKey(const ValueKey('settings-download-manager-button')),
+        find.byKey(
+          const ValueKey('settings-download-manager-button'),
+          skipOffstage: false,
+        ),
         findsOneWidget,
       );
 
+      await tester.ensureVisible(toggle);
+      await tester.pumpAndSettle();
       await tester.tap(toggle);
       await tester.pumpAndSettle();
 
@@ -514,17 +578,31 @@ void main() {
         isFalse,
       );
       expect(
-        find.byKey(const ValueKey('settings-download-manager-button')),
+        find.byKey(
+          const ValueKey('settings-download-manager-button'),
+          skipOffstage: false,
+        ),
         findsNothing,
       );
-
-      await tester.tap(find.text('Customize'));
-      await tester.pumpAndSettle();
-      final homeNavigation = find.byKey(
-        const ValueKey('inline-section-toggle-home-navigation'),
+      expect(
+        FocusManager.instance.primaryFocus?.debugLabel,
+        'accounts.streaming.offline-downloads',
       );
-      await tester.ensureVisible(homeNavigation);
-      await tester.tap(homeNavigation);
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
+      await tester.pumpAndSettle();
+      expect(
+        FocusManager.instance.primaryFocus?.debugLabel,
+        'accounts.streaming.offline-downloads',
+        reason: 'Down must stop on the last mounted Services control.',
+      );
+
+      await tester.tap(find.text('Appearance'));
+      await tester.pumpAndSettle();
+      final menuOrder = find.byKey(
+        const ValueKey('settings-appearance-menu-order'),
+      );
+      await tester.ensureVisible(menuOrder);
+      await tester.tap(menuOrder);
       await tester.pumpAndSettle();
       expect(
         find.byKey(const ValueKey('settings-top-navigation-toggle-downloads')),
@@ -556,7 +634,7 @@ void main() {
           const ProviderScope(child: MaterialApp(home: AccountsScreen())),
         );
         await tester.pumpAndSettle();
-        await tester.tap(find.text('Streaming'));
+        await tester.tap(find.text('Services'));
         await tester.pumpAndSettle();
         for (
           var scroll = 0;
@@ -572,18 +650,31 @@ void main() {
         }
 
         expect(find.text('Local, Jellyfin & Plex sources'), findsOneWidget);
-        expect(find.text('Manage sources'), findsOneWidget);
+        expect(find.text('Manage sources'), findsWidgets);
+        expect(
+          find.byKey(const ValueKey('settings-card-services-features')),
+          findsOneWidget,
+        );
         expect(find.text('Watch Party'), findsOneWidget);
         expect(
           find.byKey(const ValueKey('settings-watch-party-toggle')),
           findsOneWidget,
+        );
+        expect(
+          find.byKey(const ValueKey('settings-offline-downloads-toggle')),
+          findsOneWidget,
+          reason: 'Offline download controls belong in Services.',
+        );
+        expect(
+          find.byKey(const ValueKey('settings-area-downloads')),
+          findsNothing,
         );
         expect(tester.takeException(), isNull);
       },
     );
   }
 
-  testWidgets('Home shelves expand inline from a collapsed heading', (
+  testWidgets('Home shelves remain directly available below the dashboard', (
     tester,
   ) async {
     FlutterSecureStorage.setMockInitialValues({});
@@ -597,15 +688,13 @@ void main() {
     );
     await tester.pumpAndSettle();
 
-    expect(find.text('Home section'), findsNothing);
-    expect(find.text('Continue watching'), findsNothing);
-
-    await tester.tap(
+    expect(
       find.byKey(const ValueKey('inline-section-toggle-home-shelves')),
+      findsNothing,
+      reason: 'Appearance no longer hides settings in an accordion.',
     );
-    await tester.pumpAndSettle();
-
-    expect(find.text('Continue watching'), findsOneWidget);
+    expect(find.text('Home shelves'), findsOneWidget);
+    expect(find.text('Continue watching'), findsNWidgets(2));
     expect(find.text('Watch history'), findsOneWidget);
     expect(find.text('Recently released'), findsOneWidget);
     expect(find.text('Trending now'), findsOneWidget);
@@ -639,11 +728,6 @@ void main() {
     );
     await tester.pumpAndSettle();
 
-    await tester.tap(
-      find.byKey(const ValueKey('inline-section-toggle-home-shelves')),
-    );
-    await tester.pumpAndSettle();
-
     expect(
       tester.widget<Scaffold>(find.byType(Scaffold).first).backgroundColor,
       palette.background,
@@ -653,9 +737,12 @@ void main() {
         (widget) =>
             widget is AnimatedContainer &&
             widget.decoration is BoxDecoration &&
-            (widget.decoration! as BoxDecoration).color == palette.accent,
+            ((widget.decoration! as BoxDecoration).border as Border?)
+                    ?.bottom
+                    .color ==
+                palette.accentBright,
       ),
-      findsOneWidget,
+      findsWidgets,
     );
     expect(
       find.byWidgetPredicate(
@@ -699,12 +786,13 @@ void main() {
     );
     await tester.pumpAndSettle();
 
-    await tester.tap(
-      find.byKey(const ValueKey('inline-section-toggle-home-shelves')),
+    final trackingShelf = find.byWidgetPredicate(
+      (widget) =>
+          widget is TvFocusable &&
+          widget.focusNode?.debugLabel == 'accounts.shelf.tracking',
     );
-    await tester.pumpAndSettle();
-
-    await tester.tap(find.text('Continue watching'));
+    await tester.ensureVisible(trackingShelf);
+    tester.widget<TvFocusable>(trackingShelf).onPressed();
     await tester.pumpAndSettle();
     expect(
       container.read(homeShelfPreferencesProvider),
@@ -718,11 +806,31 @@ void main() {
       container.read(homeShelfOrderProvider).take(2),
       orderedEquals([HomeShelf.history, HomeShelf.tracking]),
     );
-    expect(find.text('Home section'), findsNothing);
+    expect(find.text('Home shelves'), findsOneWidget);
     expect(tester.takeException(), isNull);
   });
 
-  testWidgets('D-pad Expand all and Collapse all update all Customize groups', (
+  Future<void> selectSettingsArea(WidgetTester tester, String area) async {
+    final tab = find.byKey(ValueKey('settings-area-$area'));
+    for (var attempt = 0; attempt < 4 && tab.evaluate().isEmpty; attempt++) {
+      final tabs = find.ancestor(
+        of: find.byKey(const ValueKey('settings-area-appearance')),
+        matching: find.byWidgetPredicate(
+          (widget) =>
+              widget is ListView && widget.scrollDirection == Axis.horizontal,
+        ),
+      );
+      await tester.drag(tabs, const Offset(-260, 0));
+      await tester.pumpAndSettle();
+    }
+    final focusable = tester.widget<TvFocusable>(tab);
+    focusable.focusNode!.requestFocus();
+    await tester.pump();
+    await tester.sendKeyEvent(LogicalKeyboardKey.enter);
+    await tester.pumpAndSettle();
+  }
+
+  testWidgets('Appearance dashboard is direct and D-pad ordered', (
     tester,
   ) async {
     FlutterSecureStorage.setMockInitialValues({});
@@ -738,93 +846,54 @@ void main() {
     );
     await tester.pumpAndSettle();
 
-    final toggleAll = find.byKey(
-      const ValueKey('customize-toggle-all-sections'),
-    );
-    expect(find.text('Expand all'), findsOneWidget);
-    for (final label in const [
-      'Continue watching',
-      'Theme Studio',
-      'Default landing page',
-      'On-screen keyboard',
-      'Text color',
-      'Preferred audio',
-    ]) {
-      expect(find.text(label), findsNothing);
-    }
-
-    await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
-    await tester.pumpAndSettle();
+    expect(find.text('Expand all'), findsNothing);
+    expect(find.text('Collapse all'), findsNothing);
     expect(
-      FocusManager.instance.primaryFocus?.debugLabel,
-      'accounts.customization.toggle-all',
+      find.byKey(const ValueKey('customize-toggle-all-sections')),
+      findsNothing,
     );
-    await tester.sendKeyEvent(LogicalKeyboardKey.enter);
-    await tester.pumpAndSettle();
-
-    expect(find.text('Collapse all'), findsOneWidget);
     for (final label in const [
-      'Continue watching',
       'Theme Studio',
-      'Default landing page',
-      'On-screen keyboard',
-      'Text color',
-      'Preferred audio',
+      'Title language',
+      'Show title style',
+      'Navigation size',
+      'Menu order',
+      'Reset appearance and navigation',
     ]) {
       expect(find.text(label), findsOneWidget);
     }
     expect(
       FocusManager.instance.primaryFocus?.debugLabel,
-      'accounts.customization.toggle-all',
+      'accounts.customization.first',
     );
-
-    final displayToggle = find.byKey(
-      const ValueKey('inline-section-toggle-display'),
-    );
-    tester.widget<TvFocusable>(displayToggle).onPressed();
-    await tester.pumpAndSettle();
-    expect(find.text('Expand all'), findsOneWidget);
-    expect(find.text('Theme Studio'), findsNothing);
-    expect(find.text('Continue watching'), findsOneWidget);
-    expect(find.text('Default landing page'), findsOneWidget);
-
-    tester
-        .widget<TvFocusable>(
-          find.descendant(of: toggleAll, matching: find.byType(TvFocusable)),
-        )
-        .onPressed();
-    await tester.pumpAndSettle();
-    expect(find.text('Collapse all'), findsOneWidget);
-    expect(find.text('Theme Studio'), findsOneWidget);
-    expect(find.text('Screen layout'), findsNothing);
-
-    tester
-        .widget<TvFocusable>(
-          find.descendant(of: toggleAll, matching: find.byType(TvFocusable)),
-        )
-        .onPressed();
-    await tester.pumpAndSettle();
-    expect(find.text('Expand all'), findsOneWidget);
-    for (final label in const [
-      'Continue watching',
-      'Theme Studio',
-      'Default landing page',
-      'On-screen keyboard',
-      'Text color',
-      'Preferred audio',
+    for (final expected in const [
+      'accounts.title-language',
+      'accounts.show-title-style',
+      'accounts.customization.navigation-size',
+      'accounts.customization.menu-order',
+      'accounts.customization.reset',
     ]) {
-      expect(find.text(label), findsNothing);
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
+      await tester.pumpAndSettle();
+      expect(FocusManager.instance.primaryFocus?.debugLabel, expected);
     }
+    await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
+    await tester.pumpAndSettle();
+    expect(
+      FocusManager.instance.primaryFocus?.debugLabel,
+      'accounts.customization.reset',
+      reason: 'Down stops on the final row in the Appearance column.',
+    );
     await tester.sendKeyEvent(LogicalKeyboardKey.arrowLeft);
     await tester.pumpAndSettle();
     expect(
       FocusManager.instance.primaryFocus?.debugLabel,
-      'accounts.area.system',
+      'top-level.active-navigation',
     );
     expect(tester.takeException(), isNull);
   });
 
-  testWidgets('Customize groups expand and collapse independently', (
+  testWidgets('Appearance keeps direct dashboard and advanced controls', (
     tester,
   ) async {
     FlutterSecureStorage.setMockInitialValues({});
@@ -839,70 +908,33 @@ void main() {
     await tester.pumpAndSettle();
 
     for (final key in const [
-      ValueKey('customize-section-home-shelves'),
-      ValueKey('customize-section-display'),
-      ValueKey('customize-section-home-navigation'),
-      ValueKey('customize-section-input-feedback'),
-      ValueKey('customize-section-closed-captions'),
-      ValueKey('customize-section-player-controls'),
+      ValueKey('appearance-theme-display-card'),
+      ValueKey('appearance-navigation-card'),
+      ValueKey('appearance-home-screen-card'),
     ]) {
       expect(find.byKey(key), findsOneWidget);
     }
-
-    expect(find.text('Continue watching'), findsNothing);
-    expect(find.text('Screen layout'), findsNothing);
-    expect(find.text('Theme Studio'), findsNothing);
-    expect(find.text('Title language'), findsNothing);
-    expect(find.text('Show title style'), findsNothing);
-    expect(find.text('Text color'), findsNothing);
-
-    final shelvesToggle = find.byKey(
-      const ValueKey('inline-section-toggle-home-shelves'),
-    );
-    await tester.tap(shelvesToggle);
-    await tester.pumpAndSettle();
-    expect(find.text('Continue watching'), findsOneWidget);
-    expect(find.text('Screen layout'), findsNothing);
-    expect(find.text('Theme Studio'), findsNothing);
-
-    await tester.tap(shelvesToggle);
-    await tester.pumpAndSettle();
-    expect(find.text('Continue watching'), findsNothing);
-
-    final displayToggle = find.byKey(
-      const ValueKey('inline-section-toggle-display'),
-    );
-    await tester.ensureVisible(displayToggle);
-    await tester.tap(displayToggle);
-    await tester.pumpAndSettle();
-    expect(find.text('Screen layout'), findsNothing);
     expect(find.text('Theme Studio'), findsOneWidget);
     expect(find.byKey(const ValueKey('open-theme-studio')), findsOneWidget);
     expect(find.textContaining('Classic Layout'), findsNothing);
     expect(find.text('Title language'), findsOneWidget);
     expect(find.text('Show title style'), findsOneWidget);
-    expect(
-      find.byKey(const ValueKey('show-title-style-englishLogo')),
-      findsOneWidget,
-    );
-    expect(find.byKey(const ValueKey('show-title-style-text')), findsOneWidget);
-    expect(find.text('HOME & NAVIGATION'), findsOneWidget);
+    expect(find.text('Display options'), findsOneWidget);
+    expect(find.text('Input & feedback'), findsOneWidget);
+    expect(find.text('Home shelves'), findsOneWidget);
+    expect(find.text('Default landing page'), findsOneWidget);
+    expect(find.text('On-screen keyboard'), findsOneWidget);
     expect(
       tester.getTopLeft(find.text('Title language')).dy,
-      greaterThan(tester.getTopLeft(find.text('Layout style')).dy),
+      greaterThan(tester.getTopLeft(find.text('Theme Studio')).dy),
     );
-
-    await tester.tap(displayToggle);
-    await tester.pumpAndSettle();
-    expect(find.text('Screen layout'), findsNothing);
-    expect(find.text('Theme Studio'), findsNothing);
-    expect(find.text('Title language'), findsNothing);
-    expect(find.text('Show title style'), findsNothing);
+    expect(find.text('Expand all'), findsNothing);
+    expect(find.text('Collapse all'), findsNothing);
     expect(tester.takeException(), isNull);
   });
 
   testWidgets(
-    'Closed Captions expands into its first control and collapses safely',
+    'Playback exposes direct polished rows without nested accordions',
     (tester) async {
       FlutterSecureStorage.setMockInitialValues({});
       tester.view.physicalSize = const Size(960, 540);
@@ -917,68 +949,44 @@ void main() {
       );
       await tester.pumpAndSettle();
 
-      final captionsToggle = find.byKey(
-        const ValueKey('inline-section-toggle-closed-captions'),
-      );
-      expect(captionsToggle, findsOneWidget);
-      expect(find.text('Text color'), findsNothing);
-
-      await tester.ensureVisible(captionsToggle);
-      final header = tester.widget<TvFocusable>(captionsToggle);
-      header.focusNode!.requestFocus();
-      await tester.pump();
-      expect(
-        FocusManager.instance.primaryFocus?.debugLabel,
-        'accounts.section.closed-captions',
-      );
-
-      await tester.sendKeyEvent(LogicalKeyboardKey.enter);
+      await tester.tap(find.text('Playback'));
       await tester.pumpAndSettle();
+
+      expect(
+        find.byKey(const ValueKey('inline-section-toggle-closed-captions')),
+        findsNothing,
+      );
+      expect(
+        find.byKey(const ValueKey('inline-section-toggle-player-controls')),
+        findsNothing,
+      );
       expect(find.text('Text color'), findsOneWidget);
+      expect(find.text('Default player'), findsOneWidget);
+
+      final playbackTab = tester.widget<TvFocusable>(
+        find.byKey(const ValueKey('settings-area-playback')),
+      );
+      playbackTab.focusNode!.requestFocus();
+      await tester.pump();
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
+      await tester.pumpAndSettle();
       expect(
         FocusManager.instance.primaryFocus?.debugLabel,
         'accounts.captions.text-color',
       );
-      final whiteControl = tester.widget<TvFocusable>(
-        find
-            .ancestor(
-              of: find.text('White'),
-              matching: find.byType(TvFocusable),
-            )
-            .first,
-      );
-      final hiddenChildFocus = whiteControl.focusNode!;
-      expect(hiddenChildFocus.context, isNotNull);
 
       await tester.sendKeyEvent(LogicalKeyboardKey.arrowUp);
       await tester.pumpAndSettle();
       expect(
         FocusManager.instance.primaryFocus?.debugLabel,
-        'accounts.section.closed-captions',
-      );
-      await tester.sendKeyEvent(LogicalKeyboardKey.enter);
-      await tester.pumpAndSettle();
-
-      expect(find.text('Text color'), findsNothing);
-      expect(hiddenChildFocus.context?.mounted ?? false, isFalse);
-      expect(hiddenChildFocus.hasFocus, isFalse);
-      expect(
-        FocusManager.instance.primaryFocus?.debugLabel,
-        'accounts.section.closed-captions',
-      );
-
-      await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
-      await tester.pumpAndSettle();
-      expect(
-        FocusManager.instance.primaryFocus?.debugLabel,
-        'accounts.section.player-controls',
+        'accounts.area.playback',
       );
       expect(tester.takeException(), isNull);
     },
   );
 
   testWidgets(
-    'D-pad scrolling continues after a Customize section is collapsed',
+    'advanced Appearance controls remain mounted below the dashboard',
     (tester) async {
       FlutterSecureStorage.setMockInitialValues({});
       tester.view.physicalSize = const Size(960, 360);
@@ -993,26 +1001,6 @@ void main() {
       );
       await tester.pumpAndSettle();
 
-      final displayToggle = find.byKey(
-        const ValueKey('inline-section-toggle-display'),
-      );
-      await tester.ensureVisible(displayToggle);
-      final displayHeader = tester.widget<TvFocusable>(displayToggle);
-      displayHeader.focusNode!.requestFocus();
-      await tester.pump();
-
-      await tester.sendKeyEvent(LogicalKeyboardKey.enter);
-      await tester.pumpAndSettle();
-      expect(find.text('Theme Studio'), findsOneWidget);
-      expect(find.text('Screen layout'), findsNothing);
-      await tester.sendKeyEvent(LogicalKeyboardKey.enter);
-      await tester.pumpAndSettle();
-      expect(find.text('Theme Studio'), findsNothing);
-      expect(
-        FocusManager.instance.primaryFocus?.debugLabel,
-        'accounts.section.display',
-      );
-
       final settingsList = find.byWidgetPredicate(
         (widget) =>
             widget is ListView && widget.scrollDirection == Axis.vertical,
@@ -1022,87 +1010,77 @@ void main() {
         find.descendant(of: settingsList, matching: find.byType(Scrollable)),
       );
       final before = list.position.pixels;
-
-      for (final expected in const [
-        'accounts.section.home-navigation',
-        'accounts.section.input-feedback',
-        'accounts.section.closed-captions',
-        'accounts.section.player-controls',
-        'accounts.customization.reset',
-      ]) {
-        await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
-        await tester.pumpAndSettle();
-        expect(FocusManager.instance.primaryFocus?.debugLabel, expected);
-      }
-
-      expect(list.position.pixels, greaterThan(before));
-      expect(tester.takeException(), isNull);
-    },
-  );
-
-  testWidgets(
-    'Reset appearance consumes Down and exits to Settings rail only on Left',
-    (tester) async {
-      FlutterSecureStorage.setMockInitialValues({});
-      tester.view.physicalSize = const Size(1280, 720);
-      tester.view.devicePixelRatio = 1;
-      addTearDown(tester.view.resetPhysicalSize);
-      addTearDown(tester.view.resetDevicePixelRatio);
-
-      await tester.pumpWidget(
-        ProviderScope(
-          child: MaterialApp(
-            theme: AppTheme.dark,
-            home: const TvShortcuts(child: AccountsScreen()),
-          ),
-        ),
-      );
+      final landingPage = find.text('Default landing page');
+      await tester.ensureVisible(landingPage);
       await tester.pumpAndSettle();
-
-      final resetButton = find
-          .ancestor(
-            of: find.text('Reset appearance & navigation'),
-            matching: find.byType(TvFocusable),
-          )
-          .first;
-      await tester.ensureVisible(resetButton);
-      final resetFocus = tester.widget<TvFocusable>(resetButton).focusNode!;
-      resetFocus.requestFocus();
-      await tester.pump();
-      expect(
-        FocusManager.instance.primaryFocus?.debugLabel,
-        'accounts.customization.reset',
-      );
-
-      await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
-      await tester.pump();
-      expect(resetFocus.hasFocus, isTrue);
-      expect(
-        FocusManager.instance.primaryFocus?.debugLabel,
-        'accounts.customization.reset',
-      );
-
-      await tester.sendKeyEvent(LogicalKeyboardKey.arrowLeft);
-      await tester.pump();
-      expect(
-        FocusManager.instance.primaryFocus?.debugLabel,
-        'top-level.active-navigation',
-      );
-      final settingsAction = find.byKey(const ValueKey('main-nav-settings'));
-      final settingsFocusable = find.descendant(
-        of: settingsAction,
-        matching: find.byType(FocusableActionDetector),
-      );
-      expect(
-        tester
-            .widget<FocusableActionDetector>(settingsFocusable)
-            .focusNode
-            ?.hasFocus,
-        isTrue,
-      );
+      expect(list.position.pixels, greaterThan(before));
+      expect(find.text('Display options'), findsOneWidget);
+      expect(find.text('Input & feedback'), findsOneWidget);
+      expect(find.text('Home shelves'), findsOneWidget);
+      expect(find.text('On-screen keyboard'), findsOneWidget);
+      expect(find.text('Watch history'), findsOneWidget);
       expect(tester.takeException(), isNull);
     },
   );
+
+  testWidgets('Reset appearance stops Down and exits Left to Settings rail', (
+    tester,
+  ) async {
+    FlutterSecureStorage.setMockInitialValues({});
+    tester.view.physicalSize = const Size(1280, 720);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    await tester.pumpWidget(
+      ProviderScope(
+        child: MaterialApp(
+          theme: AppTheme.dark,
+          home: const TvShortcuts(child: AccountsScreen()),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    final resetButton = find
+        .ancestor(
+          of: find.text('Reset appearance and navigation'),
+          matching: find.byType(TvFocusable),
+        )
+        .first;
+    await tester.ensureVisible(resetButton);
+    final resetFocus = tester.widget<TvFocusable>(resetButton).focusNode!;
+    resetFocus.requestFocus();
+    await tester.pump();
+    expect(
+      FocusManager.instance.primaryFocus?.debugLabel,
+      'accounts.customization.reset',
+    );
+
+    await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
+    await tester.pumpAndSettle();
+    expect(resetFocus.hasFocus, isTrue);
+
+    await tester.sendKeyEvent(LogicalKeyboardKey.arrowLeft);
+    await tester.pump();
+    expect(
+      FocusManager.instance.primaryFocus?.debugLabel,
+      'top-level.active-navigation',
+    );
+    final settingsAction = find.byKey(const ValueKey('main-nav-settings'));
+    final settingsFocusable = find.descendant(
+      of: settingsAction,
+      matching: find.byType(FocusableActionDetector),
+    );
+    expect(
+      tester
+          .widget<FocusableActionDetector>(settingsFocusable)
+          .focusNode
+          ?.hasFocus,
+      isTrue,
+    );
+    expect(tester.takeException(), isNull);
+  });
 
   testWidgets('D-pad traverses all seven visible Home shelf rows in order', (
     tester,
@@ -1120,37 +1098,26 @@ void main() {
     );
     await tester.pumpAndSettle();
 
-    await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
-    await tester.pumpAndSettle();
-
-    expect(
-      FocusManager.instance.primaryFocus?.debugLabel,
-      'accounts.customization.toggle-all',
+    final firstShelf = find.byWidgetPredicate(
+      (widget) =>
+          widget is TvFocusable &&
+          widget.focusNode?.debugLabel ==
+              'accounts.shelf.${HomeShelf.values.first.name}',
     );
-    await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
+    await tester.ensureVisible(firstShelf);
+    tester.widget<TvFocusable>(firstShelf).focusNode!.requestFocus();
     await tester.pumpAndSettle();
-    expect(
-      FocusManager.instance.primaryFocus?.debugLabel,
-      'accounts.section.home-shelves',
-    );
-    await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
-    await tester.pumpAndSettle();
-    expect(
-      FocusManager.instance.primaryFocus?.debugLabel,
-      'accounts.section.display',
-    );
     await tester.sendKeyEvent(LogicalKeyboardKey.arrowUp);
     await tester.pumpAndSettle();
     expect(
       FocusManager.instance.primaryFocus?.debugLabel,
-      'accounts.section.home-shelves',
+      'accounts.customization.home-content.continue-watching',
     );
-    await tester.sendKeyEvent(LogicalKeyboardKey.enter);
-    await tester.pumpAndSettle();
     await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
     await tester.pumpAndSettle();
 
-    for (final shelf in HomeShelf.values) {
+    for (var index = 0; index < HomeShelf.values.length; index++) {
+      final shelf = HomeShelf.values[index];
       expect(
         FocusManager.instance.primaryFocus?.debugLabel,
         'accounts.shelf.${shelf.name}',
@@ -1160,15 +1127,8 @@ void main() {
     }
     expect(
       FocusManager.instance.primaryFocus?.debugLabel,
-      'accounts.section.display',
-    );
-    await tester.sendKeyEvent(LogicalKeyboardKey.enter);
-    await tester.pumpAndSettle();
-    await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
-    await tester.pumpAndSettle();
-    expect(
-      FocusManager.instance.primaryFocus?.debugLabel,
-      'accounts.customization.first',
+      'accounts.shelf.${HomeShelf.values.last.name}',
+      reason: 'Down stops at the final visible shelf row.',
     );
     expect(tester.takeException(), isNull);
   });
@@ -1190,14 +1150,12 @@ void main() {
     expect(find.text('Optional private-repository token'), findsNothing);
     expect(find.text('Read-only GitHub token'), findsNothing);
 
+    await selectSettingsArea(tester, 'accounts');
     for (final key in [
-      LogicalKeyboardKey.arrowRight,
-      LogicalKeyboardKey.arrowRight,
-      LogicalKeyboardKey.enter,
       LogicalKeyboardKey.arrowDown,
       LogicalKeyboardKey.arrowDown,
       LogicalKeyboardKey.arrowDown,
-      LogicalKeyboardKey.arrowRight,
+      LogicalKeyboardKey.arrowDown,
     ]) {
       await tester.sendKeyEvent(key);
       await tester.pumpAndSettle();
@@ -1226,14 +1184,12 @@ void main() {
     );
     await tester.pumpAndSettle();
 
+    await selectSettingsArea(tester, 'accounts');
     for (final key in [
-      LogicalKeyboardKey.arrowRight,
-      LogicalKeyboardKey.arrowRight,
-      LogicalKeyboardKey.enter,
       LogicalKeyboardKey.arrowDown,
       LogicalKeyboardKey.arrowDown,
       LogicalKeyboardKey.arrowDown,
-      LogicalKeyboardKey.arrowRight,
+      LogicalKeyboardKey.arrowDown,
       LogicalKeyboardKey.arrowDown,
       LogicalKeyboardKey.arrowDown,
       LogicalKeyboardKey.arrowDown,
@@ -1272,19 +1228,12 @@ void main() {
       find.byKey(const ValueKey('settings-dub-episode-notifications')),
       findsOneWidget,
     );
-    final settingsScrollable = find.ancestor(
-      of: find.byKey(const ValueKey('settings-dub-episode-notifications')),
-      matching: find.byType(Scrollable),
-    );
-    final position = tester
-        .state<ScrollableState>(settingsScrollable.first)
-        .position;
     await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
     await tester.pumpAndSettle();
-    expect(position.pixels, closeTo(position.maxScrollExtent, .5));
     expect(
       FocusManager.instance.primaryFocus?.debugLabel,
       'accounts.tracking.dub-notifications',
+      reason: 'Down stops when the Discord action is unavailable and disabled.',
     );
     expect(tester.takeException(), isNull);
   });
@@ -1301,23 +1250,14 @@ void main() {
     );
     await tester.pumpAndSettle();
 
-    expect(find.textContaining('Titles:'), findsNothing);
-    expect(find.text('Title language'), findsNothing);
-    await tester.tap(
-      find.byKey(const ValueKey('inline-section-toggle-display')),
-    );
-    await tester.pumpAndSettle();
     expect(find.text('Title language'), findsOneWidget);
-    final languageDetector = find.descendant(
-      of: find.ancestor(
-        of: find.text('Title language'),
+    final languageControl = tester.widget<TvFocusable>(
+      find.descendant(
+        of: find.byKey(const ValueKey('settings-appearance-title-language')),
         matching: find.byType(TvFocusable),
       ),
-      matching: find.byType(FocusableActionDetector),
     );
-    final languageFocus = tester
-        .widget<FocusableActionDetector>(languageDetector)
-        .focusNode!;
+    final languageFocus = languageControl.focusNode!;
     languageFocus.requestFocus();
     await tester.pump();
     expect(
@@ -1333,7 +1273,7 @@ void main() {
     );
     final titleStyleControl = tester.widget<TvFocusable>(
       find.descendant(
-        of: find.byKey(const ValueKey('show-title-style-englishLogo')),
+        of: find.byKey(const ValueKey('settings-appearance-show-title-style')),
         matching: find.byType(TvFocusable),
       ),
     );
@@ -1371,9 +1311,7 @@ void main() {
     expect(find.text('Advanced: personal token'), findsNothing);
     expect(find.text('TorBox API token'), findsNothing);
 
-    await tester.sendKeyEvent(LogicalKeyboardKey.arrowRight);
-    await tester.sendKeyEvent(LogicalKeyboardKey.enter);
-    await tester.pumpAndSettle();
+    await selectSettingsArea(tester, 'services');
     await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
     await tester.pump();
     expect(find.text('Advanced: personal token'), findsNothing);
@@ -1404,11 +1342,8 @@ void main() {
     );
     await tester.pumpAndSettle();
 
+    await selectSettingsArea(tester, 'system');
     for (final key in [
-      LogicalKeyboardKey.arrowRight,
-      LogicalKeyboardKey.arrowRight,
-      LogicalKeyboardKey.arrowRight,
-      LogicalKeyboardKey.enter,
       LogicalKeyboardKey.arrowDown,
       LogicalKeyboardKey.arrowDown,
     ]) {
@@ -1443,12 +1378,6 @@ void main() {
     expect(
       FocusManager.instance.primaryFocus?.debugLabel,
       'accounts.updates.check',
-    );
-    await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
-    await tester.pumpAndSettle();
-    expect(
-      FocusManager.instance.primaryFocus?.debugLabel,
-      'accounts.system.discord-presence',
     );
     await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
     await tester.pumpAndSettle();
@@ -1530,9 +1459,7 @@ void main() {
     );
     await tester.pumpAndSettle();
 
-    for (var index = 0; index < 3; index++) {
-      await tester.sendKeyEvent(LogicalKeyboardKey.arrowRight);
-    }
+    await selectSettingsArea(tester, 'system');
     expect(
       FocusManager.instance.primaryFocus?.debugLabel,
       'accounts.area.system',
@@ -1565,9 +1492,7 @@ void main() {
       findsOneWidget,
     );
     expect(
-      find.textContaining(
-        'Developer mode cannot bypass Android downgrade protection',
-      ),
+      find.textContaining('Developer Mode cannot bypass that rule'),
       findsOneWidget,
     );
     expect(
@@ -1632,11 +1557,7 @@ void main() {
       const ProviderScope(child: MaterialApp(home: AccountsScreen())),
     );
     await tester.pumpAndSettle();
-    for (var index = 0; index < 3; index++) {
-      await tester.sendKeyEvent(LogicalKeyboardKey.arrowRight);
-    }
-    await tester.sendKeyEvent(LogicalKeyboardKey.enter);
-    await tester.pumpAndSettle();
+    await selectSettingsArea(tester, 'system');
 
     expect(find.text('Load release history'), findsOneWidget);
     expect(find.textContaining('Beta key'), findsNothing);
@@ -1657,6 +1578,12 @@ void main() {
     }
     expect(
       FocusManager.instance.primaryFocus?.debugLabel,
+      'accounts.updates.channel',
+    );
+    await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
+    await tester.pumpAndSettle();
+    expect(
+      FocusManager.instance.primaryFocus?.debugLabel,
       'accounts.updates.release-history',
     );
     expect(tester.takeException(), isNull);
@@ -1675,15 +1602,7 @@ void main() {
       const ProviderScope(child: MaterialApp(home: AccountsScreen())),
     );
     await tester.pumpAndSettle();
-    for (final key in [
-      LogicalKeyboardKey.arrowRight,
-      LogicalKeyboardKey.arrowRight,
-      LogicalKeyboardKey.arrowRight,
-      LogicalKeyboardKey.enter,
-    ]) {
-      await tester.sendKeyEvent(key);
-      await tester.pumpAndSettle();
-    }
+    await selectSettingsArea(tester, 'system');
 
     expect(find.byType(QrImageView, skipOffstage: false), findsNWidgets(2));
     expect(
@@ -1696,7 +1615,7 @@ void main() {
     );
     expect(
       find.text('Discord Rich Presence', skipOffstage: false),
-      findsOneWidget,
+      findsNothing,
     );
     expect(
       find.text('Double-click or press OK twice to copy', skipOffstage: false),
@@ -1709,28 +1628,17 @@ void main() {
     final donationTitle = find.text('Support TetoTV', skipOffstage: false);
     final discordRect = tester.getRect(discordTitle);
     final donationRect = tester.getRect(donationTitle);
-    expect(donationRect.left, greaterThan(discordRect.right));
-    expect((donationRect.top - discordRect.top).abs(), lessThan(2));
+    expect(donationRect.top, greaterThan(discordRect.bottom));
     final qrCodes = find.byType(QrImageView, skipOffstage: false);
     final discordQrRect = tester.getRect(qrCodes.at(0));
     final donationQrRect = tester.getRect(qrCodes.at(1));
     expect(discordRect.left, greaterThan(discordQrRect.right));
     expect(donationRect.left, greaterThan(donationQrRect.right));
-    expect(donationQrRect.left, greaterThan(discordQrRect.right));
-    expect(
-      (donationQrRect.top - discordQrRect.top).abs(),
-      lessThanOrEqualTo(2),
-    );
+    expect(donationQrRect.top, greaterThan(discordQrRect.bottom));
 
     await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
     await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
     await tester.sendKeyEvent(LogicalKeyboardKey.arrowRight);
-    await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
-    await tester.pumpAndSettle();
-    expect(
-      FocusManager.instance.primaryFocus?.debugLabel,
-      'accounts.system.discord-presence',
-    );
     await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
     await tester.pumpAndSettle();
     expect(
@@ -1758,9 +1666,7 @@ void main() {
     expect(tester.takeException(), isNull);
   });
 
-  testWidgets('Discord Rich Presence actions align with update actions', (
-    tester,
-  ) async {
+  testWidgets('Accounts expose Discord Rich Presence actions', (tester) async {
     FlutterSecureStorage.setMockInitialValues({});
     tester.view.physicalSize = const Size(1280, 720);
     tester.view.devicePixelRatio = 1;
@@ -1771,26 +1677,18 @@ void main() {
       const ProviderScope(child: MaterialApp(home: AccountsScreen())),
     );
     await tester.pumpAndSettle();
-    await tester.tap(find.text('System'));
+    await tester.tap(find.text('Accounts'));
     await tester.pumpAndSettle();
 
-    final updateActions = find.byKey(
-      const ValueKey('app-update-actions'),
-      skipOffstage: false,
-    );
     final discordActions = find.byKey(
       const ValueKey('discord-presence-actions'),
       skipOffstage: false,
     );
-    expect(updateActions, findsOneWidget);
     expect(discordActions, findsOneWidget);
 
     await tester.ensureVisible(discordActions);
     await tester.pumpAndSettle();
-    expect(
-      tester.getRect(discordActions).right,
-      closeTo(tester.getRect(updateActions).right, 0.1),
-    );
+    expect(tester.getSize(discordActions).width, greaterThan(0));
     expect(tester.takeException(), isNull);
   });
 
@@ -1975,9 +1873,8 @@ void main() {
     );
     await tester.pumpAndSettle();
 
+    await selectSettingsArea(tester, 'services');
     for (final key in [
-      LogicalKeyboardKey.arrowRight,
-      LogicalKeyboardKey.enter,
       LogicalKeyboardKey.arrowDown,
       LogicalKeyboardKey.arrowDown,
     ]) {
@@ -2011,17 +1908,46 @@ void main() {
       'accounts.debrid.connect',
     );
 
+    expect(find.byKey(const ValueKey('settings-area-downloads')), findsNothing);
+    Finder localMediaButton() => find.byWidgetPredicate(
+      (widget) =>
+          widget is TvFocusable &&
+          widget.focusNode?.debugLabel == 'accounts.streaming.local-media',
+    );
+    for (
+      var scroll = 0;
+      scroll < 20 && localMediaButton().evaluate().isEmpty;
+      scroll++
+    ) {
+      await tester.drag(
+        find.byKey(const ValueKey('settings-content-list')),
+        const Offset(0, -450),
+      );
+      await tester.pumpAndSettle();
+    }
+    expect(localMediaButton(), findsOneWidget);
+    tester.widget<TvFocusable>(localMediaButton()).focusNode!.requestFocus();
+    await tester.pumpAndSettle();
     await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
-    await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
-    await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
-    await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
-    await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
+    await tester.pumpAndSettle();
+    expect(
+      FocusManager.instance.primaryFocus?.debugLabel,
+      'accounts.streaming.watch-together',
+    );
     await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
     await tester.pumpAndSettle();
     expect(
       FocusManager.instance.primaryFocus?.debugLabel,
       'accounts.streaming.offline-downloads',
     );
+    await tester.sendKeyEvent(LogicalKeyboardKey.arrowUp);
+    await tester.pumpAndSettle();
+    expect(
+      FocusManager.instance.primaryFocus?.debugLabel,
+      'accounts.streaming.watch-together',
+    );
+    await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
+    await tester.pumpAndSettle();
     await tester.sendKeyEvent(LogicalKeyboardKey.arrowRight);
     await tester.pumpAndSettle();
     expect(
@@ -2036,24 +1962,7 @@ void main() {
     await tester.pumpAndSettle();
     expect(
       FocusManager.instance.primaryFocus?.debugLabel,
-      'accounts.streaming.local-media',
-    );
-    expect(find.text('Manage sources'), findsWidgets);
-    await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
-    await tester.pumpAndSettle();
-    expect(
-      FocusManager.instance.primaryFocus?.debugLabel,
-      'accounts.streaming.watch-together',
-    );
-    expect(
-      find.byKey(const ValueKey('settings-watch-party-toggle')),
-      findsOneWidget,
-    );
-    await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
-    await tester.pumpAndSettle();
-    expect(
-      FocusManager.instance.primaryFocus?.debugLabel,
-      'accounts.streaming.watch-together',
+      'accounts.streaming.download-manager',
     );
     expect(tester.takeException(), isNull);
   });
@@ -2073,10 +1982,16 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.text('Settings'), findsWidgets);
+    expect(find.text('Appearance'), findsWidgets);
+    expect(find.text('Playback'), findsOneWidget);
+    expect(find.text('Services'), findsOneWidget);
+    expect(find.text('Accounts'), findsOneWidget);
+    expect(find.byKey(const ValueKey('settings-area-downloads')), findsNothing);
     expect(find.text('Customize'), findsOneWidget);
-    expect(find.text('Streaming'), findsOneWidget);
-    expect(find.text('Appearance'), findsNothing);
-    expect(find.text('APPEARANCE & NAVIGATION'), findsOneWidget);
+    expect(
+      find.byKey(const ValueKey('appearance-theme-display-card')),
+      findsOneWidget,
+    );
     expect(find.text('10-foot layout'), findsNothing);
     expect(find.text('Denser handheld layout'), findsNothing);
     final container = ProviderScope.containerOf(
@@ -2099,16 +2014,21 @@ void main() {
     );
     expect(tester.takeException(), isNull);
 
-    final inputFeedbackToggle = find.byKey(
-      const ValueKey('inline-section-toggle-input-feedback'),
+    await selectSettingsArea(tester, 'system');
+    expect(
+      find.text(
+        'Manage this device, updates, diagnostics, privacy, storage, and legal information.',
+      ),
+      findsOneWidget,
     );
-    await tester.ensureVisible(inputFeedbackToggle);
-    await tester.tap(inputFeedbackToggle);
-    await tester.pumpAndSettle();
-    final crashToggle = find.textContaining('Anonymous error reports');
+    final crashToggle = find.text(
+      'Anonymous crash reports',
+      skipOffstage: false,
+    );
     expect(crashToggle, findsOneWidget);
     await tester.ensureVisible(crashToggle);
     await tester.pumpAndSettle();
+    expect(tester.takeException(), isNull);
     await tester.tap(crashToggle);
     await tester.pumpAndSettle();
     expect(
@@ -2118,6 +2038,48 @@ void main() {
       isTrue,
     );
 
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('switching Settings tabs starts the new tab at the top', (
+    tester,
+  ) async {
+    FlutterSecureStorage.setMockInitialValues({});
+    tester.view.physicalSize = const Size(390, 600);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [isTelevisionProvider.overrideWithValue(false)],
+        child: const MaterialApp(home: AccountsScreen()),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    final settingsList = find.byKey(const ValueKey('settings-content-list'));
+    final scrollable = find.descendant(
+      of: settingsList,
+      matching: find.byType(Scrollable),
+    );
+    final scrollState = tester.state<ScrollableState>(scrollable.first);
+    expect(scrollState.position.maxScrollExtent, greaterThan(0));
+    scrollState.position.jumpTo(scrollState.position.maxScrollExtent);
+    await tester.pump();
+    expect(scrollState.position.pixels, greaterThan(0));
+
+    await tester.tap(
+      find.byKey(const ValueKey('settings-area-services')),
+      warnIfMissed: false,
+    );
+    await tester.pumpAndSettle();
+
+    expect(scrollState.position.pixels, 0);
+    expect(
+      find.byKey(const ValueKey('settings-card-services-debrid')),
+      findsOneWidget,
+    );
     expect(tester.takeException(), isNull);
   });
 
@@ -2137,23 +2099,25 @@ void main() {
       );
       await tester.pumpAndSettle();
 
-      final homeNavigationToggle = find.byKey(
-        const ValueKey('inline-section-toggle-home-navigation'),
+      final menuOrder = find.byKey(
+        const ValueKey('settings-appearance-menu-order'),
       );
-      await tester.ensureVisible(homeNavigationToggle);
-      await tester.tap(homeNavigationToggle);
+      tester
+          .widget<TvFocusable>(
+            find.descendant(of: menuOrder, matching: find.byType(TvFocusable)),
+          )
+          .onPressed();
       await tester.pumpAndSettle();
+      expect(find.text('Navigation bar'), findsOneWidget);
       final homeToggle = find.byKey(
         const ValueKey('settings-top-navigation-toggle-home'),
       );
       await tester.ensureVisible(homeToggle);
       tester.widget<TvFocusable>(homeToggle).focusNode!.requestFocus();
       await tester.pumpAndSettle();
-      await tester.sendKeyEvent(LogicalKeyboardKey.arrowUp);
-      await tester.pumpAndSettle();
       expect(
         FocusManager.instance.primaryFocus?.debugLabel,
-        'accounts.customization.home-content.featured',
+        'accounts.customization.menu-order.home',
       );
 
       final moveSearchLater = find.byKey(
@@ -2233,22 +2197,19 @@ void main() {
     );
     await tester.pumpAndSettle();
 
-    final playerControlsToggle = find.byKey(
-      const ValueKey('inline-section-toggle-player-controls'),
-    );
-    await tester.ensureVisible(playerControlsToggle);
-    await tester.tap(playerControlsToggle);
+    await tester.tap(find.text('Playback'));
     await tester.pumpAndSettle();
-    final enabledLabel = find.text('Show filler episode labels ON');
-    expect(enabledLabel, findsOneWidget);
-    await tester.ensureVisible(enabledLabel);
+
+    final fillerLabel = find.text('Filler episode labels', skipOffstage: false);
+    expect(fillerLabel, findsOneWidget);
+    await tester.ensureVisible(fillerLabel);
     await tester.pumpAndSettle();
     expect(
-      find.ancestor(of: enabledLabel, matching: find.byType(TvFocusable)),
+      find.ancestor(of: fillerLabel, matching: find.byType(TvFocusable)),
       findsOneWidget,
     );
 
-    await tester.tap(enabledLabel);
+    await tester.tap(fillerLabel);
     await tester.pumpAndSettle();
 
     final container = ProviderScope.containerOf(
@@ -2258,7 +2219,7 @@ void main() {
       container.read(settingsPreferencesProvider).showFillerIndicators,
       isFalse,
     );
-    expect(find.text('Show filler episode labels OFF'), findsOneWidget);
+    expect(find.text('Filler episode labels'), findsOneWidget);
     expect(tester.takeException(), isNull);
   });
 
@@ -2278,9 +2239,8 @@ void main() {
       );
       await tester.pumpAndSettle();
 
+      await selectSettingsArea(tester, 'services');
       for (final key in [
-        LogicalKeyboardKey.arrowRight,
-        LogicalKeyboardKey.enter,
         LogicalKeyboardKey.arrowDown,
         LogicalKeyboardKey.enter,
         LogicalKeyboardKey.arrowDown,
@@ -2299,7 +2259,7 @@ void main() {
       expect(tester.testTextInput.isVisible, isFalse);
 
       for (final key in [
-        LogicalKeyboardKey.arrowRight,
+        LogicalKeyboardKey.arrowDown,
         LogicalKeyboardKey.arrowDown,
         LogicalKeyboardKey.arrowDown,
       ]) {
@@ -2315,7 +2275,7 @@ void main() {
       for (final key in [
         LogicalKeyboardKey.arrowUp,
         LogicalKeyboardKey.arrowUp,
-        LogicalKeyboardKey.arrowLeft,
+        LogicalKeyboardKey.arrowUp,
       ]) {
         await tester.sendKeyEvent(key);
         await tester.pumpAndSettle();

--- a/test/app_update_release_date_ui_test.dart
+++ b/test/app_update_release_date_ui_test.dart
@@ -61,8 +61,11 @@ void main() {
       find.textContaining('Latest 2.0.10 Beta • Aug 20, 2026'),
       findsWidgets,
     );
-    expect(find.text('2.0.10 Beta • Aug 20, 2026'), findsOneWidget);
-    await tester.tap(find.text('2.0.10 Beta • Aug 20, 2026'));
+    final latestHistoryEntry = find.text('2.0.10 Beta • Aug 20, 2026');
+    expect(latestHistoryEntry, findsOneWidget);
+    await tester.ensureVisible(latestHistoryEntry);
+    await tester.pumpAndSettle();
+    await tester.tap(latestHistoryEntry);
     await tester.pumpAndSettle();
     expect(find.text('2.0.9 Beta • Aug 12, 2026'), findsOneWidget);
     expect(
@@ -88,6 +91,44 @@ void main() {
 
     expect(find.text('TetoTV 1.0.2+410001'), findsOneWidget);
     expect(find.textContaining('Jan 1, 1970'), findsNothing);
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('lower Android builds stay visible but cannot be selected', (
+    tester,
+  ) async {
+    final installed = _release('2.0.10', androidVersionCode: 410010);
+    final blocked = _release('2.0.9', androidVersionCode: 410009);
+    await _pumpSystemUpdates(
+      tester,
+      AppUpdateState(
+        phase: AppUpdatePhase.upToDate,
+        currentVersion: '2.0.10+410010',
+        latestVersion: installed.version,
+        release: installed,
+        updateChannel: AppUpdateChannel.beta,
+        developerMode: true,
+        releaseHistory: [installed, blocked],
+      ),
+    );
+
+    await tester.tap(find.text('2.0.10 Beta'));
+    await tester.pumpAndSettle();
+    expect(find.text('2.0.9 Beta'), findsOneWidget);
+    expect(
+      find.text(
+        'Blocked by Android • build 410009 is lower than installed build 410010',
+      ),
+      findsOneWidget,
+    );
+
+    await tester.tap(find.text('2.0.9 Beta'), warnIfMissed: false);
+    await tester.pumpAndSettle();
+    expect(
+      find.text('Choose a compatible signed release'),
+      findsWidgets,
+      reason: 'A blocked downgrade must not close the release picker.',
+    );
     expect(tester.takeException(), isNull);
   });
 }
@@ -117,11 +158,13 @@ Future<void> _pumpSystemUpdates(
 AppReleaseInfo _release(
   String version, {
   DateTime? releasedAtUtc,
+  int? androidVersionCode,
 }) => AppReleaseInfo(
   tagName: 'v$version',
   version: version,
   name: 'TetoTV $version',
   releasedAtUtc: releasedAtUtc,
+  androidVersionCode: androidVersionCode,
   asset: AppReleaseAsset(
     name: 'TetoTV-v$version-universal.apk',
     apiUrl:

--- a/test/diagnostic_history_test.dart
+++ b/test/diagnostic_history_test.dart
@@ -602,6 +602,15 @@ void main() {
         });
       }
       await database.insert('stream_failures', {
+        'device_key': 'another-device',
+        'info_hash': List<String>.filled(40, 'e').join(),
+        'reason': 'failure-0',
+        'failure_count': 5,
+        'last_failed_at': now
+            .subtract(const Duration(seconds: 30))
+            .millisecondsSinceEpoch,
+      });
+      await database.insert('stream_failures', {
         'device_key': 'example',
         'info_hash': List<String>.filled(40, 'f').join(),
         'reason': 'outside',
@@ -641,6 +650,11 @@ void main() {
       expect(failureWindow['droppedForCapacity'], 2);
       expect(failures.first, contains('lifetimeFailureCount'));
       expect(failures.first, isNot(contains('failure_count')));
+      final repeatedFailure = failures.cast<Map>().singleWhere(
+        (failure) => failure['reason'] == 'failure-0',
+      );
+      expect(repeatedFailure['lifetimeFailureCount'], 15);
+      expect(repeatedFailure['failureRecordCount'], 2);
       expect(timings, hasLength(100));
       expect(timingWindow['retainedCount'], 100);
       expect(timingWindow['droppedForCapacity'], 5);

--- a/test/discord_tv_pairing_navigation_test.dart
+++ b/test/discord_tv_pairing_navigation_test.dart
@@ -1,5 +1,6 @@
 import 'package:anime_tv/core/layout/adaptive_layout.dart';
 import 'package:anime_tv/core/platform/android_tv_bridge.dart';
+import 'package:anime_tv/core/tv/tv_focusable.dart';
 import 'package:anime_tv/features/discord/application/discord_account_link_resolver.dart';
 import 'package:anime_tv/features/discord/application/discord_presence_controller.dart';
 import 'package:anime_tv/features/settings/presentation/accounts_screen.dart';
@@ -120,11 +121,20 @@ Future<_SettingsDiscordPlatform> _pumpAccounts(
 }
 
 Future<void> _tapConnectDiscord(WidgetTester tester) async {
-  await tester.tap(find.text('System'));
+  final accountsTab = find.byKey(const ValueKey('settings-area-accounts'));
+  await tester.ensureVisible(accountsTab);
+  tester.widget<TvFocusable>(accountsTab).onPressed();
   await tester.pumpAndSettle();
   final connect = find.text('Connect Discord');
+  await tester.scrollUntilVisible(
+    connect,
+    500,
+    scrollable: find.descendant(
+      of: find.byKey(const ValueKey('settings-content-list')),
+      matching: find.byType(Scrollable),
+    ),
+  );
   expect(connect, findsOneWidget);
-  await tester.ensureVisible(connect);
   await tester.pumpAndSettle();
   await tester.tap(connect);
   await tester.pumpAndSettle();

--- a/test/local_profiles_test.dart
+++ b/test/local_profiles_test.dart
@@ -9,6 +9,7 @@ import 'package:anime_tv/features/settings/application/tracking_accounts_control
 import 'package:anime_tv/features/settings/presentation/accounts_screen.dart';
 import 'package:anime_tv/features/watch_together/application/watch_party_public_identity_provider.dart';
 import 'package:anime_tv/core/widgets/tv_text_input.dart';
+import 'package:anime_tv/core/tv/tv_focusable.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -359,7 +360,11 @@ void main() {
       expect(manage, findsOneWidget);
       expect(find.textContaining('stored only on this device'), findsOneWidget);
       await tester.ensureVisible(manage);
-      await tester.tap(manage);
+      tester
+          .widget<TvFocusable>(
+            find.descendant(of: manage, matching: find.byType(TvFocusable)),
+          )
+          .onPressed();
       await tester.pumpAndSettle();
 
       expect(
@@ -413,7 +418,11 @@ void main() {
 
       final manage = find.byKey(const ValueKey('manage-local-profiles'));
       await tester.ensureVisible(manage);
-      await tester.tap(manage);
+      tester
+          .widget<TvFocusable>(
+            find.descendant(of: manage, matching: find.byType(TvFocusable)),
+          )
+          .onPressed();
       await tester.pumpAndSettle();
 
       expect(find.byIcon(Icons.arrow_back_rounded), findsOneWidget);
@@ -510,7 +519,11 @@ void main() {
       await tester.pumpAndSettle();
       final manage = find.byKey(const ValueKey('manage-local-profiles'));
       await tester.ensureVisible(manage);
-      await tester.tap(manage);
+      tester
+          .widget<TvFocusable>(
+            find.descendant(of: manage, matching: find.byType(TvFocusable)),
+          )
+          .onPressed();
       await tester.pumpAndSettle();
 
       final activateGuest = find.byKey(

--- a/test/mobile_surface_layout_test.dart
+++ b/test/mobile_surface_layout_test.dart
@@ -227,10 +227,26 @@ void main() {
       await tester.pump();
       await tester.pump(const Duration(milliseconds: 180));
 
+      expect(
+        find.byKey(const ValueKey('settings-area-downloads')),
+        findsNothing,
+      );
+      expect(
+        find.byKey(const ValueKey('phone-bottom-navigation')),
+        entry.name == 'portrait' ? findsOneWidget : findsNothing,
+        reason: 'Settings must keep portrait phone navigation visible.',
+      );
+      expect(
+        find.byKey(const ValueKey('main-navigation')),
+        entry.name == 'landscape' ? findsOneWidget : findsNothing,
+        reason: 'Settings must keep landscape phone navigation visible.',
+      );
+
       for (final section in const [
-        'Customize',
-        'Streaming',
-        'Tracking',
+        'Appearance',
+        'Playback',
+        'Services',
+        'Accounts',
         'System',
       ]) {
         await tester.tap(find.text(section).first);
@@ -242,6 +258,53 @@ void main() {
           isNull,
           reason: '$section overflowed at the top in ${entry.name}',
         );
+
+        if (section == 'Appearance') {
+          expect(
+            find.byKey(const ValueKey('appearance-theme-display-card')),
+            findsOneWidget,
+          );
+          expect(
+            find.byKey(const ValueKey('appearance-navigation-card')),
+            findsOneWidget,
+          );
+          expect(
+            find.byKey(const ValueKey('appearance-home-screen-card')),
+            findsOneWidget,
+          );
+          expect(find.text('Expand all'), findsNothing);
+          expect(
+            find.byKey(const ValueKey('customize-toggle-all-sections')),
+            findsNothing,
+          );
+        }
+
+        if (section == 'Services') {
+          for (
+            var scroll = 0;
+            scroll < 20 &&
+                find
+                    .byKey(const ValueKey('settings-offline-downloads-toggle'))
+                    .evaluate()
+                    .isEmpty;
+            scroll++
+          ) {
+            await tester.drag(
+              find.byKey(const ValueKey('settings-content-list')),
+              const Offset(0, -400),
+            );
+            await tester.pump();
+          }
+          expect(
+            find.byKey(const ValueKey('settings-offline-downloads-toggle')),
+            findsOneWidget,
+            reason: 'Offline download controls must remain usable in Services.',
+          );
+          expect(
+            find.byKey(const ValueKey('settings-download-manager-button')),
+            findsOneWidget,
+          );
+        }
 
         final verticalScroll = find.byWidgetPredicate(
           (widget) =>
@@ -265,6 +328,14 @@ void main() {
             await tester.pump();
           }
         }
+        expect(
+          find.byKey(const ValueKey('phone-bottom-navigation')),
+          entry.name == 'portrait' ? findsOneWidget : findsNothing,
+        );
+        expect(
+          find.byKey(const ValueKey('main-navigation')),
+          entry.name == 'landscape' ? findsOneWidget : findsNothing,
+        );
       }
     });
   }

--- a/test/native_redistribution_materials_test.dart
+++ b/test/native_redistribution_materials_test.dart
@@ -36,13 +36,20 @@ void main() {
       artifacts.singleWhere(
         (item) => item['id'] == 'libtorrent4j-android-arm',
       )['sha256'],
-      '5a98e854b8f7e338a3746600be5cf22a13055853f88f7894592d62e1681865f6',
+      'fe32deb93d8bada70c7be15918cb9a31e70261cac87ff66bc81e803eaaf2f75d',
     );
     expect(
       artifacts.singleWhere(
         (item) => item['id'] == 'libtorrent4j-android-arm64',
       )['sha256'],
       '223e27338fb0a9dad9b6a6db6add7ec791c8633698a69e958757571c63e7de23',
+    );
+    expect(
+      artifacts
+          .where((item) => (item['id'] as String).startsWith('libtorrent4j-'))
+          .map((item) => item['version'])
+          .toSet(),
+      {'2.1.0-38-tetotv.2'},
     );
     expect(artifacts, hasLength(5));
     final sourceRoots = (manifest['sourceRoots'] as List<dynamic>)
@@ -157,5 +164,85 @@ void main() {
     expect(documentation, contains('independent native-license review'));
     expect(documentation, contains('zipalign'));
     expect(documentation, contains('apksigner'));
+  });
+
+  test('ARMv7 native targets retain 16 KiB ELF linker alignment', () {
+    final discordCmake = File(
+      'android/app/src/main/cpp/CMakeLists.txt',
+    ).readAsStringSync();
+    final discordArm32Options = discordCmake
+        .split('if(ANDROID_ABI STREQUAL "armeabi-v7a")')
+        .last
+        .split('endif()')
+        .first;
+    expect(discordArm32Options, contains('common-page-size=16384'));
+    expect(discordArm32Options, contains('max-page-size=16384'));
+
+    final nativeBuild = File(
+      'tool/native/build_native_playback.sh',
+    ).readAsStringSync();
+    const pageSizeAnchor = 'local -a page_size_linkflags=()';
+    final pageSizeStart = nativeBuild.indexOf(pageSizeAnchor);
+    final buildInvocation = nativeBuild.indexOf(
+      '\n  (\n    cd "\${source_copy}/swig"',
+      pageSizeStart,
+    );
+    expect(pageSizeStart, isNonNegative);
+    expect(buildInvocation, greaterThan(pageSizeStart));
+    final libtorrentArm32Options = nativeBuild.substring(
+      pageSizeStart,
+      buildInvocation,
+    );
+    expect(
+      libtorrentArm32Options,
+      contains('if [[ "\${abi}" == "armeabi-v7a" ]]'),
+    );
+    expect(libtorrentArm32Options, contains('common-page-size=16384'));
+    expect(libtorrentArm32Options, contains('max-page-size=16384'));
+  });
+
+  test('media kit native JARs retain their staging task producer', () {
+    final buildScript = File(
+      'third_party/media_kit_libs_android_video/android/build.gradle',
+    ).readAsStringSync();
+
+    expect(
+      RegExp(
+        r'\bstagedNativeLibraries\s*=\s*files\s*\(\s*fileTree\s*\(',
+      ).hasMatch(buildScript),
+      isTrue,
+    );
+    expect(
+      RegExp(
+        r'\bstagedNativeLibraries\s*\.\s*builtBy\s*'
+        r'\(\s*stageSelfBuiltNativeLibraries\s*\)',
+      ).hasMatch(buildScript),
+      isTrue,
+      reason:
+          'Gradle must know that stageSelfBuiltNativeLibraries produces the '
+          'local JAR dependency before any app task consumes it.',
+    );
+    expect(
+      RegExp(
+        r'\bimplementation\s*(?:\(\s*)?stagedNativeLibraries(?:\s*\))?',
+      ).hasMatch(buildScript),
+      isTrue,
+    );
+    expect(
+      RegExp(
+        r'\bimplementation\s*(?:\(\s*)?fileTree\s*\(',
+      ).hasMatch(buildScript),
+      isFalse,
+      reason:
+          'A bare fileTree loses the staging task dependency and fails Gradle '
+          'implicit-dependency validation when both tasks are in the graph.',
+    );
+    expect(
+      buildScript,
+      isNot(contains('collectReleaseDependencies')),
+      reason:
+          'Producer metadata must cover every consumer and variant without '
+          'task-name-specific app workarounds.',
+    );
   });
 }

--- a/test/playback_session_diagnostics_test.dart
+++ b/test/playback_session_diagnostics_test.dart
@@ -223,7 +223,110 @@ void main() {
       expect(contexts.last, isNot(contains('reason_code')));
     },
   );
+
+  test('orphaned sessions are classified after supersession or a crash', () {
+    final first = DateTime.utc(2026, 8, 30, 4, 34);
+    final second = first.add(const Duration(minutes: 1));
+    final third = second.add(const Duration(minutes: 1));
+    final events = <Map<String, Object?>>[
+      _playbackEvent(
+        timestamp: first,
+        sessionId: 'pbs-orphanedSession123',
+        sequence: 1,
+        stage: 'source_selected',
+        status: 'selected_by_user',
+      ),
+      _playbackEvent(
+        timestamp: second,
+        sessionId: 'pbs-workingSession5678',
+        sequence: 1,
+        stage: 'source_selected',
+        status: 'selected_by_user',
+      ),
+      _playbackEvent(
+        timestamp: second.add(const Duration(seconds: 1)),
+        sessionId: 'pbs-workingSession5678',
+        sequence: 2,
+        stage: 'final_outcome',
+        status: 'working',
+      ),
+      _playbackEvent(
+        timestamp: third,
+        sessionId: 'pbs-crashedSession9012',
+        sequence: 1,
+        stage: 'fallback_attempted',
+        status: 'attempted',
+      ),
+    ];
+
+    final derived = derivePlaybackSessionDiagnostics(
+      events,
+      interruptions: [
+        PlaybackDiagnosticInterruption(
+          timestamp: third.add(const Duration(milliseconds: 100)),
+          reasonCode: 'native_crash',
+        ),
+      ],
+    );
+    final sessions = (derived['playbackSessions']! as List).cast<Map>();
+    final orphaned = sessions.singleWhere(
+      (session) => session['sessionId'] == 'pbs-orphanedSession123',
+    );
+    final crashed = sessions.singleWhere(
+      (session) => session['sessionId'] == 'pbs-crashedSession9012',
+    );
+
+    expect(orphaned['finalOutcome'], 'failed');
+    expect(orphaned['finalReasonCode'], 'session_superseded');
+    expect(crashed['finalOutcome'], 'failed');
+    expect(crashed['finalReasonCode'], 'native_crash');
+    expect((derived['playbackSessionComparison'] as Map)['available'], isTrue);
+  });
+
+  test('crash correlation preserves the platform failure kind', () {
+    final startedAt = DateTime.utc(2026, 8, 30, 4, 36);
+    final derived = derivePlaybackSessionDiagnostics(
+      [
+        _playbackEvent(
+          timestamp: startedAt,
+          sessionId: 'pbs-javaCrashSession12',
+          sequence: 1,
+          stage: 'source_selected',
+          status: 'selected_by_user',
+        ),
+      ],
+      interruptions: [
+        PlaybackDiagnosticInterruption(
+          timestamp: startedAt.add(const Duration(seconds: 1)),
+          reasonCode: 'java_crash',
+        ),
+      ],
+    );
+
+    final session = ((derived['playbackSessions']! as List).single as Map);
+    expect(session['finalOutcome'], 'failed');
+    expect(session['finalReasonCode'], 'java_crash');
+  });
 }
+
+Map<String, Object?> _playbackEvent({
+  required DateTime timestamp,
+  required String sessionId,
+  required int sequence,
+  required String stage,
+  required String status,
+}) => {
+  'timestamp': timestamp.toUtc().toIso8601String(),
+  'component': playbackSessionDiagnosticComponent,
+  'severity': 'info',
+  'message': 'Playback session event',
+  'context': {
+    'session_id': sessionId,
+    'sequence': sequence,
+    'stage': stage,
+    'status': status,
+  },
+};
 
 Future<void> _createDiagnosticTables(Database database) async {
   await database.execute('''

--- a/test/profile_management_navigation_test.dart
+++ b/test/profile_management_navigation_test.dart
@@ -165,8 +165,14 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.byType(AccountsScreen), findsOneWidget);
-    expect(find.text('ANIME TRACKING'), findsOneWidget);
-    expect(find.text('APPEARANCE & NAVIGATION'), findsNothing);
+    expect(
+      find.byKey(const ValueKey('settings-card-accounts-tracking')),
+      findsOneWidget,
+    );
+    expect(
+      find.byKey(const ValueKey('appearance-theme-display-card')),
+      findsNothing,
+    );
     expect(tester.takeException(), isNull);
   });
 }

--- a/test/seamless_next_episode_player_test.dart
+++ b/test/seamless_next_episode_player_test.dart
@@ -94,6 +94,30 @@ void main() {
     expect(polls, 3);
   });
 
+  test('proxied HLS readiness uses the proxy network ceiling', () {
+    expect(
+      playerMediaReadinessMaxPolls(
+        isWebStream: true,
+        mediaContentType: 'application/vnd.apple.mpegurl; charset=utf-8',
+      ),
+      100,
+    );
+    expect(
+      playerMediaReadinessMaxPolls(
+        isWebStream: true,
+        mediaContentType: 'video/mp4',
+      ),
+      60,
+    );
+    expect(
+      playerMediaReadinessMaxPolls(
+        isWebStream: false,
+        mediaContentType: 'application/vnd.apple.mpegurl',
+      ),
+      60,
+    );
+  });
+
   test(
     'fallback readiness times out and leaves the next candidate usable',
     () async {
@@ -601,7 +625,8 @@ void main() {
       'await _openMedia(',
       'resume: resumePosition',
       'requireDecodedVideo: true',
-      'catch (_)',
+      'catch (error)',
+      'await _recordStreamFailureBestEffort(',
       'rethrow',
     ]);
     expect(source, contains('if (propagateFailure) rethrow'));
@@ -614,7 +639,7 @@ void main() {
       'final tokenService = ref.read(debridTokenServiceProvider)',
       'await AndroidTvBridge.instance.getDeviceProfile()',
       'if (!mounted || _engineHandoffInProgress) return',
-      'await _database.recordStreamFailure(',
+      'await _recordStreamFailureBestEffort(',
       'if (!mounted || _engineHandoffInProgress) return',
       'await _switchToNextDirectStream(',
     ]);
@@ -889,7 +914,7 @@ void main() {
       'requireDecodedVideo: true',
       'await widget.onStreamAdopted(option.stream, option.release)',
       'preparedOption = null',
-      '} catch (_)',
+      '} catch (error)',
       'await preparedOption?.stream.playbackLease?.close()',
     ]);
   });

--- a/test/seanime_javascript_provider_test.dart
+++ b/test/seanime_javascript_provider_test.dart
@@ -313,6 +313,37 @@ video-720.m3u8
     );
   });
 
+  test('HLS metadata inspection deduplicates and bounds optional probes', () {
+    final selected = selectHlsInspectionCandidates([
+      {'url': 'https://cdn.example/one.m3u8', 'quality': 'Auto'},
+      {
+        'url': 'https://cdn.example/one.m3u8',
+        'quality': '1080p',
+        'streamType': 'hls',
+      },
+      {'url': 'https://cdn.example/two', 'streamType': 'hls'},
+      {'url': 'https://cdn.example/three.m3u8'},
+      {'url': 'https://cdn.example/four.m3u8'},
+      {'url': 'https://cdn.example/five.m3u8'},
+      {'url': 'http://127.0.0.1/private.m3u8'},
+      {'url': 'https://cdn.example/not-hls.mp4'},
+    ]);
+
+    expect(selected, hasLength(4));
+    expect(selected.map((item) => item['url']), [
+      'https://cdn.example/one.m3u8',
+      'https://cdn.example/two',
+      'https://cdn.example/three.m3u8',
+      'https://cdn.example/four.m3u8',
+    ]);
+    expect(
+      selectHlsInspectionCandidates([
+        {'url': 'https://cdn.example/one.m3u8'},
+      ], maximum: 0),
+      isEmpty,
+    );
+  });
+
   test('HLS inspection retries one transient response and timeout', () async {
     var responseAttempts = 0;
     final status = await runHlsInspectionWithTransientRetry<int>(

--- a/test/settings_preferences_controller_test.dart
+++ b/test/settings_preferences_controller_test.dart
@@ -652,6 +652,41 @@ void main() {
     expect(restored.state.showTitleStyle, ShowTitleStyle.englishLogo);
   });
 
+  test(
+    'appearance and navigation reset preserves playback preferences',
+    () async {
+      FlutterSecureStorage.setMockInitialValues({});
+      const storage = FlutterSecureStorage();
+      final controller = SettingsPreferencesController(storage);
+
+      await controller.setInterfaceScale(.8);
+      await controller.setContentDensity(ContentDensity.compact);
+      await controller.setShowTitleStyle(ShowTitleStyle.text);
+      await controller.setShowHero(false);
+      await controller.setCaptionTextColor(0xFF00FF00);
+      await controller.setSeekBackSeconds(30);
+      await controller.setPreferredAudio(PlaybackAudioPreference.sub);
+
+      await controller.resetAppearanceAndNavigation();
+
+      expect(controller.state.interfaceScale, 1);
+      expect(controller.state.contentDensity, ContentDensity.standard);
+      expect(controller.state.showTitleStyle, ShowTitleStyle.englishLogo);
+      expect(controller.state.showHero, isTrue);
+      expect(controller.state.captionTextColor, 0xFF00FF00);
+      expect(controller.state.seekBackSeconds, 30);
+      expect(controller.state.preferredAudio, PlaybackAudioPreference.sub);
+
+      final restored = SettingsPreferencesController(storage);
+      await restored.load();
+      expect(restored.state.interfaceScale, 1);
+      expect(restored.state.showTitleStyle, ShowTitleStyle.englishLogo);
+      expect(restored.state.captionTextColor, 0xFF00FF00);
+      expect(restored.state.seekBackSeconds, 30);
+      expect(restored.state.preferredAudio, PlaybackAudioPreference.sub);
+    },
+  );
+
   test('explicit built-in keyboard choice is preserved', () async {
     FlutterSecureStorage.setMockInitialValues({
       'input_use_built_in_keyboard': 'true',

--- a/test/settings_restyle_contract_test.dart
+++ b/test/settings_restyle_contract_test.dart
@@ -1,0 +1,290 @@
+import 'package:anime_tv/core/layout/adaptive_layout.dart';
+import 'package:anime_tv/core/theme/app_theme.dart';
+import 'package:anime_tv/core/tv/tv_shortcuts.dart';
+import 'package:anime_tv/features/settings/presentation/accounts_screen.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  Future<void> pumpSettings(
+    WidgetTester tester, {
+    Size size = const Size(1280, 720),
+    bool isTelevision = true,
+  }) async {
+    FlutterSecureStorage.setMockInitialValues({});
+    tester.view.physicalSize = size;
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [isTelevisionProvider.overrideWithValue(isTelevision)],
+        child: MaterialApp(
+          theme: AppTheme.dark,
+          home: const TvShortcuts(child: AccountsScreen()),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+  }
+
+  Future<void> selectArea(WidgetTester tester, String area) async {
+    final tab = find.byKey(ValueKey('settings-area-$area'));
+    expect(tab, findsOneWidget);
+    await tester.tap(tab, warnIfMissed: false);
+    await tester.pumpAndSettle();
+  }
+
+  testWidgets('all five Settings tabs expose the restyled card contract', (
+    tester,
+  ) async {
+    await pumpSettings(tester);
+
+    const cardsByArea = <String, List<String>>{
+      'appearance': [
+        'appearance-theme-display-card',
+        'appearance-navigation-card',
+        'appearance-home-screen-card',
+        'appearance-display-options-card',
+        'appearance-input-feedback-card',
+        'appearance-home-shelves-card',
+      ],
+      'playback': [
+        'settings-card-playback-captions',
+        'settings-card-playback-player',
+      ],
+      'services': [
+        'settings-card-services-debrid',
+        'settings-card-services-sources',
+        'settings-card-services-autopick',
+        'settings-card-services-features',
+        'settings-card-services-privacy',
+      ],
+      'accounts': [
+        'settings-card-accounts-tracking',
+        'settings-card-accounts-profiles',
+        'settings-card-accounts-behavior',
+        'settings-card-accounts-discord',
+      ],
+      'system': [
+        'settings-card-system-support',
+        'settings-card-system-updates',
+        'settings-card-system-community',
+        'settings-card-system-storage',
+        'settings-card-system-legal',
+        'settings-card-system-privacy-diagnostics',
+      ],
+    };
+
+    for (final entry in cardsByArea.entries) {
+      await selectArea(tester, entry.key);
+
+      for (final key in entry.value) {
+        final card = find.byKey(ValueKey(key), skipOffstage: false);
+        expect(
+          card,
+          findsOneWidget,
+          reason: '${entry.key} must keep the restyled $key card.',
+        );
+      }
+
+      expect(find.text('Expand all'), findsNothing);
+      expect(find.text('Collapse all'), findsNothing);
+      expect(tester.takeException(), isNull);
+    }
+  });
+
+  testWidgets('non-Appearance tabs use the shared Settings section card', (
+    tester,
+  ) async {
+    await pumpSettings(tester);
+
+    const cardsByArea = <String, List<String>>{
+      'playback': [
+        'settings-card-playback-captions',
+        'settings-card-playback-player',
+      ],
+      'services': [
+        'settings-card-services-debrid',
+        'settings-card-services-sources',
+        'settings-card-services-autopick',
+        'settings-card-services-features',
+        'settings-card-services-privacy',
+      ],
+      'accounts': [
+        'settings-card-accounts-tracking',
+        'settings-card-accounts-profiles',
+        'settings-card-accounts-behavior',
+        'settings-card-accounts-discord',
+      ],
+      'system': [
+        'settings-card-system-support',
+        'settings-card-system-updates',
+        'settings-card-system-community',
+        'settings-card-system-storage',
+        'settings-card-system-legal',
+        'settings-card-system-privacy-diagnostics',
+      ],
+    };
+
+    for (final entry in cardsByArea.entries) {
+      await selectArea(tester, entry.key);
+
+      for (final key in entry.value) {
+        final card = find.byKey(ValueKey(key), skipOffstage: false);
+        expect(card, findsOneWidget);
+        await tester.ensureVisible(card);
+        await tester.pump();
+        expect(
+          tester.widget(card).runtimeType.toString(),
+          '_SettingsSectionCard',
+          reason: '$key must use the shared restyled section-card primitive.',
+        );
+        expect(
+          find.descendant(
+            of: card,
+            matching: find.byWidgetPredicate(
+              (widget) => widget.runtimeType.toString() == '_SettingsCardFrame',
+            ),
+            skipOffstage: false,
+          ),
+          findsOneWidget,
+          reason: '$key must use the shared card frame.',
+        );
+        expect(
+          find.descendant(
+            of: card,
+            matching: find.byWidgetPredicate(
+              (widget) =>
+                  widget.runtimeType.toString() == '_AppearanceCardTitle',
+            ),
+            skipOffstage: false,
+          ),
+          findsOneWidget,
+          reason: '$key must use the shared Settings heading treatment.',
+        );
+      }
+    }
+
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('TV Settings use compact controls across every area', (
+    tester,
+  ) async {
+    await pumpSettings(tester);
+
+    AnimatedContainer compactSurface(String key) => tester
+        .widgetList<AnimatedContainer>(
+          find.descendant(
+            of: find.byKey(ValueKey(key), skipOffstage: false),
+            matching: find.byType(AnimatedContainer, skipOffstage: false),
+            skipOffstage: false,
+          ),
+        )
+        .firstWhere((widget) => widget.constraints?.minHeight != null);
+
+    expect(
+      tester
+          .getSize(find.byKey(const ValueKey('settings-area-appearance')))
+          .height,
+      lessThanOrEqualTo(40),
+    );
+
+    final titleLanguage = compactSurface('settings-appearance-title-language');
+    expect(titleLanguage.constraints?.minHeight, 48);
+    expect(
+      titleLanguage.padding,
+      const EdgeInsets.symmetric(horizontal: 10, vertical: 5),
+    );
+    expect(
+      tester
+          .widget<Text>(
+            find.descendant(
+              of: find.byKey(
+                const ValueKey('settings-appearance-title-language'),
+              ),
+              matching: find.text('Title language'),
+            ),
+          )
+          .style
+          ?.fontSize,
+      16,
+    );
+    expect(
+      tester
+          .getSize(find.byKey(const ValueKey('appearance-theme-display-card')))
+          .height,
+      lessThanOrEqualTo(220),
+    );
+    expect(
+      tester
+          .getSize(find.byKey(const ValueKey('appearance-navigation-card')))
+          .height,
+      lessThanOrEqualTo(220),
+    );
+    expect(
+      tester
+          .getSize(find.byKey(const ValueKey('appearance-home-screen-card')))
+          .height,
+      lessThanOrEqualTo(420),
+    );
+
+    const representativeRows = <String, String>{
+      'playback': 'settings-default-player',
+      'services': 'settings-direct-torrent-toggle',
+      'accounts': 'settings-tracking-update-threshold',
+      'system': 'settings-anonymous-crash-reports',
+    };
+    for (final entry in representativeRows.entries) {
+      await selectArea(tester, entry.key);
+      final surface = compactSurface(entry.value);
+      expect(
+        surface.constraints?.minHeight,
+        48,
+        reason: '${entry.key} must use the compact shared TV row.',
+      );
+      expect(tester.takeException(), isNull);
+    }
+  });
+
+  testWidgets('mobile Settings retain their existing control sizing', (
+    tester,
+  ) async {
+    await pumpSettings(tester, size: const Size(360, 800), isTelevision: false);
+
+    final row = tester
+        .widgetList<AnimatedContainer>(
+          find.descendant(
+            of: find.byKey(
+              const ValueKey('settings-appearance-title-language'),
+            ),
+            matching: find.byType(AnimatedContainer),
+          ),
+        )
+        .firstWhere((widget) => widget.constraints?.minHeight != null);
+    expect(row.constraints?.minHeight, 64);
+    expect(
+      row.padding,
+      const EdgeInsets.symmetric(horizontal: 13, vertical: 11),
+    );
+    expect(
+      tester
+          .widget<Text>(
+            find.descendant(
+              of: find.byKey(
+                const ValueKey('settings-appearance-title-language'),
+              ),
+              matching: find.text('Title language'),
+            ),
+          )
+          .style
+          ?.fontSize,
+      14,
+    );
+    expect(tester.takeException(), isNull);
+  });
+}

--- a/test/web_playback_proxy_test.dart
+++ b/test/web_playback_proxy_test.dart
@@ -587,7 +587,7 @@ void main() {
       await session.close();
     });
 
-    test('rejects private nested HLS references and live playlists', () async {
+    test('rejects private nested HLS references', () async {
       Future<void> expectRejected(String manifest) async {
         final upstream = _fakeUpstream(
           (request) async => _textResponse(request, manifest),
@@ -604,8 +604,51 @@ void main() {
         '#EXTM3U\n#EXT-X-TARGETDURATION:10\n#EXTINF:10,\n'
         'https://127.0.0.1/private.ts\n#EXT-X-ENDLIST\n',
       );
-      await expectRejected(
-        '#EXTM3U\n#EXT-X-TARGETDURATION:10\n#EXTINF:10,\nsegment.ts\n',
+    });
+
+    test('closes only a media playlist explicitly declared as VOD', () async {
+      final root = Uri.parse('https://cdn.example/root.m3u8');
+      final segment = Uri.parse('https://cdn.example/segment.ts');
+      final upstream = _fakeUpstream((request) async {
+        if (request.uri == root) {
+          return _textResponse(
+            request,
+            '#EXTM3U\n#EXT-X-PLAYLIST-TYPE:VOD\n'
+            '#EXT-X-TARGETDURATION:10\n#EXTINF:10,\nsegment.ts\n',
+          );
+        }
+        expect(request.uri, segment);
+        return _response(request, contentType: 'video/mp2t', bytes: [7, 8, 9]);
+      });
+      final proxy = WebPlaybackProxy(upstream: upstream);
+      addTearDown(proxy.close);
+
+      final session = await proxy.prepare(uri: root);
+      final media = utf8.decode(
+        (await _localRequest(session.playbackUri)).body,
+      );
+      expect(media, contains('#EXT-X-ENDLIST'));
+      final segmentLocal = Uri.parse(
+        media.split('\n').firstWhere((line) => line.startsWith('http://')),
+      );
+      expect((await _localRequest(segmentLocal)).body, [7, 8, 9]);
+      await session.close();
+    });
+
+    test('does not truncate an ordinary open media playlist', () async {
+      final proxy = WebPlaybackProxy(
+        upstream: _fakeUpstream(
+          (request) async => _textResponse(
+            request,
+            '#EXTM3U\n#EXT-X-TARGETDURATION:10\n#EXTINF:10,\nsegment.ts\n',
+          ),
+        ),
+      );
+      addTearDown(proxy.close);
+
+      await expectLater(
+        proxy.prepare(uri: Uri.parse('https://cdn.example/live.m3u8')),
+        throwsFormatException,
       );
     });
 

--- a/third_party/media_kit_libs_android_video/android/build.gradle
+++ b/third_party/media_kit_libs_android_video/android/build.gradle
@@ -40,9 +40,6 @@ android {
         minSdkVersion 16
     }
 
-    dependencies {
-        implementation fileTree(dir: "$buildDir/output", include: "*.jar")
-    }
 }
 
 def nativeArtifactDirectory = {
@@ -93,16 +90,15 @@ def stageSelfBuiltNativeLibraries = tasks.register("stageSelfBuiltNativeLibrarie
     }
 }
 
-tasks.named("preBuild").configure {
-    dependsOn(stageSelfBuiltNativeLibraries)
+def stagedNativeLibraries = files(
+    fileTree(dir: "$buildDir/output", include: "*.jar")
+)
+stagedNativeLibraries.builtBy(stageSelfBuiltNativeLibraries)
+
+dependencies {
+    implementation stagedNativeLibraries
 }
 
-// AGP's application-level dependency-report tasks inspect this library's
-// local JAR file dependency directly. Gradle 9 no longer infers that the
-// report must wait for the library preBuild task, so declare the cross-project
-// ordering instead of allowing a report to observe a partially staged JAR.
-rootProject.project(":app").tasks.configureEach { task ->
-    if (task.name == "collectReleaseDependencies") {
-        task.dependsOn(stageSelfBuiltNativeLibraries)
-    }
+tasks.named("preBuild").configure {
+    dependsOn(stageSelfBuiltNativeLibraries)
 }

--- a/tool/native/README.md
+++ b/tool/native/README.md
@@ -38,8 +38,12 @@ accepted only when all expected prior output JARs are present.
 The two default JARs contain self-built `libmpv.so` and
 `libmediakitandroidhelper.so`. The Android libtorrent JARs contain self-built
 `libtorrent4j.so`; the core JAR contains the wrapper compiled from the pinned
-Java source. JAR entry times and source-build environment values are fixed
-where practical.
+Java source. The current set is identified as `2.1.0-38-tetotv.2` in the
+release manifest while retaining upstream-compatible JAR file names. JAR entry
+times and source-build environment values are fixed where practical. Both ARM
+libtorrent outputs use 16 KiB-compatible ELF LOAD alignment. The build adds the
+required maximum/common page-size linker options only for ARMv7 because NDK
+r28 already produces compliant ARM64 segments.
 
 ## Source and toolchain policy
 

--- a/tool/native/build_native_playback.sh
+++ b/tool/native/build_native_playback.sh
@@ -336,12 +336,21 @@ build_libtorrent4j_abi() {
   export AR="${toolchain}/bin/llvm-ar"
   export LD="${toolchain}/bin/ld"
   export RANLIB="${toolchain}/bin/llvm-ranlib"
+  local -a page_size_linkflags=()
+  if [[ "${abi}" == "armeabi-v7a" ]]; then
+    # NDK r28's ARMv7 linker default is still 4 KiB. Keep the already-compliant
+    # ARM64 output unchanged while making this ELF loadable on 16 KiB devices.
+    page_size_linkflags=(
+      "linkflags=-Wl,-z,common-page-size=16384 -Wl,-z,max-page-size=16384"
+    )
+  fi
   (
     cd "${source_copy}/swig"
     "${boost_root}/b2" -j"${JOBS}" \
       --user-config="config/${boost_config}" variant=release \
       toolset="${boost_toolset}" target-os=android \
-      location="bin/release/android/${abi}"
+      location="bin/release/android/${abi}" \
+      "${page_size_linkflags[@]}"
   )
   "${toolchain}/bin/llvm-strip" --strip-unneeded -x \
     "${source_copy}/swig/bin/release/android/${abi}/libtorrent4j.so"

--- a/tool/release/native_playback_manifest.json
+++ b/tool/release/native_playback_manifest.json
@@ -21,7 +21,7 @@
     {
       "id": "libtorrent4j-core",
       "provider": "TetoTV source build",
-      "version": "2.1.0-38-tetotv.1",
+      "version": "2.1.0-38-tetotv.2",
       "fileName": "libtorrent4j-2.1.0-38.jar",
       "size": 764741,
       "sha256": "cb86224533873de990b24360a8ba26cb66286a0842eac3b4facc58a7370fcf91"
@@ -29,15 +29,15 @@
     {
       "id": "libtorrent4j-android-arm",
       "provider": "TetoTV source build",
-      "version": "2.1.0-38-tetotv.1",
+      "version": "2.1.0-38-tetotv.2",
       "fileName": "libtorrent4j-android-arm-2.1.0-38.jar",
-      "size": 5430366,
-      "sha256": "5a98e854b8f7e338a3746600be5cf22a13055853f88f7894592d62e1681865f6"
+      "size": 5430466,
+      "sha256": "fe32deb93d8bada70c7be15918cb9a31e70261cac87ff66bc81e803eaaf2f75d"
     },
     {
       "id": "libtorrent4j-android-arm64",
       "provider": "TetoTV source build",
-      "version": "2.1.0-38-tetotv.1",
+      "version": "2.1.0-38-tetotv.2",
       "fileName": "libtorrent4j-android-arm64-2.1.0-38.jar",
       "size": 6249560,
       "sha256": "223e27338fb0a9dad9b6a6db6add7ec791c8633698a69e958757571c63e7de23"
@@ -45,7 +45,7 @@
   ],
   "build": {
     "scriptPath": "tool/native/build_native_playback.sh",
-    "scriptSha256": "871db10f90865928a772708e81ee0eb5a9a9c60527bdc160393a193f69750de6",
+    "scriptSha256": "b5913bfb68ee0549268ae8168c913320886f0ef3517dba2df31f97a16b205919",
     "sourceDateEpoch": 1704067200,
     "toolchains": [
       {
@@ -374,11 +374,11 @@
   "apkNativeLibraries": [
     {
       "path": "lib/arm64-v8a/libapp.so",
-      "size": 12190608,
-      "sha256": "6833293a74cb4d5fccec4a2c937240e7559b826906bdcf69438c191cf914350f",
-      "origin": "TetoTV Flutter application AOT 2.0.47",
+      "size": 12256144,
+      "sha256": "f1832ec746df2ac6edf49e4907794b8fb9a46f9ceb1704615bb8ea6b65dc428d",
+      "origin": "TetoTV Flutter application AOT 2.0.48",
       "license": "MIT",
-      "sourceLocator": "Git tag v2.0.47",
+      "sourceLocator": "Git tag v2.0.48",
       "noticeLocator": "LICENSE"
     },
     {
@@ -423,7 +423,7 @@
       "sha256": "dc05f53278b2733094f12aeaed54c080329309762ce49e6de4118e4bfb0fff55",
       "origin": "TetoTV source build of media-kit Android helper at 42054e5d479f39ccbb0ae604862e2bcaf59b74c2",
       "license": "MIT",
-      "sourceLocator": "TetoTV-v2.0.47-native-playback-sources.zip: sources/media-kit-android-helper-42054e5d479f39ccbb0ae604862e2bcaf59b74c2.zip",
+      "sourceLocator": "TetoTV-v2.0.48-native-playback-sources.zip: sources/media-kit-android-helper-42054e5d479f39ccbb0ae604862e2bcaf59b74c2.zip",
       "noticeLocator": "assets/legal/native/MEDIA_KIT_ANDROID_HELPER_LICENSE.txt; assets/legal/native/NATIVE_PLAYBACK_NOTICE.txt"
     },
     {
@@ -432,13 +432,13 @@
       "sha256": "a7399d0be70844e5ee94cc5b1acc1516571113c50561fe0a5d05b49101c53ef2",
       "origin": "TetoTV source build of the pinned mpv and FFmpeg native playback stack",
       "license": "LGPL-3.0-or-later (conservative combined classification) plus component terms",
-      "sourceLocator": "TetoTV-v2.0.47-native-playback-sources.zip and tool/native/build_native_playback.sh",
+      "sourceLocator": "TetoTV-v2.0.48-native-playback-sources.zip and tool/native/build_native_playback.sh",
       "noticeLocator": "assets/legal/native/NATIVE_PLAYBACK_NOTICE.txt and its referenced exact license assets"
     },
     {
       "path": "lib/arm64-v8a/libtetotv_discord.so",
-      "size": 752992,
-      "sha256": "8d2caee054011b042dd16f2265b23c6a20c2609a17ad7d24302fd8dd44493bf6",
+      "size": 764040,
+      "sha256": "dd5407f17d342357ca36ae1f054aaa7d6a4c72aed9e831fce9b3a177a17d7e94",
       "origin": "TetoTV Discord JNI wrapper",
       "license": "MIT for the TetoTV wrapper; Discord Social SDK Terms for the dynamically linked SDK",
       "sourceLocator": "android/app/src/main/cpp",
@@ -450,16 +450,16 @@
       "sha256": "263ba714570fb3acfc308cce52776b00506ec8809d225617e52352336144cfa2",
       "origin": "TetoTV source build of the pinned libtorrent4j and libtorrent-rasterbar stack",
       "license": "Mixed MIT, BSD, Boost-1.0, Apache-2.0, and MPL-2.0 component terms",
-      "sourceLocator": "TetoTV-v2.0.47-native-playback-sources.zip and tool/native/build_native_playback.sh",
+      "sourceLocator": "TetoTV-v2.0.48-native-playback-sources.zip and tool/native/build_native_playback.sh",
       "noticeLocator": "assets/legal/native/DIRECT_TORRENT_NATIVE_NOTICE.txt and its referenced exact license assets"
     },
     {
       "path": "lib/armeabi-v7a/libapp.so",
-      "size": 13320780,
-      "sha256": "8cf1db06551eac7f5911a1ff9eed74ea86d139f5270548053cb915f23b1f7c23",
-      "origin": "TetoTV Flutter application AOT 2.0.47",
+      "size": 13402700,
+      "sha256": "ad9ef662c56d6d3b23e5bc5b5640184596a949c3cdd0c32497118457b2f1081e",
+      "origin": "TetoTV Flutter application AOT 2.0.48",
       "license": "MIT",
-      "sourceLocator": "Git tag v2.0.47",
+      "sourceLocator": "Git tag v2.0.48",
       "noticeLocator": "LICENSE"
     },
     {
@@ -504,7 +504,7 @@
       "sha256": "8820a12e07bb3dc45f5b4286acf6918827fba4c265767e7f1cc8f07215c84b6a",
       "origin": "TetoTV source build of media-kit Android helper at 42054e5d479f39ccbb0ae604862e2bcaf59b74c2",
       "license": "MIT",
-      "sourceLocator": "TetoTV-v2.0.47-native-playback-sources.zip: sources/media-kit-android-helper-42054e5d479f39ccbb0ae604862e2bcaf59b74c2.zip",
+      "sourceLocator": "TetoTV-v2.0.48-native-playback-sources.zip: sources/media-kit-android-helper-42054e5d479f39ccbb0ae604862e2bcaf59b74c2.zip",
       "noticeLocator": "assets/legal/native/MEDIA_KIT_ANDROID_HELPER_LICENSE.txt; assets/legal/native/NATIVE_PLAYBACK_NOTICE.txt"
     },
     {
@@ -513,13 +513,13 @@
       "sha256": "d5a220fdf41edde10f161f86addc846ae9cb18137ea48e4db541cd703fec5092",
       "origin": "TetoTV source build of the pinned mpv and FFmpeg native playback stack",
       "license": "LGPL-3.0-or-later (conservative combined classification) plus component terms",
-      "sourceLocator": "TetoTV-v2.0.47-native-playback-sources.zip and tool/native/build_native_playback.sh",
+      "sourceLocator": "TetoTV-v2.0.48-native-playback-sources.zip and tool/native/build_native_playback.sh",
       "noticeLocator": "assets/legal/native/NATIVE_PLAYBACK_NOTICE.txt and its referenced exact license assets"
     },
     {
       "path": "lib/armeabi-v7a/libtetotv_discord.so",
-      "size": 481224,
-      "sha256": "a2c52aaedfeb41a457f717796bc7df6ea26c709ba2d59187d1365d559bcacd69",
+      "size": 488012,
+      "sha256": "15b9aa642e9f21d73342f90d7b99baba5a8dd63973d1daa0470806dab3e699b6",
       "origin": "TetoTV Discord JNI wrapper",
       "license": "MIT for the TetoTV wrapper; Discord Social SDK Terms for the dynamically linked SDK",
       "sourceLocator": "android/app/src/main/cpp",
@@ -528,10 +528,10 @@
     {
       "path": "lib/armeabi-v7a/libtorrent4j.so",
       "size": 13826612,
-      "sha256": "5e090380a7c1c26c16763d40c7f451bdb4fc2542bc5e1b8a410206f66dea4330",
+      "sha256": "ba0a19d2730969b8e6107db1847888ea8d3b8cafd14a535a3259dd04f8b28d60",
       "origin": "TetoTV source build of the pinned libtorrent4j and libtorrent-rasterbar stack",
       "license": "Mixed MIT, BSD, Boost-1.0, Apache-2.0, and MPL-2.0 component terms",
-      "sourceLocator": "TetoTV-v2.0.47-native-playback-sources.zip and tool/native/build_native_playback.sh",
+      "sourceLocator": "TetoTV-v2.0.48-native-playback-sources.zip and tool/native/build_native_playback.sh",
       "noticeLocator": "assets/legal/native/DIRECT_TORRENT_NATIVE_NOTICE.txt and its referenced exact license assets"
     }
   ],


### PR DESCRIPTION
## Summary

- compact the redesigned Settings UI on televisions while preserving the existing mobile sizing
- make incompatible lower-build release history visible but disabled with Android's exact downgrade limitation
- harden playback failover, provider diagnostics, direct-torrent policy, and Discord Rich Presence lifecycle behavior
- update native redistribution provenance and prepare the signed 2.0.48 Beta release contract

## Verification

- flutter analyze: passed
- flutter test: 1,913 passed, 17 skipped, 0 failed
- Android unit tests: 68 passed
- Android lint: 0 errors
- release APK verification: passed for 2.0.48 (410025), arm64-v8a and armeabi-v7a
- native redistribution verification: passed