### PR TITLE
Prepare TetoTV 2.0.49 Beta release

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 
 <p align="center">
   <a href="https://github.com/LindersOSX/TetoTV-Beta/releases/latest"><strong>Download Beta</strong></a>
-  · <a href="docs/RELEASE_NOTES_2.0.48.md">What's new</a>
+  · <a href="docs/RELEASE_NOTES_2.0.49.md">What's new</a>
   · <a href="https://github.com/LindersOSX/TetoTV-Beta/issues/new">Report an issue</a>
   · <a href="https://discord.gg/juC6k7d4WY">Discord</a>
   · <a href="https://www.youtube.com/@TetoTVApp">YouTube</a>
@@ -85,10 +85,10 @@ TetoTV runs directly on the Android device with no companion server required for
 | Channel | Version | Best for |
 | --- | --- | --- |
 | Public | Not published | Source and release-readiness documents are available, but no Public APK is currently offered |
-| Beta | [2.0.48](docs/RELEASE_NOTES_2.0.48.md) | Testing playback recovery, Discord stability, richer diagnostics, compact TV Settings, and safer release-history compatibility before a separately reviewed Public release |
+| Beta | [2.0.49](docs/RELEASE_NOTES_2.0.49.md) | Testing playback recovery, Discord stability, richer diagnostics, compact TV Settings, and safer release-history compatibility before a separately reviewed Public release |
 
 > [!WARNING]
-> Beta 2.0.48 uses the repository's explicit unreviewed-Beta exception. Its native-library and corresponding-source material did not receive independent license review, and automated integrity checks are not a legal compliance determination. Read the [complete Beta disclosure](docs/RELEASE_NOTES_2.0.48.md). This exception does not apply to a future Public release.
+> Beta 2.0.49 uses the repository's explicit unreviewed-Beta exception. Its native-library and corresponding-source material did not receive independent license review, and automated integrity checks are not a legal compliance determination. Read the [complete Beta disclosure](docs/RELEASE_NOTES_2.0.49.md). This exception does not apply to a future Public release.
 
 The Public updater repository intentionally has no release while the Public build is held for review. Existing Beta installations continue to update from the Beta repository. Android never permits an in-place install of an APK with a lower build code; Developer Mode does not bypass that platform rule.
 

--- a/docs/BUILD_WINDOWS.md
+++ b/docs/BUILD_WINDOWS.md
@@ -220,39 +220,39 @@ APK containing both supported application ABIs.
 Public and Beta updates use anonymous GitHub requests. No Beta key, GitHub
 token, update-proxy URL, or update-specific Dart define is required. Every
 published APK uses the production signing identity. No Public APK is currently
-published. Beta 2.0.48 uses Android build code `410025`. Flutter reuses
+published. Beta 2.0.49 uses Android build code `410026`. Flutter reuses
 `app-release.apk`, so copy and rename the Beta artifact immediately after the
 build:
 
 ```powershell
-New-Item -ItemType Directory -Force .\build\fire-tv\v2.0.48 | Out-Null
+New-Item -ItemType Directory -Force .\build\fire-tv\v2.0.49 | Out-Null
 
-# Beta 2.0.48
+# Beta 2.0.49
 flutter build apk --release --target-platform android-arm,android-arm64 `
-  --build-name 2.0.48 --build-number 410025 --no-tree-shake-icons
+  --build-name 2.0.49 --build-number 410026 --no-tree-shake-icons
 Copy-Item .\build\app\outputs\flutter-apk\app-release.apk `
-  .\build\fire-tv\v2.0.48\TetoTV-v2.0.48-universal.apk
+  .\build\fire-tv\v2.0.49\TetoTV-v2.0.49-universal.apk
 
 .\tool\release\verify_release_apk.ps1 `
   -Channel Beta `
-  -ApkPath .\build\fire-tv\v2.0.48\TetoTV-v2.0.48-universal.apk
+  -ApkPath .\build\fire-tv\v2.0.49\TetoTV-v2.0.49-universal.apk
 
 .\tool\release\verify_native_redistribution.ps1 `
   -RequireResolvedBinaries `
   -ResolvedBinaryDirectory .\build\native-playback\outputs `
