### PR TITLE
Refine TV Settings spacing for Beta 2.0.50

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 
 <p align="center">
   <a href="https://github.com/LindersOSX/TetoTV-Beta/releases/latest"><strong>Download Beta</strong></a>
-  · <a href="docs/RELEASE_NOTES_2.0.49.md">What's new</a>
+  · <a href="docs/RELEASE_NOTES_2.0.50.md">What's new</a>
   · <a href="https://github.com/LindersOSX/TetoTV-Beta/issues/new">Report an issue</a>
   · <a href="https://discord.gg/juC6k7d4WY">Discord</a>
   · <a href="https://www.youtube.com/@TetoTVApp">YouTube</a>
@@ -85,10 +85,10 @@ TetoTV runs directly on the Android device with no companion server required for
 | Channel | Version | Best for |
 | --- | --- | --- |
 | Public | Not published | Source and release-readiness documents are available, but no Public APK is currently offered |
-| Beta | [2.0.49](docs/RELEASE_NOTES_2.0.49.md) | Testing playback recovery, Discord stability, richer diagnostics, compact TV Settings, and safer release-history compatibility before a separately reviewed Public release |
+| Beta | [2.0.50](docs/RELEASE_NOTES_2.0.50.md) | Testing the evenly packed TV Settings layout while retaining the approved compact sizing and existing phone layout before a separately reviewed Public release |
 
 > [!WARNING]
-> Beta 2.0.49 uses the repository's explicit unreviewed-Beta exception. Its native-library and corresponding-source material did not receive independent license review, and automated integrity checks are not a legal compliance determination. Read the [complete Beta disclosure](docs/RELEASE_NOTES_2.0.49.md). This exception does not apply to a future Public release.
+> Beta 2.0.50 uses the repository's explicit unreviewed-Beta exception. Its native-library and corresponding-source material did not receive independent license review, and automated integrity checks are not a legal compliance determination. Read the [complete Beta disclosure](docs/RELEASE_NOTES_2.0.50.md). This exception does not apply to a future Public release.
 
 The Public updater repository intentionally has no release while the Public build is held for review. Existing Beta installations continue to update from the Beta repository. Android never permits an in-place install of an APK with a lower build code; Developer Mode does not bypass that platform rule.
 

--- a/docs/BUILD_WINDOWS.md
+++ b/docs/BUILD_WINDOWS.md
@@ -220,39 +220,39 @@ APK containing both supported application ABIs.
 Public and Beta updates use anonymous GitHub requests. No Beta key, GitHub
 token, update-proxy URL, or update-specific Dart define is required. Every
 published APK uses the production signing identity. No Public APK is currently
-published. Beta 2.0.49 uses Android build code `410026`. Flutter reuses
+published. Beta 2.0.50 uses Android build code `410027`. Flutter reuses
 `app-release.apk`, so copy and rename the Beta artifact immediately after the
 build:
 
 ```powershell
-New-Item -ItemType Directory -Force .\build\fire-tv\v2.0.49 | Out-Null
+New-Item -ItemType Directory -Force .\build\fire-tv\v2.0.50 | Out-Null
 
-# Beta 2.0.49
+# Beta 2.0.50
 flutter build apk --release --target-platform android-arm,android-arm64 `
-  --build-name 2.0.49 --build-number 410026 --no-tree-shake-icons
+  --build-name 2.0.50 --build-number 410027 --no-tree-shake-icons
 Copy-Item .\build\app\outputs\flutter-apk\app-release.apk `
-  .\build\fire-tv\v2.0.49\TetoTV-v2.0.49-universal.apk
+  .\build\fire-tv\v2.0.50\TetoTV-v2.0.50-universal.apk
 
 .\tool\release\verify_release_apk.ps1 `
   -Channel Beta `
-  -ApkPath .\build\fire-tv\v2.0.49\TetoTV-v2.0.49-universal.apk
+  -ApkPath .\build\fire-tv\v2.0.50\TetoTV-v2.0.50-universal.apk
 
 .\tool\release\verify_native_redistribution.ps1 `
   -RequireResolvedBinaries `
   -ResolvedBinaryDirectory .\build\native-playback\outputs `
-  -StageBundle -ReleaseTag v2.0.49
+  -StageBundle -ReleaseTag v2.0.50
 
 .\tool\release\new_release_checksums.ps1 `
-  -ApkPath .\build\fire-tv\v2.0.49\TetoTV-v2.0.49-universal.apk `
-  -NativeSourcePath .\build\release-compliance\v2.0.49\TetoTV-v2.0.49-native-playback-sources.zip `
-  -OutputPath .\build\fire-tv\v2.0.49\SHA256SUMS
+  -ApkPath .\build\fire-tv\v2.0.50\TetoTV-v2.0.50-universal.apk `
+  -NativeSourcePath .\build\release-compliance\v2.0.50\TetoTV-v2.0.50-native-playback-sources.zip `
+  -OutputPath .\build\fire-tv\v2.0.50\SHA256SUMS
 
 .\tool\release\verify_release_payloads.ps1 `
   -Channel Beta `
-  -ApkPath .\build\fire-tv\v2.0.49\TetoTV-v2.0.49-universal.apk `
-  -NativeSourcePath .\build\release-compliance\v2.0.49\TetoTV-v2.0.49-native-playback-sources.zip `
-  -ChecksumsPath .\build\fire-tv\v2.0.49\SHA256SUMS `
-  -ReleaseNotesPath .\docs\RELEASE_NOTES_2.0.49.md
+  -ApkPath .\build\fire-tv\v2.0.50\TetoTV-v2.0.50-universal.apk `
+  -NativeSourcePath .\build\release-compliance\v2.0.50\TetoTV-v2.0.50-native-playback-sources.zip `
+  -ChecksumsPath .\build\fire-tv\v2.0.50\SHA256SUMS `
+  -ReleaseNotesPath .\docs\RELEASE_NOTES_2.0.50.md
 ```
 
 The final payload check requires all five exact, source-built native JARs

--- a/docs/RELEASE_NOTES_2.0.50.md
+++ b/docs/RELEASE_NOTES_2.0.50.md
@@ -1,0 +1,33 @@
+# TetoTV 2.0.50 Beta
+
+> [!WARNING]
+> No independent native-license review: This Beta has not received independent native-library licensing review. Automated checks verify the APK, native-source bundle, notices, pinned inputs, and checksums, but do not establish legal compliance or reproducible builds.
+
+This Beta refines the compact TV Settings design so the same controls now use the available screen space more evenly, without changing the approved sizing or the phone layout.
+
+## What's changed
+
+- TV Settings tabs now divide the available width evenly with one consistent gap between every category.
+- Settings cards use a consistent compact gutter horizontally and vertically across Appearance, Playback, Services, Accounts, and System.
+- Appearance, Services, Accounts, and System now flow as continuous two-column TV layouts, eliminating large blank lanes caused by unrelated cards sharing rigid rows.
+- Appearance cards size themselves to their actual controls instead of reserving unnecessary empty height.
+- The Settings page no longer leaves a large unused footer below the final TV card.
+- Existing control, text, icon, and card sizing remains unchanged from the previously approved compact design.
+- Phone Settings retain their existing single-column ordering, spacing, and sizing.
+- New layout-contract tests protect the equal tab widths, consistent card gutters, continuous TV card stacks, compact card bounds, and unchanged phone layout.
+- TetoTV still does not bundle, recommend, or endorse content providers. Users choose and configure their own lawful services and extensions, and the existing source-safety checks remain enforced.
+- Development disclosure: TetoTV includes code created and reviewed with AI-assisted development tools. Releases are tested and maintained by the project owner.
+
+## Release assets
+
+- `TetoTV-v2.0.50-universal.apk`
+- `TetoTV-v2.0.50-native-playback-sources.zip`
+- `SHA256SUMS`
+
+## Beta notes
+
+- This is a Beta-channel build with Android build code `410027`.
+- No Public APK is being published with this release.
+- Android does not permit an in-place install over an APK with a higher build code. A future Public counterpart must use build code `410027` or newer for data-preserving channel switching.
+
+<!-- tetotv-android-version-code: 410027 -->

--- a/docs/UPDATE_CHANNELS.md
+++ b/docs/UPDATE_CHANNELS.md
@@ -35,11 +35,11 @@ Beta reads completed 2.x releases from:
 https://api.github.com/repos/LindersOSX/TetoTV-Beta/releases/latest
 ```
 
-The current Beta source build is `v2.0.49` with Android build code `410026`.
+The current Beta source build is `v2.0.50` with Android build code `410027`.
 Its release title is:
 
 ```text
-TetoTV 2.0.49 Beta - Android TV / Google TV / Fire TV
+TetoTV 2.0.50 Beta - Android TV / Google TV / Fire TV
 ```
 
 Publish it as a normal, non-draft, non-prerelease GitHub release so
@@ -72,7 +72,7 @@ proxy.
 Release notes must include the exact asset names and this build-code marker:
 
 ```html