-  -StageBundle -ReleaseTag v2.0.48
+  -StageBundle -ReleaseTag v2.0.49
 
 .\tool\release\new_release_checksums.ps1 `
-  -ApkPath .\build\fire-tv\v2.0.48\TetoTV-v2.0.48-universal.apk `
-  -NativeSourcePath .\build\release-compliance\v2.0.48\TetoTV-v2.0.48-native-playback-sources.zip `
-  -OutputPath .\build\fire-tv\v2.0.48\SHA256SUMS
+  -ApkPath .\build\fire-tv\v2.0.49\TetoTV-v2.0.49-universal.apk `
+  -NativeSourcePath .\build\release-compliance\v2.0.49\TetoTV-v2.0.49-native-playback-sources.zip `
+  -OutputPath .\build\fire-tv\v2.0.49\SHA256SUMS
 
 .\tool\release\verify_release_payloads.ps1 `
   -Channel Beta `
-  -ApkPath .\build\fire-tv\v2.0.48\TetoTV-v2.0.48-universal.apk `
-  -NativeSourcePath .\build\release-compliance\v2.0.48\TetoTV-v2.0.48-native-playback-sources.zip `
-  -ChecksumsPath .\build\fire-tv\v2.0.48\SHA256SUMS `
-  -ReleaseNotesPath .\docs\RELEASE_NOTES_2.0.48.md
+  -ApkPath .\build\fire-tv\v2.0.49\TetoTV-v2.0.49-universal.apk `
+  -NativeSourcePath .\build\release-compliance\v2.0.49\TetoTV-v2.0.49-native-playback-sources.zip `
+  -ChecksumsPath .\build\fire-tv\v2.0.49\SHA256SUMS `
+  -ReleaseNotesPath .\docs\RELEASE_NOTES_2.0.49.md
 ```
 
 The final payload check requires all five exact, source-built native JARs

--- a/docs/RELEASE_NOTES_2.0.49.md
+++ b/docs/RELEASE_NOTES_2.0.49.md
@@ -1,0 +1,39 @@
+# TetoTV 2.0.49 Beta
+
+> [!WARNING]
+> No independent native-license review: This Beta has not received independent native-library licensing review. Automated checks verify the APK, native-source bundle, notices, pinned inputs, and checksums, but do not establish legal compliance or reproducible builds.
+
+This Beta focuses on dependable playback recovery, safer Discord Rich Presence lifecycle handling, more useful diagnostics, and a cleaner Settings experience across TVs and phones.
+
+## What's changed
+
+- Settings are reorganized into Appearance, Playback, Services, Accounts, and System so related controls are easier to find without removing existing functionality.
+- The Settings layout uses consistent dark cards, clear pink focus states, responsive two-column TV organization, and a single-column phone presentation.
+- TV Settings controls, cards, tabs, dialogs, and spacing are substantially more compact so more options fit on screen without changing the existing mobile layout.
+- Offline download controls now live with source and media services instead of occupying a separate Settings tab; the Download Manager and every existing download option remain available.
+- Developer release history now keeps lower-build releases visible but clearly disabled, preventing a failed download/install attempt when Android cannot perform an in-place downgrade.
+- Proxied HLS streams receive an appropriate first-frame readiness budget, preventing valid streams that need more than 12 seconds to start from being abandoned prematurely.
+- Automatic fallback advances cleanly past failed direct-stream validation and records each failed candidate once for more useful troubleshooting.
+- Optional HLS metadata inspection is deduplicated, bounded, and concurrent so compatible extensions return usable results sooner.
+- Explicit VOD playlists that omit `#EXT-X-ENDLIST` are safely finalized for playback, while live, event, low-latency, and otherwise mutable playlists remain blocked from an unsafe frozen rewrite.
+- Discord Rich Presence operations are serialized and stale callbacks are invalidated, preventing overlapping activity writes, disconnects, and reconnects from racing the native WebSocket lifecycle.
+- Immediate Discord reconnects now wait for both token readiness and complete socket teardown before opening exactly one replacement connection.
+- Diagnostics retain a larger bounded event window, aggregate repeated technical stream failures, classify interrupted playback sessions, and preserve whether the interruption was native, Java, Flutter, ANR, or another platform failure.
+- Empty GitHub repository-access collections are now interpreted correctly by the fail-closed Beta publisher without weakening checks for actual collaborators, invitations, apps, webhooks, runners, or deploy keys.
+- TetoTV still does not bundle, recommend, or endorse content providers. Users choose and configure their own lawful services and extensions, and the existing source-safety checks remain enforced.
+- Development disclosure: TetoTV includes code created and reviewed with AI-assisted development tools. Releases are tested and maintained by the project owner.
+
+## Release assets
+
+- `TetoTV-v2.0.49-universal.apk`
+- `TetoTV-v2.0.49-native-playback-sources.zip`
+- `SHA256SUMS`
+
+## Beta notes
+
+- This is a Beta-channel build with Android build code `410026`.
+- No Public APK is being published with this release.
+- Skip-button availability still depends on valid timing data from the configured metadata service or TetoTV's validated local cache; TetoTV does not guess unsafe skip points when that service is unavailable.
+- Android does not permit an in-place install over an APK with a higher build code. A future Public counterpart must use build code `410026` or newer for data-preserving channel switching.
+
+<!-- tetotv-android-version-code: 410026 -->

--- a/docs/UPDATE_CHANNELS.md
+++ b/docs/UPDATE_CHANNELS.md
@@ -35,11 +35,11 @@ Beta reads completed 2.x releases from:
 https://api.github.com/repos/LindersOSX/TetoTV-Beta/releases/latest
 ```
 
-The current Beta source build is `v2.0.48` with Android build code `410025`.
+The current Beta source build is `v2.0.49` with Android build code `410026`.
 Its release title is:
 
 ```text
-TetoTV 2.0.48 Beta - Android TV / Google TV / Fire TV
+TetoTV 2.0.49 Beta - Android TV / Google TV / Fire TV
 ```
 
 Publish it as a normal, non-draft, non-prerelease GitHub release so
@@ -72,7 +72,7 @@ proxy.
 Release notes must include the exact asset names and this build-code marker:
 
 ```html
-<!-- tetotv-android-version-code: 410025 -->
+<!-- tetotv-android-version-code: 410026 -->
 ```
 
 When build-code metadata is present, the updater rejects a known lower build
@@ -94,10 +94,10 @@ These rules apply equally on phones, Android TV, Google TV, and Fire TV.
 
 ## Switching and rollback
 
-The current Beta uses build code `410025`. No Public counterpart is available.
+The current Beta uses build code `410026`. No Public counterpart is available.
 An older Public install can move to this Beta when Android accepts the higher
 build code, but it cannot move back in place until a future Public build uses
-code `410025` or higher. Uninstalling first permits an older APK but deletes
+code `410026` or higher. Uninstalling first permits an older APK but deletes
 local application data. Developer Mode and in-app settings cannot override
 this Android rule.
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: 'none'
 # Public and Beta artifacts built from the same source use one monotonically
 # increasing Android versionCode. The project default carries the Beta display
 # version; the Public universal APK overrides the build name to the 1.x line.
-version: 2.0.48+410025
+version: 2.0.49+410026
 
 environment:
   sdk: ^3.12.2

--- a/tool/release/native_playback_manifest.json
+++ b/tool/release/native_playback_manifest.json
@@ -376,9 +376,9 @@
       "path": "lib/arm64-v8a/libapp.so",
       "size": 12256144,
       "sha256": "f1832ec746df2ac6edf49e4907794b8fb9a46f9ceb1704615bb8ea6b65dc428d",
-      "origin": "TetoTV Flutter application AOT 2.0.48",
+      "origin": "TetoTV Flutter application AOT 2.0.49",
       "license": "MIT",
-      "sourceLocator": "Git tag v2.0.48",
+      "sourceLocator": "Git tag v2.0.49",
       "noticeLocator": "LICENSE"
     },
     {
@@ -423,7 +423,7 @@
       "sha256": "dc05f53278b2733094f12aeaed54c080329309762ce49e6de4118e4bfb0fff55",
       "origin": "TetoTV source build of media-kit Android helper at 42054e5d479f39ccbb0ae604862e2bcaf59b74c2",
       "license": "MIT",
-      "sourceLocator": "TetoTV-v2.0.48-native-playback-sources.zip: sources/media-kit-android-helper-42054e5d479f39ccbb0ae604862e2bcaf59b74c2.zip",
+      "sourceLocator": "TetoTV-v2.0.49-native-playback-sources.zip: sources/media-kit-android-helper-42054e5d479f39ccbb0ae604862e2bcaf59b74c2.zip",
       "noticeLocator": "assets/legal/native/MEDIA_KIT_ANDROID_HELPER_LICENSE.txt; assets/legal/native/NATIVE_PLAYBACK_NOTICE.txt"
     },
     {
@@ -432,7 +432,7 @@
       "sha256": "a7399d0be70844e5ee94cc5b1acc1516571113c50561fe0a5d05b49101c53ef2",
       "origin": "TetoTV source build of the pinned mpv and FFmpeg native playback stack",
       "license": "LGPL-3.0-or-later (conservative combined classification) plus component terms",
-      "sourceLocator": "TetoTV-v2.0.48-native-playback-sources.zip and tool/native/build_native_playback.sh",
+      "sourceLocator": "TetoTV-v2.0.49-native-playback-sources.zip and tool/native/build_native_playback.sh",
       "noticeLocator": "assets/legal/native/NATIVE_PLAYBACK_NOTICE.txt and its referenced exact license assets"
     },
     {
@@ -450,16 +450,16 @@
       "sha256": "263ba714570fb3acfc308cce52776b00506ec8809d225617e52352336144cfa2",
       "origin": "TetoTV source build of the pinned libtorrent4j and libtorrent-rasterbar stack",
       "license": "Mixed MIT, BSD, Boost-1.0, Apache-2.0, and MPL-2.0 component terms",
-      "sourceLocator": "TetoTV-v2.0.48-native-playback-sources.zip and tool/native/build_native_playback.sh",
+      "sourceLocator": "TetoTV-v2.0.49-native-playback-sources.zip and tool/native/build_native_playback.sh",
       "noticeLocator": "assets/legal/native/DIRECT_TORRENT_NATIVE_NOTICE.txt and its referenced exact license assets"
     },
     {
       "path": "lib/armeabi-v7a/libapp.so",
       "size": 13402700,
       "sha256": "ad9ef662c56d6d3b23e5bc5b5640184596a949c3cdd0c32497118457b2f1081e",
-      "origin": "TetoTV Flutter application AOT 2.0.48",
+      "origin": "TetoTV Flutter application AOT 2.0.49",
       "license": "MIT",
-      "sourceLocator": "Git tag v2.0.48",
+      "sourceLocator": "Git tag v2.0.49",
       "noticeLocator": "LICENSE"
     },
     {
@@ -504,7 +504,7 @@
       "sha256": "8820a12e07bb3dc45f5b4286acf6918827fba4c265767e7f1cc8f07215c84b6a",
       "origin": "TetoTV source build of media-kit Android helper at 42054e5d479f39ccbb0ae604862e2bcaf59b74c2",
       "license": "MIT",
-      "sourceLocator": "TetoTV-v2.0.48-native-playback-sources.zip: sources/media-kit-android-helper-42054e5d479f39ccbb0ae604862e2bcaf59b74c2.zip",
+      "sourceLocator": "TetoTV-v2.0.49-native-playback-sources.zip: sources/media-kit-android-helper-42054e5d479f39ccbb0ae604862e2bcaf59b74c2.zip",
       "noticeLocator": "assets/legal/native/MEDIA_KIT_ANDROID_HELPER_LICENSE.txt; assets/legal/native/NATIVE_PLAYBACK_NOTICE.txt"
     },
     {
@@ -513,7 +513,7 @@
       "sha256": "d5a220fdf41edde10f161f86addc846ae9cb18137ea48e4db541cd703fec5092",
       "origin": "TetoTV source build of the pinned mpv and FFmpeg native playback stack",
       "license": "LGPL-3.0-or-later (conservative combined classification) plus component terms",
-      "sourceLocator": "TetoTV-v2.0.48-native-playback-sources.zip and tool/native/build_native_playback.sh",
+      "sourceLocator": "TetoTV-v2.0.49-native-playback-sources.zip and tool/native/build_native_playback.sh",
       "noticeLocator": "assets/legal/native/NATIVE_PLAYBACK_NOTICE.txt and its referenced exact license assets"
     },
     {
@@ -531,7 +531,7 @@
       "sha256": "ba0a19d2730969b8e6107db1847888ea8d3b8cafd14a535a3259dd04f8b28d60",
       "origin": "TetoTV source build of the pinned libtorrent4j and libtorrent-rasterbar stack",
       "license": "Mixed MIT, BSD, Boost-1.0, Apache-2.0, and MPL-2.0 component terms",
-      "sourceLocator": "TetoTV-v2.0.48-native-playback-sources.zip and tool/native/build_native_playback.sh",
+      "sourceLocator": "TetoTV-v2.0.49-native-playback-sources.zip and tool/native/build_native_playback.sh",
       "noticeLocator": "assets/legal/native/DIRECT_TORRENT_NATIVE_NOTICE.txt and its referenced exact license assets"
     }
   ],


### PR DESCRIPTION
## Summary

- publish the verified Settings and reliability build as 2.0.49 / Android build 410026
- preserve the protected unpublished 2.0.48 tag instead of weakening tag rules
- bind release docs and native source locators to v2.0.49

## Verification

- release APK verification passed for 2.0.49 (410026), arm64-v8a and armeabi-v7a
- flutter analyze passed
- release policy, native redistribution, TV Settings, and phone layout tests: 20 passed
- v2.0.49 native source bundle verification passed