-<!-- tetotv-android-version-code: 410026 -->
+<!-- tetotv-android-version-code: 410027 -->
 ```
 
 When build-code metadata is present, the updater rejects a known lower build
@@ -94,10 +94,10 @@ These rules apply equally on phones, Android TV, Google TV, and Fire TV.
 
 ## Switching and rollback
 
-The current Beta uses build code `410026`. No Public counterpart is available.
+The current Beta uses build code `410027`. No Public counterpart is available.
 An older Public install can move to this Beta when Android accepts the higher
 build code, but it cannot move back in place until a future Public build uses
-code `410026` or higher. Uninstalling first permits an older APK but deletes
+code `410027` or higher. Uninstalling first permits an older APK but deletes
 local application data. Developer Mode and in-app settings cannot override
 this Android rule.
 

--- a/lib/features/settings/presentation/accounts_screen.dart
+++ b/lib/features/settings/presentation/accounts_screen.dart
@@ -1550,6 +1550,218 @@ class _AccountsScreenState extends ConsumerState<AccountsScreen> {
         ],
       ],
     );
+
+    Widget automaticSourceSelectionCard() => _SettingsSectionCard(
+      key: const ValueKey('settings-card-services-autopick'),
+      title: 'Automatic source selection',
+      subtitle:
+          'Prioritize source type, quality, and audio when TetoTV chooses for you.',
+      child: _AutoPickSourcePanel(
+        preferences: preferences,
+        enabledFocusNode: _autoPickEnabledFocus,
+        sourceSectionFocusNode: _autoPickSourceFocus,
+        qualitySectionFocusNode: _autoPickQualityFocus,
+        sourceRowFocusNodes: _autoPickSourceRowFocusNodes,
+        qualityRowFocusNodes: _autoPickQualityRowFocusNodes,
+        sourceExpanded: _expandedAutoPickPrioritySections.contains(
+          _AutoPickPrioritySection.source,
+        ),
+        qualityExpanded: _expandedAutoPickPrioritySections.contains(
+          _AutoPickPrioritySection.quality,
+        ),
+        audioFocusNode: _autoPickAudioFocus,
+        onEnabledChanged: ref
+            .read(settingsPreferencesProvider.notifier)
+            .setAutoPickSourceEnabled,
+        onSourceMoved: ref
+            .read(settingsPreferencesProvider.notifier)
+            .moveAutoPickSourcePriority,
+        onQualityMoved: ref
+            .read(settingsPreferencesProvider.notifier)
+            .moveAutoPickQualityPriority,
+        onSourceExpandedChanged: (expanded) =>
+            _setAutoPickPrioritySectionExpanded(
+              _AutoPickPrioritySection.source,
+              expanded,
+            ),
+        onQualityExpandedChanged: (expanded) =>
+            _setAutoPickPrioritySectionExpanded(
+              _AutoPickPrioritySection.quality,
+              expanded,
+            ),
+        onAudioSelected: ref
+            .read(settingsPreferencesProvider.notifier)
+            .setAutoPickAudio,
+      ),
+    );
+
+    Widget librariesAndFeaturesCard() => _SettingsSectionCard(
+      key: const ValueKey('settings-card-services-features'),
+      title: 'Libraries & features',
+      subtitle: 'Manage local libraries, Watch Party, and offline viewing.',
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          _AppearanceActionRow(
+            label: 'Local, Jellyfin & Plex sources',
+            subtitle:
+                'Connect libraries and add local files that appear in the normal source picker.',
+            value: 'Manage sources',
+            icon: Icons.video_library_outlined,
+            focusNode: _localMediaFocus,
+            showDivider: true,
+            onPressed: () => context.push('/settings/local-media'),
+          ),
+          _AppearanceToggleRow(
+            key: const ValueKey('settings-watch-party-toggle'),
+            label: 'Watch Party',
+            subtitle: preferences.showWatchTogether
+                ? 'Available in navigation, episode actions, and the player.'
+                : 'Hidden from navigation, episode actions, and the player.',
+            icon: Icons.groups_2_outlined,
+            value: preferences.showWatchTogether,
+            focusNode: _watchTogetherFocus,
+            showDivider: true,
+            onChanged: ref
+                .read(settingsPreferencesProvider.notifier)
+                .setShowWatchTogether,
+          ),
+          offlineDownloadsPanel(),
+        ],
+      ),
+    );
+
+    Widget streamingPrivacyCard() => _SettingsSectionCard(
+      key: const ValueKey('settings-card-services-privacy'),
+      title: 'Streaming privacy',
+      subtitle: 'Control privacy-sensitive source and playback behavior.',
+      child: _StreamingPrivacyPanel(preferences: preferences),
+    );
+
+    Widget discordPresenceCard() => _SettingsSectionCard(
+      key: const ValueKey('settings-card-accounts-discord'),
+      title: 'Discord Rich Presence',
+      subtitle: 'Control the optional Discord activity shown while you watch.',
+      child: _DiscordPresencePanel(
+        state: discordPresence,
+        primaryFocusNode: _discordPresenceFocus,
+        unlinkFocusNode: _discordDisconnectFocus,
+        onLink: () async {
+          final resolver = ref.read(discordAccountLinkResolverProvider);
+          final controller = ref.read(
+            discordPresenceControllerProvider.notifier,
+          );
+          final flow = await resolver.resolve(startupTelevision: isTelevision);
+          if (!context.mounted) return;
+          if (flow == DiscordAccountLinkFlow.deviceQr) {
+            await context.push('/pair/discord');
+          } else {
+            final confirmation = await showDiscordMinimumAgeConfirmationDialog(
+              context,
+            );
+            if (confirmation != null) {
+              await controller.linkAccount(confirmation);
+            }
+          }
+        },
+        onToggle: () => ref
+            .read(discordPresenceControllerProvider.notifier)
+            .setEnabled(!discordPresence.enabled),
+        onRetry: () =>
+            ref.read(discordPresenceControllerProvider.notifier).retry(),
+        onUnlink: () => ref
+            .read(discordPresenceControllerProvider.notifier)
+            .unlinkAccount(),
+      ),
+    );
+
+    Widget communityCard() => _SettingsSectionCard(
+      key: const ValueKey('settings-card-system-community'),
+      title: 'Community',
+      subtitle:
+          'Join the TetoTV Discord for announcements, support, and feature requests.',
+      child: _CommunityPanels(
+        discordQrFocusNode: _discordQrFocus,
+        discordFocusNode: _discordFocus,
+        donationQrFocusNode: _donationQrFocus,
+        donationFocusNode: _donateFocus,
+      ),
+    );
+
+    Widget storageAndResetCard() => _SettingsSectionCard(
+      key: const ValueKey('settings-card-system-storage'),
+      title: 'Storage & reset',
+      subtitle: 'Remove temporary files or return TetoTV to first-time setup.',
+      child: _StorageResetPanel(
+        clearCacheFocusNode: _clearCacheFocus,
+        resetAppFocusNode: _resetAppFocus,
+      ),
+    );
+
+    Widget legalNoticesCard() => _SettingsSectionCard(
+      key: const ValueKey('settings-card-system-legal'),
+      title: 'About & legal',
+      subtitle: 'Privacy, attribution, and open-source notices.',
+      child: _LegalNoticesPanel(
+        privacyFocusNode: _privacyFocus,
+        licenseFocusNode: _legalFocus,
+      ),
+    );
+
+    Widget privacyAndDiagnosticsCard() => _SettingsSectionCard(
+      key: const ValueKey('settings-card-system-privacy-diagnostics'),
+      title: 'Privacy & diagnostics',
+      subtitle:
+          'Control optional privacy-safe reporting and Beta activity signals.',
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          _AppearanceToggleRow(
+            key: const ValueKey('settings-anonymous-crash-reports'),
+            label: 'Anonymous crash reports',
+            subtitle:
+                'Send a redacted technical report after an unexpected crash.',
+            icon: Icons.monitor_heart_outlined,
+            value: preferences.anonymousCrashReportingEnabled,
+            focusNode: _anonymousCrashReportingFocus,
+            showDivider: true,
+            onChanged: ref
+                .read(settingsPreferencesProvider.notifier)
+                .setAnonymousCrashReportingEnabled,
+          ),
+          if (showAnonymousUsageCount)
+            _AppearanceToggleRow(
+              key: const ValueKey('settings-anonymous-live-count'),
+              label: 'Anonymous live count',
+              subtitle:
+                  'Include this device in the privacy-safe Beta activity count.',
+              icon: Icons.groups_2_outlined,
+              value: preferences.anonymousUsageCountEnabled,
+              focusNode: _anonymousUsageCountFocus,
+              showDivider: true,
+              onChanged: ref
+                  .read(settingsPreferencesProvider.notifier)
+                  .setAnonymousUsageCountEnabled,
+            ),
+          Padding(
+            padding: EdgeInsets.symmetric(
+              horizontal: _usesTvSettingsScale(context) ? 10 : 13,
+              vertical: _usesTvSettingsScale(context) ? 6 : 11,
+            ),
+            child: Text(
+              'Crash reports are off by default and contain only the app/build, error type and time, Android version, CPU architecture, device class, and a redacted technical trace. They never include a show, episode, account, device ID, source, or URL.'
+              '${showAnonymousUsageCount ? ' The Beta live count shares only whether TetoTV is active or has an MPV player open. It contains no profile or media details; normal HTTPS delivery and short-lived abuse limits may process an IP address, but the presence record does not store it.' : ''}',
+              style: TextStyle(
+                color: context.appPalette.mutedText,
+                fontSize: _usesTvSettingsScale(context) ? 12 : 11,
+                height: 1.35,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+
     return TetoTopLevelShell(
       preferences: preferences,
       activeDestination: TopNavigationDestination.settings,
@@ -1620,7 +1832,7 @@ class _AccountsScreenState extends ConsumerState<AccountsScreen> {
                 padding: EdgeInsets.only(
                   bottom:
                       MediaQuery.viewInsetsOf(context).bottom +
-                      (layout.usesTvRail ? 88 : 24),
+                      (layout.usesTvRail ? 16 : 24),
                 ),
                 children: [
                   if (_activeArea == _SettingsArea.appearance) ...[
@@ -1712,333 +1924,285 @@ class _AccountsScreenState extends ConsumerState<AccountsScreen> {
                       const SizedBox(height: 8),
                     ],
                     _SettingsResponsiveColumns(
-                      left: _SettingsSectionCard(
-                        key: const ValueKey('settings-card-services-debrid'),
-                        title: 'Debrid streaming',
-                        subtitle:
-                            'Choose and securely connect the provider used to resolve streams.',
-                        child: Column(
-                          crossAxisAlignment: CrossAxisAlignment.stretch,
-                          children: [
-                            _SettingsSelection<DebridService>(
-                              focusNode: _debridProviderFocus,
-                              label: 'Debrid provider',
-                              value: preferences.debridProvider,
-                              options: [
-                                for (final service in DebridService.values)
-                                  _SettingsOption(
-                                    value: service,
-                                    label: service.displayName,
-                                    detail:
-                                        switch (service) {
-                                          DebridService.realDebrid =>
-                                            debrid.hasSavedToken,
-                                          DebridService.torBox =>
-                                            torBox.hasSavedToken,
-                                          DebridService.allDebrid =>
-                                            allDebrid.hasSavedToken,
-                                          DebridService.premiumize =>
-                                            premiumize.hasSavedToken,
-                                        }
-                                        ? 'Connected'
-                                        : 'Not connected',
+                      left: _SettingsCardLane(
+                        children: [
+                          _SettingsSectionCard(
+                            key: const ValueKey(
+                              'settings-card-services-debrid',
+                            ),
+                            title: 'Debrid streaming',
+                            subtitle:
+                                'Choose and securely connect the provider used to resolve streams.',
+                            child: Column(
+                              crossAxisAlignment: CrossAxisAlignment.stretch,
+                              children: [
+                                _SettingsSelection<DebridService>(
+                                  focusNode: _debridProviderFocus,
+                                  label: 'Debrid provider',
+                                  value: preferences.debridProvider,
+                                  options: [
+                                    for (final service in DebridService.values)
+                                      _SettingsOption(
+                                        value: service,
+                                        label: service.displayName,
+                                        detail:
+                                            switch (service) {
+                                              DebridService.realDebrid =>
+                                                debrid.hasSavedToken,
+                                              DebridService.torBox =>
+                                                torBox.hasSavedToken,
+                                              DebridService.allDebrid =>
+                                                allDebrid.hasSavedToken,
+                                              DebridService.premiumize =>
+                                                premiumize.hasSavedToken,
+                                            }
+                                            ? 'Connected'
+                                            : 'Not connected',
+                                      ),
+                                  ],
+                                  onSelected: ref
+                                      .read(
+                                        settingsPreferencesProvider.notifier,
+                                      )
+                                      .setDebridProvider,
+                                  showDivider: true,
+                                ),
+                                switch (preferences.debridProvider) {
+                                  DebridService.realDebrid => _RealDebridPanel(
+                                    state: debrid,
+                                    onDisconnect: () => ref
+                                        .read(
+                                          realDebridSettingsControllerProvider
+                                              .notifier,
+                                        )
+                                        .disconnect(),
+                                    onDeviceConnect: () =>
+                                        context.push('/pair/realdebrid'),
+                                    connectFocusNode: _debridConnectFocus,
                                   ),
+                                  DebridService.torBox => _TorBoxPanel(
+                                    state: torBox,
+                                    tokenController: _torBoxTokenController,
+                                    onSave: () async {
+                                      final saved = await ref
+                                          .read(
+                                            torBoxSettingsControllerProvider
+                                                .notifier,
+                                          )
+                                          .saveAndValidate(
+                                            _torBoxTokenController.text,
+                                          );
+                                      if (saved) _torBoxTokenController.clear();
+                                    },
+                                    onDisconnect: () => ref
+                                        .read(
+                                          torBoxSettingsControllerProvider
+                                              .notifier,
+                                        )
+                                        .disconnect(),
+                                    onDeviceConnect: () async {
+                                      await context.push('/pair/torbox');
+                                      await ref
+                                          .read(
+                                            torBoxSettingsControllerProvider
+                                                .notifier,
+                                          )
+                                          .load();
+                                    },
+                                    actionFocusNode: _torBoxActionFocus,
+                                    tokenFocusNode: _torBoxTokenFocus,
+                                    saveFocusNode: _torBoxSaveFocus,
+                                  ),
+                                  DebridService.allDebrid => _ApiKeyDebridPanel(
+                                    title: 'AllDebrid',
+                                    icon: Icons.cloud_sync_rounded,
+                                    gradient: [
+                                      context.appPalette.accent,
+                                      context.appPalette.secondaryAccent,
+                                    ],
+                                    connected: allDebrid.account != null,
+                                    hasSavedToken: allDebrid.hasSavedToken,
+                                    connectedLabel: 'PREMIUM',
+                                    description: allDebrid.account == null
+                                        ? 'Authorize with AllDebrid PIN, or enter a personal API key.'
+                                        : 'Connected as ${allDebrid.account!.username}. '
+                                              'Torrent files resolve through AllDebrid only.',
+                                    errorMessage: allDebrid.errorMessage,
+                                    isLoading: allDebrid.isLoading,
+                                    tokenController: _allDebridTokenController,
+                                    tokenTitle: 'AllDebrid API key',
+                                    keyboardTitle: 'Enter AllDebrid API key',
+                                    connectLabel: 'Connect by PIN',
+                                    connectIcon: Icons.qr_code_rounded,
+                                    onSave: () async {
+                                      final saved = await ref
+                                          .read(
+                                            allDebridSettingsControllerProvider
+                                                .notifier,
+                                          )
+                                          .saveAndValidate(
+                                            _allDebridTokenController.text,
+                                          );
+                                      if (saved) {
+                                        _allDebridTokenController.clear();
+                                      }
+                                    },
+                                    onDisconnect: () => ref
+                                        .read(
+                                          allDebridSettingsControllerProvider
+                                              .notifier,
+                                        )
+                                        .disconnect(),
+                                    onConnect: () async {
+                                      await context.push('/pair/alldebrid');
+                                      await ref
+                                          .read(
+                                            allDebridSettingsControllerProvider
+                                                .notifier,
+                                          )
+                                          .load();
+                                    },
+                                    actionFocusNode: _allDebridActionFocus,
+                                    tokenFocusNode: _allDebridTokenFocus,
+                                    saveFocusNode: _allDebridSaveFocus,
+                                  ),
+                                  DebridService.premiumize => _ApiKeyDebridPanel(
+                                    title: 'Premiumize',
+                                    icon: Icons.cloud_queue_rounded,
+                                    gradient: [
+                                      context.appPalette.secondaryAccent,
+                                      context.appPalette.accentBright,
+                                    ],
+                                    connected: premiumize.account != null,
+                                    hasSavedToken: premiumize.hasSavedToken,
+                                    connectedLabel: 'PREMIUM',
+                                    description: premiumize.account == null
+                                        ? 'Enter the API key from your Premiumize account page.'
+                                        : 'Connected as customer '
+                                              '${premiumize.account!.customerId}. '
+                                              'Torrent files resolve through Premiumize only.',
+                                    errorMessage: premiumize.errorMessage,
+                                    isLoading: premiumize.isLoading,
+                                    tokenController: _premiumizeTokenController,
+                                    tokenTitle: 'Premiumize API key',
+                                    keyboardTitle: 'Enter Premiumize API key',
+                                    connectLabel: 'Connection help',
+                                    connectIcon: Icons.key_rounded,
+                                    onSave: () async {
+                                      final saved = await ref
+                                          .read(
+                                            premiumizeSettingsControllerProvider
+                                                .notifier,
+                                          )
+                                          .saveAndValidate(
+                                            _premiumizeTokenController.text,
+                                          );
+                                      if (saved) {
+                                        _premiumizeTokenController.clear();
+                                      }
+                                    },
+                                    onDisconnect: () => ref
+                                        .read(
+                                          premiumizeSettingsControllerProvider
+                                              .notifier,
+                                        )
+                                        .disconnect(),
+                                    onConnect: () async {
+                                      await context.push('/pair/premiumize');
+                                      await ref
+                                          .read(
+                                            premiumizeSettingsControllerProvider
+                                                .notifier,
+                                          )
+                                          .load();
+                                    },
+                                    actionFocusNode: _premiumizeActionFocus,
+                                    tokenFocusNode: _premiumizeTokenFocus,
+                                    saveFocusNode: _premiumizeSaveFocus,
+                                  ),
+                                },
                               ],
-                              onSelected: ref
-                                  .read(settingsPreferencesProvider.notifier)
-                                  .setDebridProvider,
-                              showDivider: true,
                             ),
-                            switch (preferences.debridProvider) {
-                              DebridService.realDebrid => _RealDebridPanel(
-                                state: debrid,
-                                onDisconnect: () => ref
-                                    .read(
-                                      realDebridSettingsControllerProvider
-                                          .notifier,
-                                    )
-                                    .disconnect(),
-                                onDeviceConnect: () =>
-                                    context.push('/pair/realdebrid'),
-                                connectFocusNode: _debridConnectFocus,
-                              ),
-                              DebridService.torBox => _TorBoxPanel(
-                                state: torBox,
-                                tokenController: _torBoxTokenController,
-                                onSave: () async {
-                                  final saved = await ref
-                                      .read(
-                                        torBoxSettingsControllerProvider
-                                            .notifier,
-                                      )
-                                      .saveAndValidate(
-                                        _torBoxTokenController.text,
-                                      );
-                                  if (saved) _torBoxTokenController.clear();
-                                },
-                                onDisconnect: () => ref
-                                    .read(
-                                      torBoxSettingsControllerProvider.notifier,
-                                    )
-                                    .disconnect(),
-                                onDeviceConnect: () async {
-                                  await context.push('/pair/torbox');
-                                  await ref
-                                      .read(
-                                        torBoxSettingsControllerProvider
-                                            .notifier,
-                                      )
-                                      .load();
-                                },
-                                actionFocusNode: _torBoxActionFocus,
-                                tokenFocusNode: _torBoxTokenFocus,
-                                saveFocusNode: _torBoxSaveFocus,
-                              ),
-                              DebridService.allDebrid => _ApiKeyDebridPanel(
-                                title: 'AllDebrid',
-                                icon: Icons.cloud_sync_rounded,
-                                gradient: [
-                                  context.appPalette.accent,
-                                  context.appPalette.secondaryAccent,
-                                ],
-                                connected: allDebrid.account != null,
-                                hasSavedToken: allDebrid.hasSavedToken,
-                                connectedLabel: 'PREMIUM',
-                                description: allDebrid.account == null
-                                    ? 'Authorize with AllDebrid PIN, or enter a personal API key.'
-                                    : 'Connected as ${allDebrid.account!.username}. '
-                                          'Torrent files resolve through AllDebrid only.',
-                                errorMessage: allDebrid.errorMessage,
-                                isLoading: allDebrid.isLoading,
-                                tokenController: _allDebridTokenController,
-                                tokenTitle: 'AllDebrid API key',
-                                keyboardTitle: 'Enter AllDebrid API key',
-                                connectLabel: 'Connect by PIN',
-                                connectIcon: Icons.qr_code_rounded,
-                                onSave: () async {
-                                  final saved = await ref
-                                      .read(
-                                        allDebridSettingsControllerProvider
-                                            .notifier,
-                                      )
-                                      .saveAndValidate(
-                                        _allDebridTokenController.text,
-                                      );
-                                  if (saved) _allDebridTokenController.clear();
-                                },
-                                onDisconnect: () => ref
-                                    .read(
-                                      allDebridSettingsControllerProvider
-                                          .notifier,
-                                    )
-                                    .disconnect(),
-                                onConnect: () async {
-                                  await context.push('/pair/alldebrid');
-                                  await ref
-                                      .read(
-                                        allDebridSettingsControllerProvider
-                                            .notifier,
-                                      )
-                                      .load();
-                                },
-                                actionFocusNode: _allDebridActionFocus,
-                                tokenFocusNode: _allDebridTokenFocus,
-                                saveFocusNode: _allDebridSaveFocus,
-                              ),
-                              DebridService.premiumize => _ApiKeyDebridPanel(
-                                title: 'Premiumize',
-                                icon: Icons.cloud_queue_rounded,
-                                gradient: [
-                                  context.appPalette.secondaryAccent,
-                                  context.appPalette.accentBright,
-                                ],
-                                connected: premiumize.account != null,
-                                hasSavedToken: premiumize.hasSavedToken,
-                                connectedLabel: 'PREMIUM',
-                                description: premiumize.account == null
-                                    ? 'Enter the API key from your Premiumize account page.'
-                                    : 'Connected as customer '
-                                          '${premiumize.account!.customerId}. '
-                                          'Torrent files resolve through Premiumize only.',
-                                errorMessage: premiumize.errorMessage,
-                                isLoading: premiumize.isLoading,
-                                tokenController: _premiumizeTokenController,
-                                tokenTitle: 'Premiumize API key',
-                                keyboardTitle: 'Enter Premiumize API key',
-                                connectLabel: 'Connection help',
-                                connectIcon: Icons.key_rounded,
-                                onSave: () async {
-                                  final saved = await ref
-                                      .read(
-                                        premiumizeSettingsControllerProvider
-                                            .notifier,
-                                      )
-                                      .saveAndValidate(
-                                        _premiumizeTokenController.text,
-                                      );
-                                  if (saved) _premiumizeTokenController.clear();
-                                },
-                                onDisconnect: () => ref
-                                    .read(
-                                      premiumizeSettingsControllerProvider
-                                          .notifier,
-                                    )
-                                    .disconnect(),
-                                onConnect: () async {
-                                  await context.push('/pair/premiumize');
-                                  await ref
-                                      .read(
-                                        premiumizeSettingsControllerProvider
-                                            .notifier,
-                                      )
-                                      .load();
-                                },
-                                actionFocusNode: _premiumizeActionFocus,
-                                tokenFocusNode: _premiumizeTokenFocus,
-                                saveFocusNode: _premiumizeSaveFocus,
-                              ),
-                            },
-                          ],
-                        ),
+                          ),
+                          if (layout.usesTvRail) automaticSourceSelectionCard(),
+                          if (layout.usesTvRail) librariesAndFeaturesCard(),
+                        ],
                       ),
-                      right: _SettingsSectionCard(
-                        key: const ValueKey('settings-card-services-sources'),
-                        title: 'Sources & stream order',
-                        subtitle:
-                            'Choose which source types are searched and how results are ranked.',
-                        child: Column(
-                          crossAxisAlignment: CrossAxisAlignment.stretch,
-                          children: [
-                            _StreamingSourcesPanel(
-                              preferences: preferences,
-                              debridFocusNode: _debridStreamsFocus,
-                              webFocusNode: _webStreamsFocus,
-                              directTorrentFocusNode: _directTorrentFocus,
-                              marketplaceFocusNode: _marketplaceFocus,
-                              onDebridChanged: ref
-                                  .read(settingsPreferencesProvider.notifier)
-                                  .setDebridStreamsEnabled,
-                              onWebChanged: ref
-                                  .read(settingsPreferencesProvider.notifier)
-                                  .setWebStreamsEnabled,
-                              onDirectTorrentChanged: _setDirectTorrentEnabled,
-                              onMarketplace: () =>
-                                  context.push('/settings/marketplace'),
+                      right: _SettingsCardLane(
+                        children: [
+                          _SettingsSectionCard(
+                            key: const ValueKey(
+                              'settings-card-services-sources',
                             ),
-                            const SizedBox(height: 8),
-                            _StreamRankingPanel(
-                              preferences: preferences,
-                              debridSortFocusNode: _debridSortFocus,
-                              sourcePriorityFocusNode: _sourcePriorityFocus,
-                              webQualityFocusNode: _webQualityFocus,
-                              onDebridSortSelected: ref
-                                  .read(settingsPreferencesProvider.notifier)
-                                  .setDebridStreamSort,
-                              onSourcePrioritySelected: ref
-                                  .read(settingsPreferencesProvider.notifier)
-                                  .setStreamSourcePriority,
-                              onWebQualitySelected: ref
-                                  .read(settingsPreferencesProvider.notifier)
-                                  .setWebStreamQuality,
+                            title: 'Sources & stream order',
+                            subtitle:
+                                'Choose which source types are searched and how results are ranked.',
+                            child: Column(
+                              crossAxisAlignment: CrossAxisAlignment.stretch,
+                              children: [
+                                _StreamingSourcesPanel(
+                                  preferences: preferences,
+                                  debridFocusNode: _debridStreamsFocus,
+                                  webFocusNode: _webStreamsFocus,
+                                  directTorrentFocusNode: _directTorrentFocus,
+                                  marketplaceFocusNode: _marketplaceFocus,
+                                  onDebridChanged: ref
+                                      .read(
+                                        settingsPreferencesProvider.notifier,
+                                      )
+                                      .setDebridStreamsEnabled,
+                                  onWebChanged: ref
+                                      .read(
+                                        settingsPreferencesProvider.notifier,
+                                      )
+                                      .setWebStreamsEnabled,
+                                  onDirectTorrentChanged:
+                                      _setDirectTorrentEnabled,
+                                  onMarketplace: () =>
+                                      context.push('/settings/marketplace'),
+                                ),
+                                const SizedBox(height: 8),
+                                _StreamRankingPanel(
+                                  preferences: preferences,
+                                  debridSortFocusNode: _debridSortFocus,
+                                  sourcePriorityFocusNode: _sourcePriorityFocus,
+                                  webQualityFocusNode: _webQualityFocus,
+                                  onDebridSortSelected: ref
+                                      .read(
+                                        settingsPreferencesProvider.notifier,
+                                      )
+                                      .setDebridStreamSort,
+                                  onSourcePrioritySelected: ref
+                                      .read(
+                                        settingsPreferencesProvider.notifier,
+                                      )
+                                      .setStreamSourcePriority,
+                                  onWebQualitySelected: ref
+                                      .read(
+                                        settingsPreferencesProvider.notifier,
+                                      )
+                                      .setWebStreamQuality,
+                                ),
+                              ],
                             ),
-                          ],
-                        ),
+                          ),
+                          if (layout.usesTvRail) streamingPrivacyCard(),
+                        ],
                       ),
                     ),
-                    const SizedBox(height: 8),
-                    _SettingsSectionCard(
-                      key: const ValueKey('settings-card-services-autopick'),
-                      title: 'Automatic source selection',
-                      subtitle:
-                          'Prioritize source type, quality, and audio when TetoTV chooses for you.',
-                      child: _AutoPickSourcePanel(
-                        preferences: preferences,
-                        enabledFocusNode: _autoPickEnabledFocus,
-                        sourceSectionFocusNode: _autoPickSourceFocus,
-                        qualitySectionFocusNode: _autoPickQualityFocus,
-                        sourceRowFocusNodes: _autoPickSourceRowFocusNodes,
-                        qualityRowFocusNodes: _autoPickQualityRowFocusNodes,
-                        sourceExpanded: _expandedAutoPickPrioritySections
-                            .contains(_AutoPickPrioritySection.source),
-                        qualityExpanded: _expandedAutoPickPrioritySections
-                            .contains(_AutoPickPrioritySection.quality),
-                        audioFocusNode: _autoPickAudioFocus,
-                        onEnabledChanged: ref
-                            .read(settingsPreferencesProvider.notifier)
-                            .setAutoPickSourceEnabled,
-                        onSourceMoved: ref
-                            .read(settingsPreferencesProvider.notifier)
-                            .moveAutoPickSourcePriority,
-                        onQualityMoved: ref
-                            .read(settingsPreferencesProvider.notifier)
-                            .moveAutoPickQualityPriority,
-                        onSourceExpandedChanged: (expanded) =>
-                            _setAutoPickPrioritySectionExpanded(
-                              _AutoPickPrioritySection.source,
-                              expanded,
-                            ),
-                        onQualityExpandedChanged: (expanded) =>
-                            _setAutoPickPrioritySectionExpanded(
-                              _AutoPickPrioritySection.quality,
-                              expanded,
-                            ),
-                        onAudioSelected: ref
-                            .read(settingsPreferencesProvider.notifier)
-                            .setAutoPickAudio,
-                      ),
-                    ),
-                    SizedBox(height: layout.usesTvRail ? 5 : 10),
+                    if (!layout.usesTvRail) ...[
+                      const SizedBox(height: 8),
+                      automaticSourceSelectionCard(),
+                      const SizedBox(height: 10),
+                    ],
                   ],
-                  if (_activeArea == _SettingsArea.services) ...[
+                  if (_activeArea == _SettingsArea.services &&
+                      !layout.usesTvRail) ...[
                     _SettingsResponsiveColumns(
-                      left: _SettingsSectionCard(
-                        key: const ValueKey('settings-card-services-features'),
-                        title: 'Libraries & features',
-                        subtitle:
-                            'Manage local libraries, Watch Party, and offline viewing.',
-                        child: Column(
-                          crossAxisAlignment: CrossAxisAlignment.stretch,
-                          children: [
-                            _AppearanceActionRow(
-                              label: 'Local, Jellyfin & Plex sources',
-                              subtitle:
-                                  'Connect libraries and add local files that appear in the normal source picker.',
-                              value: 'Manage sources',
-                              icon: Icons.video_library_outlined,
-                              focusNode: _localMediaFocus,
-                              showDivider: true,
-                              onPressed: () =>
-                                  context.push('/settings/local-media'),
-                            ),
-                            _AppearanceToggleRow(
-                              key: const ValueKey(
-                                'settings-watch-party-toggle',
-                              ),
-                              label: 'Watch Party',
-                              subtitle: preferences.showWatchTogether
-                                  ? 'Available in navigation, episode actions, and the player.'
-                                  : 'Hidden from navigation, episode actions, and the player.',
-                              icon: Icons.groups_2_outlined,
-                              value: preferences.showWatchTogether,
-                              focusNode: _watchTogetherFocus,
-                              showDivider: true,
-                              onChanged: ref
-                                  .read(settingsPreferencesProvider.notifier)
-                                  .setShowWatchTogether,
-                            ),
-                            offlineDownloadsPanel(),
-                          ],
-                        ),
-                      ),
-                      right: _SettingsSectionCard(
-                        key: const ValueKey('settings-card-services-privacy'),
-                        title: 'Streaming privacy',
-                        subtitle:
-                            'Control privacy-sensitive source and playback behavior.',
-                        child: _StreamingPrivacyPanel(preferences: preferences),
-                      ),
+                      left: librariesAndFeaturesCard(),
+                      right: streamingPrivacyCard(),
                     ),
-                    SizedBox(height: layout.usesTvRail ? 5 : 10),
+                    const SizedBox(height: 10),
                   ],
                   if (_activeArea == _SettingsArea.accounts) ...[
                     if (!layout.usesTvRail) ...[
@@ -2051,8 +2215,7 @@ class _AccountsScreenState extends ConsumerState<AccountsScreen> {
                       const SizedBox(height: 8),
                     ],
                     _SettingsResponsiveColumns(
-                      left: Column(
-                        crossAxisAlignment: CrossAxisAlignment.stretch,
+                      left: _SettingsCardLane(
                         children: [
                           _SettingsSectionCard(
                             key: const ValueKey(
@@ -2151,7 +2314,6 @@ class _AccountsScreenState extends ConsumerState<AccountsScreen> {
                               ],
                             ),
                           ),
-                          const SizedBox(height: 8),
                           _SettingsSectionCard(
                             key: const ValueKey(
                               'settings-card-accounts-profiles',
@@ -2166,73 +2328,88 @@ class _AccountsScreenState extends ConsumerState<AccountsScreen> {
                           ),
                         ],
                       ),
-                      right: _SettingsSectionCard(
-                        key: const ValueKey('settings-card-accounts-behavior'),
-                        title: 'Progress & notifications',
-                        subtitle:
-                            'Choose when progress syncs and which episode alerts appear.',
-                        child: Column(
-                          crossAxisAlignment: CrossAxisAlignment.stretch,
-                          children: [
-                            _SettingsSelection<TrackerUpdateThreshold>(
-                              key: const ValueKey(
-                                'settings-tracking-update-threshold',
-                              ),
-                              focusNode: _trackingThresholdFocus,
-                              label: 'When to update episode progress',
-                              value: preferences.trackerUpdateThreshold,
-                              options: [
-                                for (final threshold
-                                    in TrackerUpdateThreshold.values)
-                                  _SettingsOption(
-                                    value: threshold,
-                                    label: threshold.displayName,
-                                    detail: threshold.description,
+                      right: _SettingsCardLane(
+                        children: [
+                          _SettingsSectionCard(
+                            key: const ValueKey(
+                              'settings-card-accounts-behavior',
+                            ),
+                            title: 'Progress & notifications',
+                            subtitle:
+                                'Choose when progress syncs and which episode alerts appear.',
+                            child: Column(
+                              crossAxisAlignment: CrossAxisAlignment.stretch,
+                              children: [
+                                _SettingsSelection<TrackerUpdateThreshold>(
+                                  key: const ValueKey(
+                                    'settings-tracking-update-threshold',
                                   ),
+                                  focusNode: _trackingThresholdFocus,
+                                  label: 'When to update episode progress',
+                                  value: preferences.trackerUpdateThreshold,
+                                  options: [
+                                    for (final threshold
+                                        in TrackerUpdateThreshold.values)
+                                      _SettingsOption(
+                                        value: threshold,
+                                        label: threshold.displayName,
+                                        detail: threshold.description,
+                                      ),
+                                  ],
+                                  onSelected: ref
+                                      .read(
+                                        settingsPreferencesProvider.notifier,
+                                      )
+                                      .setTrackerUpdateThreshold,
+                                  showDivider: true,
+                                ),
+                                const _SettingsSupportingText(
+                                  'Trackers store whole completed episodes, so the '
+                                  'selected percentage marks the current episode watched.',
+                                ),
+                                _AppearanceToggleRow(
+                                  key: const ValueKey(
+                                    'settings-sub-episode-notifications',
+                                  ),
+                                  label: 'Sub & simulcast alerts',
+                                  subtitle:
+                                      'Notify when a subtitled or simulcast episode reaches its normal airtime.',
+                                  icon: Icons.subtitles_outlined,
+                                  value: preferences
+                                      .subEpisodeNotificationsEnabled,
+                                  focusNode: _subEpisodeNotificationsFocus,
+                                  showDivider: true,
+                                  onChanged: ref
+                                      .read(
+                                        settingsPreferencesProvider.notifier,
+                                      )
+                                      .setSubEpisodeNotificationsEnabled,
+                                ),
+                                _AppearanceToggleRow(
+                                  key: const ValueKey(
+                                    'settings-dub-episode-notifications',
+                                  ),
+                                  label: 'Verified dub alerts',
+                                  subtitle:
+                                      'Notify only when a dubbed episode has a verified release schedule.',
+                                  icon: Icons.record_voice_over_outlined,
+                                  value: preferences
+                                      .dubEpisodeNotificationsEnabled,
+                                  focusNode: _dubEpisodeNotificationsFocus,
+                                  onChanged: ref
+                                      .read(
+                                        settingsPreferencesProvider.notifier,
+                                      )
+                                      .setDubEpisodeNotificationsEnabled,
+                                ),
                               ],
-                              onSelected: ref
-                                  .read(settingsPreferencesProvider.notifier)
-                                  .setTrackerUpdateThreshold,
-                              showDivider: true,
                             ),
-                            const _SettingsSupportingText(
-                              'Trackers store whole completed episodes, so the '
-                              'selected percentage marks the current episode watched.',
-                            ),
-                            _AppearanceToggleRow(
-                              key: const ValueKey(
-                                'settings-sub-episode-notifications',
-                              ),
-                              label: 'Sub & simulcast alerts',
-                              subtitle:
-                                  'Notify when a subtitled or simulcast episode reaches its normal airtime.',
-                              icon: Icons.subtitles_outlined,
-                              value: preferences.subEpisodeNotificationsEnabled,
-                              focusNode: _subEpisodeNotificationsFocus,
-                              showDivider: true,
-                              onChanged: ref
-                                  .read(settingsPreferencesProvider.notifier)
-                                  .setSubEpisodeNotificationsEnabled,
-                            ),
-                            _AppearanceToggleRow(
-                              key: const ValueKey(
-                                'settings-dub-episode-notifications',
-                              ),
-                              label: 'Verified dub alerts',
-                              subtitle:
-                                  'Notify only when a dubbed episode has a verified release schedule.',
-                              icon: Icons.record_voice_over_outlined,
-                              value: preferences.dubEpisodeNotificationsEnabled,
-                              focusNode: _dubEpisodeNotificationsFocus,
-                              onChanged: ref
-                                  .read(settingsPreferencesProvider.notifier)
-                                  .setDubEpisodeNotificationsEnabled,
-                            ),
-                          ],
-                        ),
+                          ),
+                          if (layout.usesTvRail) discordPresenceCard(),
+                        ],
                       ),
                     ),
-                    const SizedBox(height: 10),
+                    if (!layout.usesTvRail) const SizedBox(height: 10),
                   ],
                   if (_activeArea == _SettingsArea.system) ...[
                     if (!layout.usesTvRail) ...[
@@ -2245,8 +2422,7 @@ class _AccountsScreenState extends ConsumerState<AccountsScreen> {
                       const SizedBox(height: 8),
                     ],
                     _SettingsResponsiveColumns(
-                      left: Column(
-                        crossAxisAlignment: CrossAxisAlignment.stretch,
+                      left: _SettingsCardLane(
                         children: [
                           _SettingsSectionCard(
                             key: const ValueKey('settings-card-system-support'),
@@ -2286,10 +2462,11 @@ class _AccountsScreenState extends ConsumerState<AccountsScreen> {
                               ],
                             ),
                           ),
+                          if (layout.usesTvRail) communityCard(),
+                          if (layout.usesTvRail) privacyAndDiagnosticsCard(),
                         ],
                       ),
-                      right: Column(
-                        crossAxisAlignment: CrossAxisAlignment.stretch,
+                      right: _SettingsCardLane(
                         children: [
                           _SettingsSectionCard(
                             key: const ValueKey('settings-card-system-updates'),
@@ -2347,174 +2524,30 @@ class _AccountsScreenState extends ConsumerState<AccountsScreen> {
                               ],
                             ),
                           ),
+                          if (layout.usesTvRail) storageAndResetCard(),
+                          if (layout.usesTvRail) legalNoticesCard(),
                         ],
                       ),
                     ),
-                    SizedBox(height: layout.usesTvRail ? 6 : 12),
+                    if (!layout.usesTvRail) const SizedBox(height: 12),
                   ],
-                  if (_activeArea == _SettingsArea.accounts) ...[
-                    _SettingsSectionCard(
-                      key: const ValueKey('settings-card-accounts-discord'),
-                      title: 'Discord Rich Presence',
-                      subtitle:
-                          'Control the optional Discord activity shown while you watch.',
-                      child: _DiscordPresencePanel(
-                        state: discordPresence,
-                        primaryFocusNode: _discordPresenceFocus,
-                        unlinkFocusNode: _discordDisconnectFocus,
-                        onLink: () async {
-                          final resolver = ref.read(
-                            discordAccountLinkResolverProvider,
-                          );
-                          final controller = ref.read(
-                            discordPresenceControllerProvider.notifier,
-                          );
-                          final flow = await resolver.resolve(
-                            startupTelevision: isTelevision,
-                          );
-                          if (!context.mounted) return;
-                          if (flow == DiscordAccountLinkFlow.deviceQr) {
-                            await context.push('/pair/discord');
-                          } else {
-                            final confirmation =
-                                await showDiscordMinimumAgeConfirmationDialog(
-                                  context,
-                                );
-                            if (confirmation != null) {
-                              await controller.linkAccount(confirmation);
-                            }
-                          }
-                        },
-                        onToggle: () => ref
-                            .read(discordPresenceControllerProvider.notifier)
-                            .setEnabled(!discordPresence.enabled),
-                        onRetry: () => ref
-                            .read(discordPresenceControllerProvider.notifier)
-                            .retry(),
-                        onUnlink: () => ref
-                            .read(discordPresenceControllerProvider.notifier)
-                            .unlinkAccount(),
-                      ),
-                    ),
-                    SizedBox(height: layout.usesTvRail ? 6 : 12),
+                  if (_activeArea == _SettingsArea.accounts &&
+                      !layout.usesTvRail) ...[
+                    discordPresenceCard(),
+                    const SizedBox(height: 12),
                   ],
-                  if (_activeArea == _SettingsArea.system) ...[
+                  if (_activeArea == _SettingsArea.system &&
+                      !layout.usesTvRail) ...[
                     _SettingsResponsiveColumns(
-                      left: Column(
-                        crossAxisAlignment: CrossAxisAlignment.stretch,
-                        children: [
-                          _SettingsSectionCard(
-                            key: const ValueKey(
-                              'settings-card-system-community',
-                            ),
-                            title: 'Community',
-                            subtitle:
-                                'Join the TetoTV Discord for announcements, support, and feature requests.',
-                            child: _CommunityPanels(
-                              discordQrFocusNode: _discordQrFocus,
-                              discordFocusNode: _discordFocus,
-                              donationQrFocusNode: _donationQrFocus,
-                              donationFocusNode: _donateFocus,
-                            ),
-                          ),
-                        ],
-                      ),
+                      left: communityCard(),
                       right: Column(
                         crossAxisAlignment: CrossAxisAlignment.stretch,
                         children: [
-                          _SettingsSectionCard(
-                            key: const ValueKey('settings-card-system-storage'),
-                            title: 'Storage & reset',
-                            subtitle:
-                                'Remove temporary files or return TetoTV to first-time setup.',
-                            child: _StorageResetPanel(
-                              clearCacheFocusNode: _clearCacheFocus,
-                              resetAppFocusNode: _resetAppFocus,
-                            ),
-                          ),
-                          SizedBox(height: layout.usesTvRail ? 6 : 12),
-                          _SettingsSectionCard(
-                            key: const ValueKey('settings-card-system-legal'),
-                            title: 'About & legal',
-                            subtitle:
-                                'Privacy, attribution, and open-source notices.',
-                            child: _LegalNoticesPanel(
-                              privacyFocusNode: _privacyFocus,
-                              licenseFocusNode: _legalFocus,
-                            ),
-                          ),
-                          SizedBox(height: layout.usesTvRail ? 6 : 12),
-                          _SettingsSectionCard(
-                            key: const ValueKey(
-                              'settings-card-system-privacy-diagnostics',
-                            ),
-                            title: 'Privacy & diagnostics',
-                            subtitle:
-                                'Control optional privacy-safe reporting and Beta activity signals.',
-                            child: Column(
-                              crossAxisAlignment: CrossAxisAlignment.stretch,
-                              children: [
-                                _AppearanceToggleRow(
-                                  key: const ValueKey(
-                                    'settings-anonymous-crash-reports',
-                                  ),
-                                  label: 'Anonymous crash reports',
-                                  subtitle:
-                                      'Send a redacted technical report after an unexpected crash.',
-                                  icon: Icons.monitor_heart_outlined,
-                                  value: preferences
-                                      .anonymousCrashReportingEnabled,
-                                  focusNode: _anonymousCrashReportingFocus,
-                                  showDivider: true,
-                                  onChanged: ref
-                                      .read(
-                                        settingsPreferencesProvider.notifier,
-                                      )
-                                      .setAnonymousCrashReportingEnabled,
-                                ),
-                                if (showAnonymousUsageCount)
-                                  _AppearanceToggleRow(
-                                    key: const ValueKey(
-                                      'settings-anonymous-live-count',
-                                    ),
-                                    label: 'Anonymous live count',
-                                    subtitle:
-                                        'Include this device in the privacy-safe Beta activity count.',
-                                    icon: Icons.groups_2_outlined,
-                                    value:
-                                        preferences.anonymousUsageCountEnabled,
-                                    focusNode: _anonymousUsageCountFocus,
-                                    showDivider: true,
-                                    onChanged: ref
-                                        .read(
-                                          settingsPreferencesProvider.notifier,
-                                        )
-                                        .setAnonymousUsageCountEnabled,
-                                  ),
-                                Padding(
-                                  padding: EdgeInsets.symmetric(
-                                    horizontal: _usesTvSettingsScale(context)
-                                        ? 10
-                                        : 13,
-                                    vertical: _usesTvSettingsScale(context)
-                                        ? 6
-                                        : 11,
-                                  ),
-                                  child: Text(
-                                    'Crash reports are off by default and contain only the app/build, error type and time, Android version, CPU architecture, device class, and a redacted technical trace. They never include a show, episode, account, device ID, source, or URL.'
-                                    '${showAnonymousUsageCount ? ' The Beta live count shares only whether TetoTV is active or has an MPV player open. It contains no profile or media details; normal HTTPS delivery and short-lived abuse limits may process an IP address, but the presence record does not store it.' : ''}',
-                                    style: TextStyle(
-                                      color: context.appPalette.mutedText,
-                                      fontSize: _usesTvSettingsScale(context)
-                                          ? 12
-                                          : 11,
-                                      height: 1.35,
-                                    ),
-                                  ),
-                                ),
-                              ],
-                            ),
-                          ),
+                          storageAndResetCard(),
+                          const SizedBox(height: 12),
+                          legalNoticesCard(),
+                          const SizedBox(height: 12),
+                          privacyAndDiagnosticsCard(),
                         ],
                       ),
                     ),
@@ -2622,8 +2655,27 @@ class _SettingsAreaTabs extends StatelessWidget {
             ),
           );
         }
+        if (tvScale) {
+          return SizedBox(
+            height: 38,
+            child: Row(
+              children: [
+                for (
+                  var index = 0;
+                  index < _SettingsArea.values.length;
+                  index++
+                ) ...[
+                  if (index > 0) const SizedBox(width: 8),
+                  Expanded(
+                    child: tab(_SettingsArea.values[index], compact: false),
+                  ),
+                ],
+              ],
+            ),
+          );
+        }
         return SizedBox(
-          height: tvScale ? 38 : 52,
+          height: 52,
           child: ListView.separated(
             scrollDirection: Axis.horizontal,
             padding: const EdgeInsets.symmetric(horizontal: 2),
@@ -2667,11 +2719,28 @@ class _SettingsResponsiveColumns extends StatelessWidget {
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
           Expanded(flex: leftFlex, child: left),
-          SizedBox(width: _usesTvSettingsScale(context) ? gap / 2 : gap),
+          SizedBox(width: _usesTvSettingsScale(context) ? 8 : gap),
           Expanded(flex: rightFlex, child: right),
         ],
       );
     },
+  );
+}
+
+class _SettingsCardLane extends StatelessWidget {
+  const _SettingsCardLane({required this.children});
+
+  final List<Widget> children;
+
+  @override
+  Widget build(BuildContext context) => Column(
+    crossAxisAlignment: CrossAxisAlignment.stretch,
+    children: [
+      for (var index = 0; index < children.length; index++) ...[
+        if (index > 0) const SizedBox(height: 8),
+        children[index],
+      ],
+    ],
   );
 }
 
@@ -2697,46 +2766,41 @@ class _SettingsCardFrame extends StatelessWidget {
     required this.title,
     required this.child,
     this.subtitle,
-    this.minimumHeight,
   });
 
   final String title;
   final String? subtitle;
-  final double? minimumHeight;
   final Widget child;
 
   @override
   Widget build(BuildContext context) {
     final tvScale = _usesTvSettingsScale(context);
     return _Panel(
-      child: ConstrainedBox(
-        constraints: BoxConstraints(minHeight: minimumHeight ?? 0),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            _AppearanceCardTitle(title),
-            if (subtitle case final detail?) ...[
-              SizedBox(height: tvScale ? 2 : 4),
-              Text(
-                detail,
-                style: TextStyle(
-                  color: context.appPalette.mutedText,
-                  fontSize: tvScale ? 11 : 11,
-                  height: 1.3,
-                ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          _AppearanceCardTitle(title),
+          if (subtitle case final detail?) ...[
+            SizedBox(height: tvScale ? 2 : 4),
+            Text(
+              detail,
+              style: TextStyle(
+                color: context.appPalette.mutedText,
+                fontSize: tvScale ? 11 : 11,
+                height: 1.3,
               ),
-            ],
-            SizedBox(height: tvScale ? 5 : 10),
-            DecoratedBox(
-              decoration: BoxDecoration(
-                color: context.appPalette.surface.withValues(alpha: .35),
-                borderRadius: BorderRadius.circular(8),
-                border: Border.all(color: _settingsBorderColor(context, .14)),
-              ),
-              child: _SettingsCardScope(child: child),
             ),
           ],
-        ),
+          SizedBox(height: tvScale ? 5 : 10),
+          DecoratedBox(
+            decoration: BoxDecoration(
+              color: context.appPalette.surface.withValues(alpha: .35),
+              borderRadius: BorderRadius.circular(8),
+              border: Border.all(color: _settingsBorderColor(context, .14)),
+            ),
+            child: _SettingsCardScope(child: child),
+          ),
+        ],
       ),
     );
   }
@@ -2832,7 +2896,6 @@ class _AppearanceSettingsLayout extends StatelessWidget {
     final themeAndDisplay = _AppearanceCard(
       key: const ValueKey('appearance-theme-display-card'),
       title: 'Theme & display',
-      minimumHeight: usesTvDashboard ? 188 : null,
       children: [
         _AppearanceActionRow(
           key: const ValueKey('open-theme-studio'),
@@ -2877,7 +2940,6 @@ class _AppearanceSettingsLayout extends StatelessWidget {
     final navigation = _AppearanceCard(
       key: const ValueKey('appearance-navigation-card'),
       title: 'Navigation',
-      minimumHeight: usesTvDashboard ? 188 : null,
       children: [
         _AppearanceSelectionRow<NavigationChromeSize>(
           key: const ValueKey('settings-appearance-navigation-size'),
@@ -2917,7 +2979,6 @@ class _AppearanceSettingsLayout extends StatelessWidget {
     final homeScreen = _AppearanceCard(
       key: const ValueKey('appearance-home-screen-card'),
       title: 'Home screen',
-      minimumHeight: usesTvDashboard ? 386 : null,
       children: [
         _AppearanceToggleRow(
           key: const ValueKey('settings-appearance-featured-hero'),
@@ -3106,33 +3167,42 @@ class _AppearanceSettingsLayout extends StatelessWidget {
       ],
     );
 
+    if (usesTvDashboard) {
+      return _SettingsResponsiveColumns(
+        leftFlex: 51,
+        rightFlex: 49,
+        left: _SettingsCardLane(
+          children: [themeAndDisplay, navigation, homeShelvesPanel],
+        ),
+        right: _SettingsCardLane(
+          children: [homeScreen, displayOptions, inputAndFeedback],
+        ),
+      );
+    }
+
     return Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
         _SettingsResponsiveColumns(
           leftFlex: 51,
           rightFlex: 49,
-          gap: usesTvDashboard ? 10 : 20,
+          gap: 20,
           left: Column(
             crossAxisAlignment: CrossAxisAlignment.stretch,
-            children: [
-              themeAndDisplay,
-              SizedBox(height: usesTvDashboard ? 8 : 18),
-              navigation,
-            ],
+            children: [themeAndDisplay, const SizedBox(height: 18), navigation],
           ),
           right: homeScreen,
         ),
-        SizedBox(height: usesTvDashboard ? 6 : 12),
+        const SizedBox(height: 12),
         _SettingsResponsiveColumns(
           leftFlex: 51,
           rightFlex: 49,
-          gap: usesTvDashboard ? 10 : 20,
+          gap: 20,
           left: Column(
             crossAxisAlignment: CrossAxisAlignment.stretch,
             children: [
               displayOptions,
-              SizedBox(height: usesTvDashboard ? 6 : 12),
+              const SizedBox(height: 12),
               inputAndFeedback,
             ],
           ),
@@ -3148,20 +3218,17 @@ class _AppearanceCard extends StatelessWidget {
     required this.title,
     required this.children,
     this.subtitle,
-    this.minimumHeight,
     super.key,
   });
 
   final String title;
   final String? subtitle;
   final List<Widget> children;
-  final double? minimumHeight;
 
   @override
   Widget build(BuildContext context) => _SettingsCardFrame(
     title: title,
     subtitle: subtitle,
-    minimumHeight: minimumHeight,
     child: Column(children: children),
   );
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: 'none'
 # Public and Beta artifacts built from the same source use one monotonically
 # increasing Android versionCode. The project default carries the Beta display
 # version; the Public universal APK overrides the build name to the 1.x line.
-version: 2.0.49+410026
+version: 2.0.50+410027
 
 environment:
   sdk: ^3.12.2

--- a/test/settings_restyle_contract_test.dart
+++ b/test/settings_restyle_contract_test.dart
@@ -38,6 +38,18 @@ void main() {
     await tester.pumpAndSettle();
   }
 
+  Finder settingsCard(String key) =>
+      find.byKey(ValueKey(key), skipOffstage: false);
+
+  Rect cardRect(WidgetTester tester, String key) =>
+      tester.getRect(settingsCard(key));
+
+  double verticalGap(WidgetTester tester, String upper, String lower) =>
+      cardRect(tester, lower).top - cardRect(tester, upper).bottom;
+
+  double horizontalGap(WidgetTester tester, String left, String right) =>
+      cardRect(tester, right).left - cardRect(tester, left).right;
+
   testWidgets('all five Settings tabs expose the restyled card contract', (
     tester,
   ) async {
@@ -251,6 +263,149 @@ void main() {
     }
   });
 
+  testWidgets('TV Settings use one consistent card gutter across every area', (
+    tester,
+  ) async {
+    await pumpSettings(tester);
+
+    const pairs = <String, (String, String)>{
+      'appearance': (
+        'appearance-theme-display-card',
+        'appearance-home-screen-card',
+      ),
+      'playback': (
+        'settings-card-playback-captions',
+        'settings-card-playback-player',
+      ),
+      'services': (
+        'settings-card-services-debrid',
+        'settings-card-services-sources',
+      ),
+      'accounts': (
+        'settings-card-accounts-tracking',
+        'settings-card-accounts-behavior',
+      ),
+      'system': (
+        'settings-card-system-support',
+        'settings-card-system-updates',
+      ),
+    };
+
+    for (final entry in pairs.entries) {
+      await selectArea(tester, entry.key);
+      final left = cardRect(tester, entry.value.$1);
+      final right = cardRect(tester, entry.value.$2);
+      expect(
+        (left.top - right.top).abs(),
+        lessThanOrEqualTo(1),
+        reason: '${entry.key} columns must start on the same baseline.',
+      );
+      expect(
+        horizontalGap(tester, entry.value.$1, entry.value.$2),
+        closeTo(8, 1),
+        reason: '${entry.key} must use the shared TV card gutter.',
+      );
+    }
+
+    final tabRects = [
+      for (final area in const [
+        'appearance',
+        'playback',
+        'services',
+        'accounts',
+        'system',
+      ])
+        tester.getRect(find.byKey(ValueKey('settings-area-$area'))),
+    ];
+    for (var index = 1; index < tabRects.length; index++) {
+      expect(tabRects[index].width, closeTo(tabRects.first.width, 1));
+      expect(tabRects[index].left - tabRects[index - 1].right, closeTo(8, 1));
+    }
+  });
+
+  testWidgets('TV Settings stack cards continuously in each visual column', (
+    tester,
+  ) async {
+    await pumpSettings(tester);
+
+    const columnsByArea = <String, List<List<String>>>{
+      'appearance': [
+        [
+          'appearance-theme-display-card',
+          'appearance-navigation-card',
+          'appearance-home-shelves-card',
+        ],
+        [
+          'appearance-home-screen-card',
+          'appearance-display-options-card',
+          'appearance-input-feedback-card',
+        ],
+      ],
+      'services': [
+        [
+          'settings-card-services-debrid',
+          'settings-card-services-autopick',
+          'settings-card-services-features',
+        ],
+        ['settings-card-services-sources', 'settings-card-services-privacy'],
+      ],
+      'accounts': [
+        ['settings-card-accounts-tracking', 'settings-card-accounts-profiles'],
+        ['settings-card-accounts-behavior', 'settings-card-accounts-discord'],
+      ],
+      'system': [
+        [
+          'settings-card-system-support',
+          'settings-card-system-community',
+          'settings-card-system-privacy-diagnostics',
+        ],
+        [
+          'settings-card-system-updates',
+          'settings-card-system-storage',
+          'settings-card-system-legal',
+        ],
+      ],
+    };
+
+    for (final entry in columnsByArea.entries) {
+      await selectArea(tester, entry.key);
+      for (final column in entry.value) {
+        for (var index = 1; index < column.length; index++) {
+          final previous = cardRect(tester, column[index - 1]);
+          final current = cardRect(tester, column[index]);
+          expect((current.left - previous.left).abs(), lessThanOrEqualTo(1));
+          expect((current.width - previous.width).abs(), lessThanOrEqualTo(1));
+          expect(
+            verticalGap(tester, column[index - 1], column[index]),
+            closeTo(8, 1),
+            reason: '${entry.key} cards must stack without a blank lane.',
+          );
+        }
+      }
+    }
+  });
+
+  testWidgets('TV Appearance cards hug their final controls', (tester) async {
+    await pumpSettings(tester);
+
+    const finalRows = <String, String>{
+      'appearance-theme-display-card': 'settings-appearance-show-title-style',
+      'appearance-navigation-card': 'settings-appearance-reset',
+      'appearance-home-screen-card': 'settings-appearance-continue-watching',
+    };
+    for (final entry in finalRows.entries) {
+      final card = cardRect(tester, entry.key);
+      final finalRow = tester.getRect(
+        find.byKey(ValueKey(entry.value), skipOffstage: false),
+      );
+      expect(
+        card.bottom - finalRow.bottom,
+        inInclusiveRange(6, 16),
+        reason: '${entry.key} must not reserve unused TV height.',
+      );
+    }
+  });
+
   testWidgets('mobile Settings retain their existing control sizing', (
     tester,
   ) async {
@@ -284,6 +439,24 @@ void main() {
           .style
           ?.fontSize,
       14,
+    );
+
+    final theme = cardRect(tester, 'appearance-theme-display-card');
+    final navigation = cardRect(tester, 'appearance-navigation-card');
+    final home = cardRect(tester, 'appearance-home-screen-card');
+    expect((navigation.left - theme.left).abs(), lessThanOrEqualTo(.5));
+    expect((navigation.width - theme.width).abs(), lessThanOrEqualTo(.5));
+    expect(navigation.top - theme.bottom, closeTo(18, .5));
+    expect(home.top - navigation.bottom, closeTo(18, .5));
+
+    await selectArea(tester, 'playback');
+    expect(
+      verticalGap(
+        tester,
+        'settings-card-playback-captions',
+        'settings-card-playback-player',
+      ),
+      closeTo(18, .5),
     );
     expect(tester.takeException(), isNull);
   });

--- a/tool/release/native_playback_manifest.json
+++ b/tool/release/native_playback_manifest.json
@@ -375,10 +375,10 @@
     {
       "path": "lib/arm64-v8a/libapp.so",
       "size": 12256144,
-      "sha256": "f1832ec746df2ac6edf49e4907794b8fb9a46f9ceb1704615bb8ea6b65dc428d",
-      "origin": "TetoTV Flutter application AOT 2.0.49",
+      "sha256": "96e62a565da9654c17da4a2b010947c7c38e67e454e06375f164af9bce3cdb90",
+      "origin": "TetoTV Flutter application AOT 2.0.50",
       "license": "MIT",
-      "sourceLocator": "Git tag v2.0.49",
+      "sourceLocator": "Git tag v2.0.50",
       "noticeLocator": "LICENSE"
     },
     {
@@ -423,7 +423,7 @@
       "sha256": "dc05f53278b2733094f12aeaed54c080329309762ce49e6de4118e4bfb0fff55",
       "origin": "TetoTV source build of media-kit Android helper at 42054e5d479f39ccbb0ae604862e2bcaf59b74c2",
       "license": "MIT",
-      "sourceLocator": "TetoTV-v2.0.49-native-playback-sources.zip: sources/media-kit-android-helper-42054e5d479f39ccbb0ae604862e2bcaf59b74c2.zip",
+      "sourceLocator": "TetoTV-v2.0.50-native-playback-sources.zip: sources/media-kit-android-helper-42054e5d479f39ccbb0ae604862e2bcaf59b74c2.zip",
       "noticeLocator": "assets/legal/native/MEDIA_KIT_ANDROID_HELPER_LICENSE.txt; assets/legal/native/NATIVE_PLAYBACK_NOTICE.txt"
     },
     {
@@ -432,7 +432,7 @@
       "sha256": "a7399d0be70844e5ee94cc5b1acc1516571113c50561fe0a5d05b49101c53ef2",
       "origin": "TetoTV source build of the pinned mpv and FFmpeg native playback stack",
       "license": "LGPL-3.0-or-later (conservative combined classification) plus component terms",
-      "sourceLocator": "TetoTV-v2.0.49-native-playback-sources.zip and tool/native/build_native_playback.sh",
+      "sourceLocator": "TetoTV-v2.0.50-native-playback-sources.zip and tool/native/build_native_playback.sh",
       "noticeLocator": "assets/legal/native/NATIVE_PLAYBACK_NOTICE.txt and its referenced exact license assets"
     },
     {
@@ -450,16 +450,16 @@
       "sha256": "263ba714570fb3acfc308cce52776b00506ec8809d225617e52352336144cfa2",
       "origin": "TetoTV source build of the pinned libtorrent4j and libtorrent-rasterbar stack",
       "license": "Mixed MIT, BSD, Boost-1.0, Apache-2.0, and MPL-2.0 component terms",
-      "sourceLocator": "TetoTV-v2.0.49-native-playback-sources.zip and tool/native/build_native_playback.sh",
+      "sourceLocator": "TetoTV-v2.0.50-native-playback-sources.zip and tool/native/build_native_playback.sh",
       "noticeLocator": "assets/legal/native/DIRECT_TORRENT_NATIVE_NOTICE.txt and its referenced exact license assets"
     },
     {
       "path": "lib/armeabi-v7a/libapp.so",
       "size": 13402700,
-      "sha256": "ad9ef662c56d6d3b23e5bc5b5640184596a949c3cdd0c32497118457b2f1081e",
-      "origin": "TetoTV Flutter application AOT 2.0.49",
+      "sha256": "ffe270a23c7234681765311bcf84737fe62edbf3863c9607a9358df70debbc3b",
+      "origin": "TetoTV Flutter application AOT 2.0.50",
       "license": "MIT",
-      "sourceLocator": "Git tag v2.0.49",
+      "sourceLocator": "Git tag v2.0.50",
       "noticeLocator": "LICENSE"
     },
     {
@@ -504,7 +504,7 @@
       "sha256": "8820a12e07bb3dc45f5b4286acf6918827fba4c265767e7f1cc8f07215c84b6a",
       "origin": "TetoTV source build of media-kit Android helper at 42054e5d479f39ccbb0ae604862e2bcaf59b74c2",
       "license": "MIT",
-      "sourceLocator": "TetoTV-v2.0.49-native-playback-sources.zip: sources/media-kit-android-helper-42054e5d479f39ccbb0ae604862e2bcaf59b74c2.zip",
+      "sourceLocator": "TetoTV-v2.0.50-native-playback-sources.zip: sources/media-kit-android-helper-42054e5d479f39ccbb0ae604862e2bcaf59b74c2.zip",
       "noticeLocator": "assets/legal/native/MEDIA_KIT_ANDROID_HELPER_LICENSE.txt; assets/legal/native/NATIVE_PLAYBACK_NOTICE.txt"
     },
     {
@@ -513,7 +513,7 @@
       "sha256": "d5a220fdf41edde10f161f86addc846ae9cb18137ea48e4db541cd703fec5092",
       "origin": "TetoTV source build of the pinned mpv and FFmpeg native playback stack",
       "license": "LGPL-3.0-or-later (conservative combined classification) plus component terms",
-      "sourceLocator": "TetoTV-v2.0.49-native-playback-sources.zip and tool/native/build_native_playback.sh",
+      "sourceLocator": "TetoTV-v2.0.50-native-playback-sources.zip and tool/native/build_native_playback.sh",
       "noticeLocator": "assets/legal/native/NATIVE_PLAYBACK_NOTICE.txt and its referenced exact license assets"
     },
     {
@@ -531,7 +531,7 @@
       "sha256": "ba0a19d2730969b8e6107db1847888ea8d3b8cafd14a535a3259dd04f8b28d60",
       "origin": "TetoTV source build of the pinned libtorrent4j and libtorrent-rasterbar stack",
       "license": "Mixed MIT, BSD, Boost-1.0, Apache-2.0, and MPL-2.0 component terms",
-      "sourceLocator": "TetoTV-v2.0.49-native-playback-sources.zip and tool/native/build_native_playback.sh",
+      "sourceLocator": "TetoTV-v2.0.50-native-playback-sources.zip and tool/native/build_native_playback.sh",
       "noticeLocator": "assets/legal/native/DIRECT_TORRENT_NATIVE_NOTICE.txt and its referenced exact license assets"
     }
   ],


### PR DESCRIPTION
## Summary
- make TV Settings tabs evenly divide the available width
- flow cards through continuous two-column lanes with one consistent compact gutter
- remove forced empty card height and unused TV footer space
- preserve the approved control sizing and existing mobile layout
- prepare signed Beta 2.0.50 release metadata

## Verification
- flutter analyze
- flutter test: 1,916 passed, 17 skipped
- Android unit tests: 68 passed
- Android lint: 0 errors
- Kotlin debug compilation
- signed release APK and full release payload verification