### PR TITLE
Use a single-list TV Settings layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 
 <p align="center">
   <a href="https://github.com/LindersOSX/TetoTV-Beta/releases/latest"><strong>Download Beta</strong></a>
-  · <a href="docs/RELEASE_NOTES_2.0.50.md">What's new</a>
+  · <a href="docs/RELEASE_NOTES_2.0.51.md">What's new</a>
   · <a href="https://github.com/LindersOSX/TetoTV-Beta/issues/new">Report an issue</a>
   · <a href="https://discord.gg/juC6k7d4WY">Discord</a>
   · <a href="https://www.youtube.com/@TetoTVApp">YouTube</a>
@@ -85,10 +85,10 @@ TetoTV runs directly on the Android device with no companion server required for
 | Channel | Version | Best for |
 | --- | --- | --- |
 | Public | Not published | Source and release-readiness documents are available, but no Public APK is currently offered |
-| Beta | [2.0.50](docs/RELEASE_NOTES_2.0.50.md) | Testing the evenly packed TV Settings layout while retaining the approved compact sizing and existing phone layout before a separately reviewed Public release |
+| Beta | [2.0.51](docs/RELEASE_NOTES_2.0.51.md) | Testing the phone-inspired single-list TV Settings layout, linear remote navigation, and unchanged mobile layout before a separately reviewed Public release |
 
 > [!WARNING]
-> Beta 2.0.50 uses the repository's explicit unreviewed-Beta exception. Its native-library and corresponding-source material did not receive independent license review, and automated integrity checks are not a legal compliance determination. Read the [complete Beta disclosure](docs/RELEASE_NOTES_2.0.50.md). This exception does not apply to a future Public release.
+> Beta 2.0.51 uses the repository's explicit unreviewed-Beta exception. Its native-library and corresponding-source material did not receive independent license review, and automated integrity checks are not a legal compliance determination. Read the [complete Beta disclosure](docs/RELEASE_NOTES_2.0.51.md). This exception does not apply to a future Public release.
 
 The Public updater repository intentionally has no release while the Public build is held for review. Existing Beta installations continue to update from the Beta repository. Android never permits an in-place install of an APK with a lower build code; Developer Mode does not bypass that platform rule.
 

--- a/docs/BUILD_WINDOWS.md
+++ b/docs/BUILD_WINDOWS.md
@@ -220,39 +220,39 @@ APK containing both supported application ABIs.
 Public and Beta updates use anonymous GitHub requests. No Beta key, GitHub
 token, update-proxy URL, or update-specific Dart define is required. Every
 published APK uses the production signing identity. No Public APK is currently
-published. Beta 2.0.50 uses Android build code `410027`. Flutter reuses
+published. Beta 2.0.51 uses Android build code `410028`. Flutter reuses
 `app-release.apk`, so copy and rename the Beta artifact immediately after the
 build:
 
 ```powershell
-New-Item -ItemType Directory -Force .\build\fire-tv\v2.0.50 | Out-Null
+New-Item -ItemType Directory -Force .\build\fire-tv\v2.0.51 | Out-Null
 
-# Beta 2.0.50
+# Beta 2.0.51
 flutter build apk --release --target-platform android-arm,android-arm64 `
-  --build-name 2.0.50 --build-number 410027 --no-tree-shake-icons
+  --build-name 2.0.51 --build-number 410028 --no-tree-shake-icons
 Copy-Item .\build\app\outputs\flutter-apk\app-release.apk `
-  .\build\fire-tv\v2.0.50\TetoTV-v2.0.50-universal.apk
+  .\build\fire-tv\v2.0.51\TetoTV-v2.0.51-universal.apk
 
 .\tool\release\verify_release_apk.ps1 `
   -Channel Beta `
-  -ApkPath .\build\fire-tv\v2.0.50\TetoTV-v2.0.50-universal.apk
+  -ApkPath .\build\fire-tv\v2.0.51\TetoTV-v2.0.51-universal.apk
 
 .\tool\release\verify_native_redistribution.ps1 `
   -RequireResolvedBinaries `
   -ResolvedBinaryDirectory .\build\native-playback\outputs `
-  -StageBundle -ReleaseTag v2.0.50
+  -StageBundle -ReleaseTag v2.0.51
 
 .\tool\release\new_release_checksums.ps1 `
-  -ApkPath .\build\fire-tv\v2.0.50\TetoTV-v2.0.50-universal.apk `
-  -NativeSourcePath .\build\release-compliance\v2.0.50\TetoTV-v2.0.50-native-playback-sources.zip `
-  -OutputPath .\build\fire-tv\v2.0.50\SHA256SUMS
+  -ApkPath .\build\fire-tv\v2.0.51\TetoTV-v2.0.51-universal.apk `
+  -NativeSourcePath .\build\release-compliance\v2.0.51\TetoTV-v2.0.51-native-playback-sources.zip `
+  -OutputPath .\build\fire-tv\v2.0.51\SHA256SUMS
 
 .\tool\release\verify_release_payloads.ps1 `
   -Channel Beta `
-  -ApkPath .\build\fire-tv\v2.0.50\TetoTV-v2.0.50-universal.apk `
-  -NativeSourcePath .\build\release-compliance\v2.0.50\TetoTV-v2.0.50-native-playback-sources.zip `
-  -ChecksumsPath .\build\fire-tv\v2.0.50\SHA256SUMS `
-  -ReleaseNotesPath .\docs\RELEASE_NOTES_2.0.50.md
+  -ApkPath .\build\fire-tv\v2.0.51\TetoTV-v2.0.51-universal.apk `
+  -NativeSourcePath .\build\release-compliance\v2.0.51\TetoTV-v2.0.51-native-playback-sources.zip `
+  -ChecksumsPath .\build\fire-tv\v2.0.51\SHA256SUMS `
+  -ReleaseNotesPath .\docs\RELEASE_NOTES_2.0.51.md
 ```
 
 The final payload check requires all five exact, source-built native JARs

--- a/docs/RELEASE_NOTES_2.0.51.md
+++ b/docs/RELEASE_NOTES_2.0.51.md
@@ -1,0 +1,33 @@
+# TetoTV 2.0.51 Beta
+
+> [!WARNING]
+> No independent native-license review: This Beta has not received independent native-library licensing review. Automated checks verify the APK, native-source bundle, notices, pinned inputs, and checksums, but do not establish legal compliance or reproducible builds.
+
+This Beta replaces the side-by-side TV Settings dashboard with a simpler phone-inspired list while preserving the compact TV sizing and the existing phone and tablet layouts.
+
+## What's changed
+
+- Every TV Settings category now uses one full-width vertical card list instead of side-by-side columns.
+- Appearance, Playback, Services, Accounts, and System all follow the same consistent 8-pixel card spacing.
+- Appearance keeps `Reset appearance and navigation` as its final remote action, so Down stops there and Left returns to the Settings rail as before.
+- D-pad navigation now follows the visible list through caption controls, source toggles, connected tracking actions, Discord actions, update controls, storage actions, and legal/privacy controls.
+- Connected tracking-account and Discord disconnect actions can no longer be skipped with a TV remote.
+- The TV Settings rail, compact control sizing, five category tabs, and all existing Settings functionality remain available.
+- Phone and tablet Settings retain their existing responsive layout and control sizing.
+- Expanded layout and focus regression tests protect both the new TV list and unchanged non-TV behavior.
+- TetoTV still does not bundle, recommend, or endorse content providers. Users choose and configure their own lawful services and extensions, and the existing source-safety checks remain enforced.
+- Development disclosure: TetoTV includes code created and reviewed with AI-assisted development tools. Releases are tested and maintained by the project owner.
+
+## Release assets
+
+- `TetoTV-v2.0.51-universal.apk`
+- `TetoTV-v2.0.51-native-playback-sources.zip`
+- `SHA256SUMS`
+
+## Beta notes
+
+- This is a Beta-channel build with Android build code `410028`.
+- No Public APK is being published with this release.
+- Android does not permit an in-place install over an APK with a higher build code. A future Public counterpart must use build code `410028` or newer for data-preserving channel switching.
+
+<!-- tetotv-android-version-code: 410028 -->

--- a/docs/UPDATE_CHANNELS.md
+++ b/docs/UPDATE_CHANNELS.md
@@ -35,11 +35,11 @@ Beta reads completed 2.x releases from:
 https://api.github.com/repos/LindersOSX/TetoTV-Beta/releases/latest
 ```
 
-The current Beta source build is `v2.0.50` with Android build code `410027`.
+The current Beta source build is `v2.0.51` with Android build code `410028`.
 Its release title is:
 
 ```text
-TetoTV 2.0.50 Beta - Android TV / Google TV / Fire TV
+TetoTV 2.0.51 Beta - Android TV / Google TV / Fire TV
 ```
 
 Publish it as a normal, non-draft, non-prerelease GitHub release so
@@ -72,7 +72,7 @@ proxy.
 Release notes must include the exact asset names and this build-code marker:
 
 ```html
-<!-- tetotv-android-version-code: 410027 -->
+<!-- tetotv-android-version-code: 410028 -->
 ```
 
 When build-code metadata is present, the updater rejects a known lower build
@@ -94,10 +94,10 @@ These rules apply equally on phones, Android TV, Google TV, and Fire TV.
 
 ## Switching and rollback
 
-The current Beta uses build code `410027`. No Public counterpart is available.
+The current Beta uses build code `410028`. No Public counterpart is available.
 An older Public install can move to this Beta when Android accepts the higher
 build code, but it cannot move back in place until a future Public build uses
-code `410027` or higher. Uninstalling first permits an older APK but deletes
+code `410028` or higher. Uninstalling first permits an older APK but deletes
 local application data. Developer Mode and in-app settings cannot override
 this Android rule.
 

--- a/lib/features/settings/presentation/accounts_screen.dart
+++ b/lib/features/settings/presentation/accounts_screen.dart
@@ -157,6 +157,9 @@ class _AccountsScreenState extends ConsumerState<AccountsScreen> {
   final _displaySectionFocus = FocusNode(
     debugLabel: 'accounts.section.display',
   );
+  final _cardDetailsFocus = FocusNode(
+    debugLabel: 'accounts.customization.display.card-details',
+  );
   final _homeNavigationSectionFocus = FocusNode(
     debugLabel: 'accounts.section.home-navigation',
   );
@@ -178,11 +181,17 @@ class _AccountsScreenState extends ConsumerState<AccountsScreen> {
   final _inputFeedbackSectionFocus = FocusNode(
     debugLabel: 'accounts.section.input-feedback',
   );
+  final _clickSoundsFocus = FocusNode(
+    debugLabel: 'accounts.customization.input.click-sounds',
+  );
   final _closedCaptionsSectionFocus = FocusNode(
     debugLabel: 'accounts.section.closed-captions',
   );
   final _captionTextColorFocus = FocusNode(
     debugLabel: 'accounts.captions.text-color',
+  );
+  final _captionTextSizeFocus = FocusNode(
+    debugLabel: 'accounts.captions.text-size',
   );
   final _playerControlsSectionFocus = FocusNode(
     debugLabel: 'accounts.section.player-controls',
@@ -221,6 +230,9 @@ class _AccountsScreenState extends ConsumerState<AccountsScreen> {
   );
   final _anilistFocus = FocusNode(debugLabel: 'accounts.anilist');
   final _malFocus = FocusNode(debugLabel: 'accounts.myanimelist');
+  final _trackingDisconnectFocus = FocusNode(
+    debugLabel: 'accounts.tracking.disconnect',
+  );
   final _anilistTokenFocus = FocusNode(debugLabel: 'accounts.anilist.token');
   final _anilistSaveFocus = FocusNode(debugLabel: 'accounts.anilist.save');
   final _malTokenFocus = FocusNode(debugLabel: 'accounts.myanimelist.token');
@@ -463,6 +475,7 @@ class _AccountsScreenState extends ConsumerState<AccountsScreen> {
     _customizationFocus.dispose();
     _homeShelvesSectionFocus.dispose();
     _displaySectionFocus.dispose();
+    _cardDetailsFocus.dispose();
     _homeNavigationSectionFocus.dispose();
     _featuredHomeContentFocus.dispose();
     _posterMetadataFocus.dispose();
@@ -470,8 +483,10 @@ class _AccountsScreenState extends ConsumerState<AccountsScreen> {
     _navigationSizeFocus.dispose();
     _menuOrderFocus.dispose();
     _inputFeedbackSectionFocus.dispose();
+    _clickSoundsFocus.dispose();
     _closedCaptionsSectionFocus.dispose();
     _captionTextColorFocus.dispose();
+    _captionTextSizeFocus.dispose();
     _playerControlsSectionFocus.dispose();
     _customizationResetFocus.dispose();
     _setupFocus.dispose();
@@ -491,6 +506,7 @@ class _AccountsScreenState extends ConsumerState<AccountsScreen> {
     _premiumizeSaveFocus.dispose();
     _anilistFocus.dispose();
     _malFocus.dispose();
+    _trackingDisconnectFocus.dispose();
     _anilistTokenFocus.dispose();
     _anilistSaveFocus.dispose();
     _malTokenFocus.dispose();
@@ -555,6 +571,7 @@ class _AccountsScreenState extends ConsumerState<AccountsScreen> {
       return KeyEventResult.handled;
     }
     final current = FocusManager.instance.primaryFocus;
+    final tvListLayout = layout?.usesTvRail == true;
     bool focusNodeIsMounted(FocusNode node) => node.context?.mounted ?? false;
     final preferences = ref.read(settingsPreferencesProvider);
     final selectedDebridAction = switch (preferences.debridProvider) {
@@ -618,11 +635,14 @@ class _AccountsScreenState extends ConsumerState<AccountsScreen> {
       areaNodes.first,
       _homeShelvesSectionFocus,
       _displaySectionFocus,
+      _cardDetailsFocus,
       _homeNavigationSectionFocus,
       ...topNavigationNodes,
       _inputFeedbackSectionFocus,
+      _clickSoundsFocus,
       _closedCaptionsSectionFocus,
       _captionTextColorFocus,
+      _captionTextSizeFocus,
       _playerControlsSectionFocus,
       _customizationResetFocus,
       ...shelfNodes,
@@ -652,6 +672,7 @@ class _AccountsScreenState extends ConsumerState<AccountsScreen> {
       _watchTogetherFocus,
       _trackingProviderFocus,
       selectedTrackingAction,
+      _trackingDisconnectFocus,
       _anilistTokenFocus,
       _anilistSaveFocus,
       _malTokenFocus,
@@ -673,6 +694,22 @@ class _AccountsScreenState extends ConsumerState<AccountsScreen> {
       _anonymousCrashReportingFocus,
       _anonymousUsageCountFocus,
     };
+    if (tvListLayout) {
+      leftEdgeNodes.addAll({
+        _featuredHomeContentFocus,
+        _posterMetadataFocus,
+        _continueWatchingFocus,
+        _webStreamsFocus,
+        _directTorrentFocus,
+        _dubEpisodeNotificationsFocus,
+        _discordDisconnectFocus,
+        _calibrationFocus,
+        _diagnosticsFocus,
+        _checkUpdatesFocus,
+        _resetAppFocus,
+        _legalFocus,
+      });
+    }
     if (key == LogicalKeyboardKey.arrowLeft &&
         layout?.usesSideNavigation != true &&
         leftEdgeNodes.contains(current) &&
@@ -712,13 +749,17 @@ class _AccountsScreenState extends ConsumerState<AccountsScreen> {
       }
     } else if (shelfIndex >= 0) {
       if (key == LogicalKeyboardKey.arrowUp) {
-        target = shelfIndex > 0
-            ? shelfNodes[shelfIndex - 1]
-            : _continueWatchingFocus;
+        if (shelfIndex > 0) {
+          target = shelfNodes[shelfIndex - 1];
+        } else {
+          target = tvListLayout ? _clickSoundsFocus : _continueWatchingFocus;
+        }
       }
       if (key == LogicalKeyboardKey.arrowDown) {
         if (shelfIndex < shelfNodes.length - 1) {
           target = shelfNodes[shelfIndex + 1];
+        } else if (tvListLayout) {
+          target = _navigationSizeFocus;
         } else {
           return KeyEventResult.handled;
         }
@@ -728,11 +769,13 @@ class _AccountsScreenState extends ConsumerState<AccountsScreen> {
     if (areaIndex >= 0 || shelfIndex >= 0) {
       // Settings-area and Home-shelf navigation were handled above.
     } else if (current == _featuredHomeContentFocus) {
-      if (key == LogicalKeyboardKey.arrowLeft) {
+      if (key == LogicalKeyboardKey.arrowLeft && !tvListLayout) {
         target = _customizationFocus;
       }
       if (key == LogicalKeyboardKey.arrowUp) {
-        target = _areaFocusNodes[_SettingsArea.appearance];
+        target = tvListLayout
+            ? _showTitleStyleFocus
+            : _areaFocusNodes[_SettingsArea.appearance];
       }
       if (key == LogicalKeyboardKey.arrowDown) {
         target = _posterMetadataFocus;
@@ -760,7 +803,9 @@ class _AccountsScreenState extends ConsumerState<AccountsScreen> {
     } else if (current == _displaySectionFocus) {
       if (_activeArea == _SettingsArea.appearance) {
         if (key == LogicalKeyboardKey.arrowUp) {
-          target = _customizationResetFocus;
+          target = tvListLayout
+              ? _continueWatchingFocus
+              : _customizationResetFocus;
         }
       } else {
         if (key == LogicalKeyboardKey.arrowUp) {
@@ -774,6 +819,10 @@ class _AccountsScreenState extends ConsumerState<AccountsScreen> {
               : _homeNavigationSectionFocus;
         }
       }
+    } else if (current == _cardDetailsFocus) {
+      if (key == LogicalKeyboardKey.arrowDown && tvListLayout) {
+        target = _inputFeedbackSectionFocus;
+      }
     } else if (current == _backFocus) {
       if (key == LogicalKeyboardKey.arrowRight ||
           key == LogicalKeyboardKey.arrowDown) {
@@ -785,7 +834,7 @@ class _AccountsScreenState extends ConsumerState<AccountsScreen> {
       if (key == LogicalKeyboardKey.arrowUp) {
         target = _areaFocusNodes[_SettingsArea.appearance];
       }
-      if (key == LogicalKeyboardKey.arrowRight) {
+      if (key == LogicalKeyboardKey.arrowRight && !tvListLayout) {
         target = _featuredHomeContentFocus;
       }
       if (key == LogicalKeyboardKey.arrowDown) {
@@ -795,7 +844,7 @@ class _AccountsScreenState extends ConsumerState<AccountsScreen> {
       if (key == LogicalKeyboardKey.arrowUp) {
         target = _customizationFocus;
       }
-      if (key == LogicalKeyboardKey.arrowRight) {
+      if (key == LogicalKeyboardKey.arrowRight && !tvListLayout) {
         target = _posterMetadataFocus;
       }
       if (key == LogicalKeyboardKey.arrowDown) {
@@ -805,17 +854,19 @@ class _AccountsScreenState extends ConsumerState<AccountsScreen> {
       if (key == LogicalKeyboardKey.arrowUp) {
         target = _titleLanguageFocus;
       }
-      if (key == LogicalKeyboardKey.arrowRight) {
+      if (key == LogicalKeyboardKey.arrowRight && !tvListLayout) {
         target = _continueWatchingFocus;
       }
       if (key == LogicalKeyboardKey.arrowDown) {
-        target = _navigationSizeFocus;
+        target = tvListLayout
+            ? _featuredHomeContentFocus
+            : _navigationSizeFocus;
       }
     } else if (current == _navigationSizeFocus) {
       if (key == LogicalKeyboardKey.arrowUp) {
-        target = _showTitleStyleFocus;
+        target = tvListLayout ? shelfNodes.last : _showTitleStyleFocus;
       }
-      if (key == LogicalKeyboardKey.arrowRight) {
+      if (key == LogicalKeyboardKey.arrowRight && !tvListLayout) {
         target = _continueWatchingFocus;
       }
       if (key == LogicalKeyboardKey.arrowDown) {
@@ -825,14 +876,14 @@ class _AccountsScreenState extends ConsumerState<AccountsScreen> {
       if (key == LogicalKeyboardKey.arrowUp) {
         target = _navigationSizeFocus;
       }
-      if (key == LogicalKeyboardKey.arrowRight) {
+      if (key == LogicalKeyboardKey.arrowRight && !tvListLayout) {
         target = _continueWatchingFocus;
       }
       if (key == LogicalKeyboardKey.arrowDown) {
         target = _customizationResetFocus;
       }
     } else if (current == _posterMetadataFocus) {
-      if (key == LogicalKeyboardKey.arrowLeft) {
+      if (key == LogicalKeyboardKey.arrowLeft && !tvListLayout) {
         target = _titleLanguageFocus;
       }
       if (key == LogicalKeyboardKey.arrowUp) {
@@ -842,14 +893,14 @@ class _AccountsScreenState extends ConsumerState<AccountsScreen> {
         target = _continueWatchingFocus;
       }
     } else if (current == _continueWatchingFocus) {
-      if (key == LogicalKeyboardKey.arrowLeft) {
+      if (key == LogicalKeyboardKey.arrowLeft && !tvListLayout) {
         target = _showTitleStyleFocus;
       }
       if (key == LogicalKeyboardKey.arrowUp) {
         target = _posterMetadataFocus;
       }
       if (key == LogicalKeyboardKey.arrowDown) {
-        target = shelfNodes.first;
+        target = tvListLayout ? _displaySectionFocus : shelfNodes.first;
       }
     } else if (current == _homeNavigationSectionFocus) {
       if (key == LogicalKeyboardKey.arrowUp &&
@@ -865,7 +916,11 @@ class _AccountsScreenState extends ConsumerState<AccountsScreen> {
         target = _inputFeedbackSectionFocus;
       }
     } else if (current == _inputFeedbackSectionFocus) {
-      if (_activeArea != _SettingsArea.appearance) {
+      if (_activeArea == _SettingsArea.appearance && tvListLayout) {
+        if (key == LogicalKeyboardKey.arrowUp) {
+          target = _cardDetailsFocus;
+        }
+      } else if (_activeArea != _SettingsArea.appearance) {
         if (key == LogicalKeyboardKey.arrowUp &&
             !_expandedCustomizationSections.contains(
               _CustomizationSection.homeNavigation,
@@ -878,6 +933,10 @@ class _AccountsScreenState extends ConsumerState<AccountsScreen> {
             )) {
           target = _customizationResetFocus;
         }
+      }
+    } else if (current == _clickSoundsFocus) {
+      if (key == LogicalKeyboardKey.arrowDown && tvListLayout) {
+        target = shelfNodes.first;
       }
     } else if (current == _closedCaptionsSectionFocus) {
       if (key == LogicalKeyboardKey.arrowUp) {
@@ -897,14 +956,21 @@ class _AccountsScreenState extends ConsumerState<AccountsScreen> {
             ? _areaFocusNodes[_SettingsArea.playback]
             : _closedCaptionsSectionFocus;
       }
+    } else if (current == _captionTextSizeFocus) {
+      if (key == LogicalKeyboardKey.arrowDown && tvListLayout) {
+        target = _playerControlsSectionFocus;
+      }
     } else if (current == _playerControlsSectionFocus) {
-      if (key == LogicalKeyboardKey.arrowUp &&
-          !_expandedCustomizationSections.contains(
-            _CustomizationSection.closedCaptions,
-          )) {
-        target = _activeArea == _SettingsArea.playback
-            ? _captionTextColorFocus
-            : _closedCaptionsSectionFocus;
+      if (key == LogicalKeyboardKey.arrowUp) {
+        if (tvListLayout && _activeArea == _SettingsArea.playback) {
+          target = _captionTextSizeFocus;
+        } else if (!_expandedCustomizationSections.contains(
+          _CustomizationSection.closedCaptions,
+        )) {
+          target = _activeArea == _SettingsArea.playback
+              ? _captionTextColorFocus
+              : _closedCaptionsSectionFocus;
+        }
       }
     } else if (current == _customizationResetFocus) {
       if (key == LogicalKeyboardKey.arrowUp) {
@@ -913,6 +979,7 @@ class _AccountsScreenState extends ConsumerState<AccountsScreen> {
             : _inputFeedbackSectionFocus;
       }
       if (key == LogicalKeyboardKey.arrowRight &&
+          !tvListLayout &&
           _activeArea == _SettingsArea.appearance) {
         target = _continueWatchingFocus;
       }
@@ -945,33 +1012,53 @@ class _AccountsScreenState extends ConsumerState<AccountsScreen> {
             ? selectedDebridLast
             : selectedDebridAction;
       }
-      if (key == LogicalKeyboardKey.arrowRight) target = _webStreamsFocus;
-      if (key == LogicalKeyboardKey.arrowDown) target = _debridSortFocus;
+      if (key == LogicalKeyboardKey.arrowRight && !tvListLayout) {
+        target = _webStreamsFocus;
+      }
+      if (key == LogicalKeyboardKey.arrowDown) {
+        target = tvListLayout ? _webStreamsFocus : _debridSortFocus;
+      }
     } else if (current == _webStreamsFocus) {
       if (key == LogicalKeyboardKey.arrowUp) {
-        target = focusNodeIsMounted(selectedDebridLast)
+        target = tvListLayout
+            ? _debridStreamsFocus
+            : focusNodeIsMounted(selectedDebridLast)
             ? selectedDebridLast
             : selectedDebridAction;
       }
-      if (key == LogicalKeyboardKey.arrowLeft) target = _debridStreamsFocus;
-      if (key == LogicalKeyboardKey.arrowRight) {
+      if (key == LogicalKeyboardKey.arrowLeft && !tvListLayout) {
+        target = _debridStreamsFocus;
+      }
+      if (key == LogicalKeyboardKey.arrowRight && !tvListLayout) {
         target = _directTorrentFocus;
       }
-      if (key == LogicalKeyboardKey.arrowDown) target = _debridSortFocus;
+      if (key == LogicalKeyboardKey.arrowDown) {
+        target = tvListLayout ? _directTorrentFocus : _debridSortFocus;
+      }
     } else if (current == _directTorrentFocus) {
       if (key == LogicalKeyboardKey.arrowUp) {
-        target = focusNodeIsMounted(selectedDebridLast)
+        target = tvListLayout
+            ? _webStreamsFocus
+            : focusNodeIsMounted(selectedDebridLast)
             ? selectedDebridLast
             : selectedDebridAction;
       }
-      if (key == LogicalKeyboardKey.arrowLeft) target = _webStreamsFocus;
-      if (key == LogicalKeyboardKey.arrowRight) target = _marketplaceFocus;
-      if (key == LogicalKeyboardKey.arrowDown) target = _debridSortFocus;
+      if (key == LogicalKeyboardKey.arrowLeft && !tvListLayout) {
+        target = _webStreamsFocus;
+      }
+      if (key == LogicalKeyboardKey.arrowRight && !tvListLayout) {
+        target = _marketplaceFocus;
+      }
+      if (key == LogicalKeyboardKey.arrowDown) {
+        target = tvListLayout ? _marketplaceFocus : _debridSortFocus;
+      }
     } else if (current == _marketplaceFocus) {
       if (key == LogicalKeyboardKey.arrowUp) target = _directTorrentFocus;
       if (key == LogicalKeyboardKey.arrowDown) target = _debridSortFocus;
     } else if (current == _debridSortFocus) {
-      if (key == LogicalKeyboardKey.arrowUp) target = _debridStreamsFocus;
+      if (key == LogicalKeyboardKey.arrowUp) {
+        target = tvListLayout ? _marketplaceFocus : _debridStreamsFocus;
+      }
       if (key == LogicalKeyboardKey.arrowDown) target = _sourcePriorityFocus;
     } else if (current == _sourcePriorityFocus) {
       if (key == LogicalKeyboardKey.arrowUp) target = _debridSortFocus;
@@ -1092,7 +1179,9 @@ class _AccountsScreenState extends ConsumerState<AccountsScreen> {
           focusNodeIsMounted(_anilistTokenFocus)) {
         target = _anilistTokenFocus;
       } else if (key == LogicalKeyboardKey.arrowDown) {
-        target = _localProfilesFocus;
+        target = tvListLayout && focusNodeIsMounted(_trackingDisconnectFocus)
+            ? _trackingDisconnectFocus
+            : _localProfilesFocus;
       }
       if (key == LogicalKeyboardKey.arrowUp) target = _trackingProviderFocus;
     } else if (current == _malFocus) {
@@ -1100,7 +1189,9 @@ class _AccountsScreenState extends ConsumerState<AccountsScreen> {
           focusNodeIsMounted(_malTokenFocus)) {
         target = _malTokenFocus;
       } else if (key == LogicalKeyboardKey.arrowDown) {
-        target = _localProfilesFocus;
+        target = tvListLayout && focusNodeIsMounted(_trackingDisconnectFocus)
+            ? _trackingDisconnectFocus
+            : _localProfilesFocus;
       }
       if (key == LogicalKeyboardKey.arrowUp) target = _trackingProviderFocus;
     } else if (current == _anilistTokenFocus) {
@@ -1119,15 +1210,26 @@ class _AccountsScreenState extends ConsumerState<AccountsScreen> {
       if (key == LogicalKeyboardKey.arrowDown) {
         target = _localProfilesFocus;
       }
+    } else if (current == _trackingDisconnectFocus) {
+      if (key == LogicalKeyboardKey.arrowUp) {
+        target = selectedTrackingAction;
+      }
+      if (key == LogicalKeyboardKey.arrowDown) {
+        target = _localProfilesFocus;
+      }
     } else if (current == _localProfilesFocus) {
       if (key == LogicalKeyboardKey.arrowUp) {
-        final selectedSave =
-            preferences.trackingProvider == TrackingProvider.anilist
-            ? _anilistSaveFocus
-            : _malSaveFocus;
-        target = focusNodeIsMounted(selectedSave)
-            ? selectedSave
-            : selectedTrackingAction;
+        if (tvListLayout && focusNodeIsMounted(_trackingDisconnectFocus)) {
+          target = _trackingDisconnectFocus;
+        } else {
+          final selectedSave =
+              preferences.trackingProvider == TrackingProvider.anilist
+              ? _anilistSaveFocus
+              : _malSaveFocus;
+          target = focusNodeIsMounted(selectedSave)
+              ? selectedSave
+              : selectedTrackingAction;
+        }
       }
       if (key == LogicalKeyboardKey.arrowDown) {
         target = _trackingThresholdFocus;
@@ -1143,11 +1245,13 @@ class _AccountsScreenState extends ConsumerState<AccountsScreen> {
       if (key == LogicalKeyboardKey.arrowUp) {
         target = _trackingThresholdFocus;
       }
-      if (key == LogicalKeyboardKey.arrowRight) {
+      if (key == LogicalKeyboardKey.arrowRight && !tvListLayout) {
         target = _dubEpisodeNotificationsFocus;
       }
       if (key == LogicalKeyboardKey.arrowDown) {
-        if (focusNodeIsMounted(_discordPresenceFocus) &&
+        if (tvListLayout) {
+          target = _dubEpisodeNotificationsFocus;
+        } else if (focusNodeIsMounted(_discordPresenceFocus) &&
             _discordPresenceFocus.canRequestFocus) {
           target = _discordPresenceFocus;
         } else {
@@ -1156,9 +1260,11 @@ class _AccountsScreenState extends ConsumerState<AccountsScreen> {
       }
     } else if (current == _dubEpisodeNotificationsFocus) {
       if (key == LogicalKeyboardKey.arrowUp) {
-        target = _trackingThresholdFocus;
+        target = tvListLayout
+            ? _subEpisodeNotificationsFocus
+            : _trackingThresholdFocus;
       }
-      if (key == LogicalKeyboardKey.arrowLeft) {
+      if (key == LogicalKeyboardKey.arrowLeft && !tvListLayout) {
         target = _subEpisodeNotificationsFocus;
       }
       if (key == LogicalKeyboardKey.arrowDown) {
@@ -1173,34 +1279,52 @@ class _AccountsScreenState extends ConsumerState<AccountsScreen> {
       if (key == LogicalKeyboardKey.arrowUp) {
         target = _areaFocusNodes[_SettingsArea.system];
       }
-      if (key == LogicalKeyboardKey.arrowRight) target = _calibrationFocus;
+      if (key == LogicalKeyboardKey.arrowRight && !tvListLayout) {
+        target = _calibrationFocus;
+      }
       if (key == LogicalKeyboardKey.arrowDown) {
-        target = _automaticUpdatesFocus;
+        target = tvListLayout ? _calibrationFocus : _automaticUpdatesFocus;
       }
     } else if (current == _calibrationFocus) {
       if (key == LogicalKeyboardKey.arrowUp) {
-        target = _areaFocusNodes[_SettingsArea.system];
+        target = tvListLayout
+            ? _setupFocus
+            : _areaFocusNodes[_SettingsArea.system];
       }
-      if (key == LogicalKeyboardKey.arrowLeft) target = _setupFocus;
-      if (key == LogicalKeyboardKey.arrowRight) target = _diagnosticsFocus;
+      if (key == LogicalKeyboardKey.arrowLeft && !tvListLayout) {
+        target = _setupFocus;
+      }
+      if (key == LogicalKeyboardKey.arrowRight && !tvListLayout) {
+        target = _diagnosticsFocus;
+      }
       if (key == LogicalKeyboardKey.arrowDown) {
-        target = _automaticUpdatesFocus;
+        target = tvListLayout ? _diagnosticsFocus : _automaticUpdatesFocus;
       }
     } else if (current == _diagnosticsFocus) {
       if (key == LogicalKeyboardKey.arrowUp) {
-        target = _areaFocusNodes[_SettingsArea.system];
+        target = tvListLayout
+            ? _calibrationFocus
+            : _areaFocusNodes[_SettingsArea.system];
       }
-      if (key == LogicalKeyboardKey.arrowLeft) target = _calibrationFocus;
+      if (key == LogicalKeyboardKey.arrowLeft && !tvListLayout) {
+        target = _calibrationFocus;
+      }
       if (key == LogicalKeyboardKey.arrowDown) {
         target = _automaticUpdatesFocus;
       }
     } else if (current == _automaticUpdatesFocus) {
-      if (key == LogicalKeyboardKey.arrowUp) target = _setupFocus;
-      if (key == LogicalKeyboardKey.arrowRight) target = _checkUpdatesFocus;
+      if (key == LogicalKeyboardKey.arrowUp) {
+        target = tvListLayout ? _diagnosticsFocus : _setupFocus;
+      }
+      if (key == LogicalKeyboardKey.arrowRight && !tvListLayout) {
+        target = _checkUpdatesFocus;
+      }
       if (key == LogicalKeyboardKey.arrowDown) target = _checkUpdatesFocus;
     } else if (current == _checkUpdatesFocus) {
-      if (key == LogicalKeyboardKey.arrowUp) target = _setupFocus;
-      if (key == LogicalKeyboardKey.arrowLeft) {
+      if (key == LogicalKeyboardKey.arrowUp) {
+        target = tvListLayout ? _automaticUpdatesFocus : _setupFocus;
+      }
+      if (key == LogicalKeyboardKey.arrowLeft && !tvListLayout) {
         target = _automaticUpdatesFocus;
       }
       if (key == LogicalKeyboardKey.arrowDown) {
@@ -1216,19 +1340,32 @@ class _AccountsScreenState extends ConsumerState<AccountsScreen> {
       if (key == LogicalKeyboardKey.arrowDown) target = _discordQrFocus;
     } else if (current == _discordPresenceFocus) {
       if (key == LogicalKeyboardKey.arrowUp) {
-        target = _subEpisodeNotificationsFocus;
+        target = tvListLayout
+            ? _dubEpisodeNotificationsFocus
+            : _subEpisodeNotificationsFocus;
       }
       if (key == LogicalKeyboardKey.arrowRight &&
+          !tvListLayout &&
           focusNodeIsMounted(_discordDisconnectFocus)) {
         target = _discordDisconnectFocus;
       }
       if (key == LogicalKeyboardKey.arrowDown) {
-        return KeyEventResult.handled;
+        if (tvListLayout &&
+            focusNodeIsMounted(_discordDisconnectFocus) &&
+            _discordDisconnectFocus.canRequestFocus) {
+          target = _discordDisconnectFocus;
+        } else {
+          return KeyEventResult.handled;
+        }
       }
     } else if (current == _discordDisconnectFocus) {
-      if (key == LogicalKeyboardKey.arrowLeft) target = _discordPresenceFocus;
+      if (key == LogicalKeyboardKey.arrowLeft && !tvListLayout) {
+        target = _discordPresenceFocus;
+      }
       if (key == LogicalKeyboardKey.arrowUp) {
-        target = _subEpisodeNotificationsFocus;
+        target = tvListLayout
+            ? _discordPresenceFocus
+            : _subEpisodeNotificationsFocus;
       }
       if (key == LogicalKeyboardKey.arrowDown) {
         return KeyEventResult.handled;
@@ -1269,14 +1406,24 @@ class _AccountsScreenState extends ConsumerState<AccountsScreen> {
       if (key == LogicalKeyboardKey.arrowDown) target = _clearCacheFocus;
     } else if (current == _clearCacheFocus) {
       if (key == LogicalKeyboardKey.arrowUp) target = _donateFocus;
-      if (key == LogicalKeyboardKey.arrowRight) target = _resetAppFocus;
-      if (key == LogicalKeyboardKey.arrowDown) target = _privacyFocus;
+      if (key == LogicalKeyboardKey.arrowRight && !tvListLayout) {
+        target = _resetAppFocus;
+      }
+      if (key == LogicalKeyboardKey.arrowDown) {
+        target = tvListLayout ? _resetAppFocus : _privacyFocus;
+      }
     } else if (current == _resetAppFocus) {
-      if (key == LogicalKeyboardKey.arrowUp) target = _donateFocus;
-      if (key == LogicalKeyboardKey.arrowLeft) target = _clearCacheFocus;
+      if (key == LogicalKeyboardKey.arrowUp) {
+        target = tvListLayout ? _clearCacheFocus : _donateFocus;
+      }
+      if (key == LogicalKeyboardKey.arrowLeft && !tvListLayout) {
+        target = _clearCacheFocus;
+      }
       if (key == LogicalKeyboardKey.arrowDown) target = _privacyFocus;
     } else if (current == _privacyFocus) {
-      if (key == LogicalKeyboardKey.arrowUp) target = _clearCacheFocus;
+      if (key == LogicalKeyboardKey.arrowUp) {
+        target = tvListLayout ? _resetAppFocus : _clearCacheFocus;
+      }
       if (key == LogicalKeyboardKey.arrowRight ||
           key == LogicalKeyboardKey.arrowDown) {
         target = _legalFocus;
@@ -1497,6 +1644,7 @@ class _AccountsScreenState extends ConsumerState<AccountsScreen> {
       inputFeedbackSectionFocusNode: _inputFeedbackSectionFocus,
       closedCaptionsSectionFocusNode: _closedCaptionsSectionFocus,
       captionTextColorFocusNode: _captionTextColorFocus,
+      captionTextSizeFocusNode: _captionTextSizeFocus,
       playerControlsSectionFocusNode: _playerControlsSectionFocus,
       resetFocusNode: _customizationResetFocus,
       expandedSections: _expandedCustomizationSections,
@@ -1681,6 +1829,7 @@ class _AccountsScreenState extends ConsumerState<AccountsScreen> {
       subtitle:
           'Join the TetoTV Discord for announcements, support, and feature requests.',
       child: _CommunityPanels(
+        forceSingleColumn: isTelevision,
         discordQrFocusNode: _discordQrFocus,
         discordFocusNode: _discordFocus,
         donationQrFocusNode: _donationQrFocus,
@@ -1693,6 +1842,7 @@ class _AccountsScreenState extends ConsumerState<AccountsScreen> {
       title: 'Storage & reset',
       subtitle: 'Remove temporary files or return TetoTV to first-time setup.',
       child: _StorageResetPanel(
+        forceSingleColumn: isTelevision,
         clearCacheFocusNode: _clearCacheFocus,
         resetAppFocusNode: _resetAppFocus,
       ),
@@ -1846,6 +1996,7 @@ class _AccountsScreenState extends ConsumerState<AccountsScreen> {
                       const SizedBox(height: 8),
                     ],
                     _AppearanceSettingsLayout(
+                      usesTvListLayout: layout.usesTvRail,
                       preferences: preferences,
                       titlePreference: titlePreference,
                       homeShelves: homeShelves,
@@ -1863,7 +2014,9 @@ class _AccountsScreenState extends ConsumerState<AccountsScreen> {
                       posterMetadataFocusNode: _posterMetadataFocus,
                       continueWatchingFocusNode: _continueWatchingFocus,
                       displayOptionsFirstFocusNode: _displaySectionFocus,
+                      cardDetailsFocusNode: _cardDetailsFocus,
                       inputFeedbackFirstFocusNode: _inputFeedbackSectionFocus,
+                      clickSoundsFocusNode: _clickSoundsFocus,
                       shelfFocusNodes: _shelfFocusNodes,
                       onOpenThemeStudio: () =>
                           context.push(ThemeStudioScreen.routePath),
@@ -1892,6 +2045,7 @@ class _AccountsScreenState extends ConsumerState<AccountsScreen> {
                       const SizedBox(height: 8),
                     ],
                     _SettingsResponsiveColumns(
+                      forceSingleColumn: layout.usesTvRail,
                       left: _SettingsSectionCard(
                         key: const ValueKey('settings-card-playback-captions'),
                         title: 'Closed captions',
@@ -1924,6 +2078,7 @@ class _AccountsScreenState extends ConsumerState<AccountsScreen> {
                       const SizedBox(height: 8),
                     ],
                     _SettingsResponsiveColumns(
+                      forceSingleColumn: layout.usesTvRail,
                       left: _SettingsCardLane(
                         children: [
                           _SettingsSectionCard(
@@ -2124,8 +2279,6 @@ class _AccountsScreenState extends ConsumerState<AccountsScreen> {
                               ],
                             ),
                           ),
-                          if (layout.usesTvRail) automaticSourceSelectionCard(),
-                          if (layout.usesTvRail) librariesAndFeaturesCard(),
                         ],
                       ),
                       right: _SettingsCardLane(
@@ -2186,6 +2339,8 @@ class _AccountsScreenState extends ConsumerState<AccountsScreen> {
                               ],
                             ),
                           ),
+                          if (layout.usesTvRail) automaticSourceSelectionCard(),
+                          if (layout.usesTvRail) librariesAndFeaturesCard(),
                           if (layout.usesTvRail) streamingPrivacyCard(),
                         ],
                       ),
@@ -2215,6 +2370,7 @@ class _AccountsScreenState extends ConsumerState<AccountsScreen> {
                       const SizedBox(height: 8),
                     ],
                     _SettingsResponsiveColumns(
+                      forceSingleColumn: layout.usesTvRail,
                       left: _SettingsCardLane(
                         children: [
                           _SettingsSectionCard(
@@ -2310,6 +2466,7 @@ class _AccountsScreenState extends ConsumerState<AccountsScreen> {
                                           TrackingProvider.anilist
                                       ? _anilistSaveFocus
                                       : _malSaveFocus,
+                                  disconnectFocusNode: _trackingDisconnectFocus,
                                 ),
                               ],
                             ),
@@ -2422,6 +2579,7 @@ class _AccountsScreenState extends ConsumerState<AccountsScreen> {
                       const SizedBox(height: 8),
                     ],
                     _SettingsResponsiveColumns(
+                      forceSingleColumn: layout.usesTvRail,
                       left: _SettingsCardLane(
                         children: [
                           _SettingsSectionCard(
@@ -2462,8 +2620,6 @@ class _AccountsScreenState extends ConsumerState<AccountsScreen> {
                               ],
                             ),
                           ),
-                          if (layout.usesTvRail) communityCard(),
-                          if (layout.usesTvRail) privacyAndDiagnosticsCard(),
                         ],
                       ),
                       right: _SettingsCardLane(
@@ -2477,6 +2633,7 @@ class _AccountsScreenState extends ConsumerState<AccountsScreen> {
                               crossAxisAlignment: CrossAxisAlignment.stretch,
                               children: [
                                 _AppUpdatePanel(
+                                  forceSingleColumn: isTelevision,
                                   state: appUpdate,
                                   automaticFocusNode: _automaticUpdatesFocus,
                                   checkFocusNode: _checkUpdatesFocus,
@@ -2524,8 +2681,10 @@ class _AccountsScreenState extends ConsumerState<AccountsScreen> {
                               ],
                             ),
                           ),
+                          if (layout.usesTvRail) communityCard(),
                           if (layout.usesTvRail) storageAndResetCard(),
                           if (layout.usesTvRail) legalNoticesCard(),
+                          if (layout.usesTvRail) privacyAndDiagnosticsCard(),
                         ],
                       ),
                     ),
@@ -2697,6 +2856,7 @@ class _SettingsResponsiveColumns extends StatelessWidget {
     this.leftFlex = 1,
     this.rightFlex = 1,
     this.gap = 20,
+    this.forceSingleColumn = false,
   });
 
   final Widget left;
@@ -2704,11 +2864,15 @@ class _SettingsResponsiveColumns extends StatelessWidget {
   final int leftFlex;
   final int rightFlex;
   final double gap;
+  final bool forceSingleColumn;
   static const double _breakpoint = 800;
 
   @override
   Widget build(BuildContext context) => LayoutBuilder(
     builder: (context, constraints) {
+      if (forceSingleColumn) {
+        return _SettingsCardLane(children: [left, right]);
+      }
       if (constraints.maxWidth < _breakpoint) {
         return Column(
           crossAxisAlignment: CrossAxisAlignment.stretch,
@@ -2818,6 +2982,7 @@ class _SettingsCardScope extends InheritedWidget {
 
 class _AppearanceSettingsLayout extends StatelessWidget {
   const _AppearanceSettingsLayout({
+    required this.usesTvListLayout,
     required this.preferences,
     required this.titlePreference,
     required this.homeShelves,
@@ -2833,7 +2998,9 @@ class _AppearanceSettingsLayout extends StatelessWidget {
     required this.posterMetadataFocusNode,
     required this.continueWatchingFocusNode,
     required this.displayOptionsFirstFocusNode,
+    required this.cardDetailsFocusNode,
     required this.inputFeedbackFirstFocusNode,
+    required this.clickSoundsFocusNode,
     required this.shelfFocusNodes,
     required this.onOpenThemeStudio,
     required this.onOpenMenuOrder,
@@ -2843,6 +3010,7 @@ class _AppearanceSettingsLayout extends StatelessWidget {
     required this.onShelfMove,
   });
 
+  final bool usesTvListLayout;
   final SettingsPreferences preferences;
   final TitleLanguagePreference titlePreference;
   final Set<HomeShelf> homeShelves;
@@ -2858,7 +3026,9 @@ class _AppearanceSettingsLayout extends StatelessWidget {
   final FocusNode posterMetadataFocusNode;
   final FocusNode continueWatchingFocusNode;
   final FocusNode displayOptionsFirstFocusNode;
+  final FocusNode cardDetailsFocusNode;
   final FocusNode inputFeedbackFirstFocusNode;
+  final FocusNode clickSoundsFocusNode;
   final Map<HomeShelf, FocusNode> shelfFocusNodes;
   final VoidCallback onOpenThemeStudio;
   final VoidCallback onOpenMenuOrder;
@@ -3105,6 +3275,7 @@ class _AppearanceSettingsLayout extends StatelessWidget {
           subtitle: 'Show supporting text beneath posters and media cards.',
           icon: Icons.subtitles_outlined,
           value: preferences.showCardSubtitles,
+          focusNode: cardDetailsFocusNode,
           onChanged: controller.setShowCardSubtitles,
         ),
       ],
@@ -3140,6 +3311,7 @@ class _AppearanceSettingsLayout extends StatelessWidget {
           subtitle: 'Play confirmation feedback when selecting an option.',
           icon: Icons.touch_app_outlined,
           value: preferences.clickSounds,
+          focusNode: clickSoundsFocusNode,
           onChanged: controller.setClickSounds,
         ),
       ],
@@ -3167,16 +3339,16 @@ class _AppearanceSettingsLayout extends StatelessWidget {
       ],
     );
 
-    if (usesTvDashboard) {
-      return _SettingsResponsiveColumns(
-        leftFlex: 51,
-        rightFlex: 49,
-        left: _SettingsCardLane(
-          children: [themeAndDisplay, navigation, homeShelvesPanel],
-        ),
-        right: _SettingsCardLane(
-          children: [homeScreen, displayOptions, inputAndFeedback],
-        ),
+    if (usesTvListLayout) {
+      return _SettingsCardLane(
+        children: [
+          themeAndDisplay,
+          homeScreen,
+          displayOptions,
+          inputAndFeedback,
+          homeShelvesPanel,
+          navigation,
+        ],
       );
     }
 
@@ -3854,6 +4026,7 @@ class _CustomizationPanel extends StatelessWidget {
     required this.inputFeedbackSectionFocusNode,
     required this.closedCaptionsSectionFocusNode,
     required this.captionTextColorFocusNode,
+    required this.captionTextSizeFocusNode,
     required this.playerControlsSectionFocusNode,
     required this.resetFocusNode,
     required this.expandedSections,
@@ -3884,6 +4057,7 @@ class _CustomizationPanel extends StatelessWidget {
   final FocusNode inputFeedbackSectionFocusNode;
   final FocusNode closedCaptionsSectionFocusNode;
   final FocusNode captionTextColorFocusNode;
+  final FocusNode captionTextSizeFocusNode;
   final FocusNode playerControlsSectionFocusNode;
   final FocusNode resetFocusNode;
   final Set<_CustomizationSection> expandedSections;
@@ -4242,6 +4416,7 @@ class _CustomizationPanel extends StatelessWidget {
                   label: 'Text size',
                   icon: Icons.text_fields_rounded,
                   value: preferences.captionTextSize,
+                  focusNode: captionTextSizeFocusNode,
                   valueLabel: '${preferences.captionTextSize.round()}',
                   options: [
                     for (final size in const [28.0, 34.0, 42.0, 50.0])
@@ -5516,6 +5691,7 @@ class _DeveloperUpdatePanel extends StatelessWidget {
 
 class _AppUpdatePanel extends StatelessWidget {
   const _AppUpdatePanel({
+    required this.forceSingleColumn,
     required this.state,
     required this.automaticFocusNode,
     required this.checkFocusNode,
@@ -5523,6 +5699,7 @@ class _AppUpdatePanel extends StatelessWidget {
     required this.onCheckOrInstall,
   });
 
+  final bool forceSingleColumn;
   final AppUpdateState state;
   final FocusNode automaticFocusNode;
   final FocusNode checkFocusNode;
@@ -5678,7 +5855,7 @@ class _AppUpdatePanel extends StatelessWidget {
                   : Icons.update_disabled_rounded,
               onPressed: state.isBusy ? null : onToggleAutomatic,
               focusNode: automaticFocusNode,
-              showDivider: !tvScale,
+              showDivider: forceSingleColumn || !tvScale,
             );
             final check = _SettingsPanelActionRow(
               label: checkLabel,
@@ -5690,7 +5867,7 @@ class _AppUpdatePanel extends StatelessWidget {
               onPressed: state.isBusy ? null : onCheckOrInstall,
               focusNode: checkFocusNode,
             );
-            if (!tvScale) {
+            if (forceSingleColumn || !tvScale) {
               return Column(children: [automatic, check]);
             }
             return Row(
@@ -6392,12 +6569,14 @@ class _LegalNoticesPanel extends StatelessWidget {
 
 class _CommunityPanels extends StatelessWidget {
   const _CommunityPanels({
+    required this.forceSingleColumn,
     required this.discordQrFocusNode,
     required this.discordFocusNode,
     required this.donationQrFocusNode,
     required this.donationFocusNode,
   });
 
+  final bool forceSingleColumn;
   final FocusNode discordQrFocusNode;
   final FocusNode discordFocusNode;
   final FocusNode donationQrFocusNode;
@@ -6415,7 +6594,7 @@ class _CommunityPanels extends StatelessWidget {
     );
     return LayoutBuilder(
       builder: (context, constraints) {
-        if (constraints.maxWidth < 900) {
+        if (constraints.maxWidth < 900 || forceSingleColumn) {
           return Column(
             children: [
               discord,
@@ -7579,6 +7758,7 @@ class _TrackingPanel extends StatefulWidget {
     required this.focusNode,
     required this.tokenFocusNode,
     required this.saveFocusNode,
+    required this.disconnectFocusNode,
     required this.isLoading,
     this.username,
     this.error,
@@ -7593,6 +7773,7 @@ class _TrackingPanel extends StatefulWidget {
   final FocusNode focusNode;
   final FocusNode tokenFocusNode;
   final FocusNode saveFocusNode;
+  final FocusNode disconnectFocusNode;
   final bool isLoading;
   final String? username;
   final String? error;
@@ -7668,6 +7849,7 @@ class _TrackingPanelState extends State<_TrackingPanel> {
             subtitle:
                 'Remove this ${widget.provider.displayName} connection from TetoTV.',
             icon: Icons.link_off_rounded,
+            focusNode: widget.disconnectFocusNode,
             destructive: true,
             onPressed: widget.onDisconnect,
           ),
@@ -7869,10 +8051,12 @@ class _Panel extends StatelessWidget {
 
 class _StorageResetPanel extends StatefulWidget {
   const _StorageResetPanel({
+    required this.forceSingleColumn,
     required this.clearCacheFocusNode,
     required this.resetAppFocusNode,
   });
 
+  final bool forceSingleColumn;
   final FocusNode clearCacheFocusNode;
   final FocusNode resetAppFocusNode;
 
@@ -7962,7 +8146,8 @@ class _StorageResetPanelState extends State<_StorageResetPanel> {
   @override
   Widget build(BuildContext context) => LayoutBuilder(
     builder: (context, constraints) {
-      final compact = !_usesTvSettingsScale(context);
+      final compact =
+          widget.forceSingleColumn || !_usesTvSettingsScale(context);
       final enabled = !_clearingCache && !_resetting;
       final clear = _SettingsPanelActionRow(
         key: const ValueKey('storage-clear-cache'),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: 'none'
 # Public and Beta artifacts built from the same source use one monotonically
 # increasing Android versionCode. The project default carries the Beta display
 # version; the Public universal APK overrides the build name to the 1.x line.
-version: 2.0.50+410027
+version: 2.0.51+410028
 
 environment:
   sdk: ^3.12.2

--- a/test/accounts_focus_test.dart
+++ b/test/accounts_focus_test.dart
@@ -1,9 +1,11 @@
 import 'package:anime_tv/core/layout/adaptive_layout.dart';
+import 'package:anime_tv/core/platform/android_tv_bridge.dart';
 import 'package:anime_tv/features/settings/application/real_debrid_settings_controller.dart';
 import 'package:anime_tv/features/settings/application/home_shelf_preferences_controller.dart';
 import 'package:anime_tv/features/settings/application/app_update_controller.dart';
 import 'package:anime_tv/features/settings/application/settings_preferences_controller.dart';
 import 'package:anime_tv/features/settings/presentation/accounts_screen.dart';
+import 'package:anime_tv/features/discord/application/discord_presence_controller.dart';
 import 'package:anime_tv/features/streaming/data/real_debrid_models.dart';
 import 'package:anime_tv/core/theme/app_theme.dart';
 import 'package:anime_tv/core/tv/tv_focusable.dart';
@@ -91,43 +93,40 @@ void main() {
     await tester.pump();
     expect(
       FocusManager.instance.primaryFocus?.debugLabel,
-      'accounts.customization.home-content.featured',
+      'accounts.customization.first',
+      reason:
+          'A vertical Settings list must not jump to another card on Right.',
     );
-    await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
-    await tester.pump();
-    expect(
-      FocusManager.instance.primaryFocus?.debugLabel,
-      'accounts.customization.home-content.poster-metadata',
-    );
-    await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
-    await tester.pump();
-    expect(
-      FocusManager.instance.primaryFocus?.debugLabel,
-      'accounts.customization.home-content.continue-watching',
-    );
-    await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
-    await tester.pump();
-    expect(
-      FocusManager.instance.primaryFocus?.debugLabel,
-      'accounts.shelf.${HomeShelf.values.first.name}',
-    );
-    await tester.sendKeyEvent(LogicalKeyboardKey.arrowUp);
-    await tester.pump();
-    expect(
-      FocusManager.instance.primaryFocus?.debugLabel,
-      'accounts.customization.home-content.continue-watching',
-    );
-    await tester.sendKeyEvent(LogicalKeyboardKey.arrowLeft);
-    await tester.pump();
-    expect(
-      FocusManager.instance.primaryFocus?.debugLabel,
+    for (final expected in const [
+      'accounts.title-language',
       'accounts.show-title-style',
+      'accounts.customization.home-content.featured',
+      'accounts.customization.home-content.poster-metadata',
+      'accounts.customization.home-content.continue-watching',
+      'accounts.section.display',
+    ]) {
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
+      await tester.pump();
+      expect(FocusManager.instance.primaryFocus?.debugLabel, expected);
+    }
+
+    final appearanceTab = tester.widget<TvFocusable>(
+      find.byKey(const ValueKey('settings-area-appearance')),
     );
-    await tester.sendKeyEvent(LogicalKeyboardKey.arrowUp);
-    await tester.sendKeyEvent(LogicalKeyboardKey.arrowUp);
-    await tester.sendKeyEvent(LogicalKeyboardKey.arrowUp);
+    appearanceTab.focusNode!.requestFocus();
+    await tester.pump();
     await tester.sendKeyEvent(LogicalKeyboardKey.arrowRight);
+    await tester.pump();
+    expect(
+      FocusManager.instance.primaryFocus?.debugLabel,
+      'accounts.area.playback',
+    );
     await tester.sendKeyEvent(LogicalKeyboardKey.arrowRight);
+    await tester.pump();
+    expect(
+      FocusManager.instance.primaryFocus?.debugLabel,
+      'accounts.area.services',
+    );
     await tester.sendKeyEvent(LogicalKeyboardKey.enter);
     await tester.pumpAndSettle();
     await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
@@ -157,7 +156,7 @@ void main() {
   });
 
   testWidgets(
-    'TV Settings keep the rail and use the polished two-column tabs',
+    'TV Settings keep the rail and use the polished single-list tabs',
     (tester) async {
       FlutterSecureStorage.setMockInitialValues({});
       tester.view.physicalSize = const Size(960, 540);
@@ -236,9 +235,12 @@ void main() {
       final homeCard = tester.getRect(
         find.byKey(const ValueKey('appearance-home-screen-card')),
       );
-      expect(homeCard.left, greaterThan(themeCard.right));
-      expect((homeCard.top - themeCard.top).abs(), lessThan(3));
-      expect(navigationCard.top, greaterThan(themeCard.bottom));
+      expect((navigationCard.left - themeCard.left).abs(), lessThan(1));
+      expect((homeCard.left - themeCard.left).abs(), lessThan(1));
+      expect((navigationCard.width - themeCard.width).abs(), lessThan(1));
+      expect((homeCard.width - themeCard.width).abs(), lessThan(1));
+      expect(homeCard.top, greaterThan(themeCard.bottom));
+      expect(navigationCard.top, greaterThan(homeCard.bottom));
       expect(
         FocusManager.instance.primaryFocus?.debugLabel,
         'accounts.customization.first',
@@ -474,7 +476,7 @@ void main() {
     expect(tester.takeException(), isNull);
   });
 
-  testWidgets('every source toggle moves Down to Debrid results', (
+  testWidgets('source controls move Down through the single-list card', (
     tester,
   ) async {
     FlutterSecureStorage.setMockInitialValues({});
@@ -490,11 +492,13 @@ void main() {
     await tester.tap(find.text('Services'));
     await tester.pumpAndSettle();
 
-    for (final debugLabel in const [
-      'accounts.streaming.debrid',
-      'accounts.streaming.web',
-      'accounts.streaming.direct-torrent',
+    for (final transition in const [
+      ('accounts.streaming.debrid', 'accounts.streaming.web'),
+      ('accounts.streaming.web', 'accounts.streaming.direct-torrent'),
+      ('accounts.streaming.direct-torrent', 'accounts.streaming.marketplace'),
+      ('accounts.streaming.marketplace', 'accounts.streaming.debrid-sort'),
     ]) {
+      final debugLabel = transition.$1;
       final focusableFinder = find.byWidgetPredicate(
         (widget) =>
             widget is TvFocusable && widget.focusNode?.debugLabel == debugLabel,
@@ -510,8 +514,8 @@ void main() {
       await tester.pumpAndSettle();
       expect(
         FocusManager.instance.primaryFocus?.debugLabel,
-        'accounts.streaming.debrid-sort',
-        reason: '$debugLabel should enter the ranking controls below sources.',
+        transition.$2,
+        reason: '$debugLabel should move to the next visible source control.',
       );
     }
     expect(tester.takeException(), isNull);
@@ -601,8 +605,13 @@ void main() {
       final menuOrder = find.byKey(
         const ValueKey('settings-appearance-menu-order'),
       );
-      await tester.ensureVisible(menuOrder);
-      await tester.tap(menuOrder);
+      final menuOrderFocusable = find
+          .descendant(of: menuOrder, matching: find.byType(TvFocusable))
+          .first;
+      await tester.ensureVisible(menuOrderFocusable);
+      tester.widget<TvFocusable>(menuOrderFocusable).focusNode!.requestFocus();
+      await tester.pumpAndSettle();
+      await tester.sendKeyEvent(LogicalKeyboardKey.enter);
       await tester.pumpAndSettle();
       expect(
         find.byKey(const ValueKey('settings-top-navigation-toggle-downloads')),
@@ -869,20 +878,50 @@ void main() {
     for (final expected in const [
       'accounts.title-language',
       'accounts.show-title-style',
-      'accounts.customization.navigation-size',
-      'accounts.customization.menu-order',
-      'accounts.customization.reset',
+      'accounts.customization.home-content.featured',
+      'accounts.customization.home-content.poster-metadata',
+      'accounts.customization.home-content.continue-watching',
+      'accounts.section.display',
     ]) {
       await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
       await tester.pumpAndSettle();
       expect(FocusManager.instance.primaryFocus?.debugLabel, expected);
     }
+
+    final navigationSize = find.byWidgetPredicate(
+      (widget) =>
+          widget is TvFocusable &&
+          widget.focusNode?.debugLabel ==
+              'accounts.customization.navigation-size',
+    );
+    await tester.ensureVisible(navigationSize);
+    final navigationFocus = tester
+        .widget<TvFocusable>(navigationSize)
+        .focusNode!;
+    navigationFocus.requestFocus();
+    await tester.pumpAndSettle();
+    expect(
+      FocusManager.instance.primaryFocus?.debugLabel,
+      'accounts.customization.navigation-size',
+    );
+    await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
+    await tester.pumpAndSettle();
+    expect(
+      FocusManager.instance.primaryFocus?.debugLabel,
+      'accounts.customization.menu-order',
+    );
     await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
     await tester.pumpAndSettle();
     expect(
       FocusManager.instance.primaryFocus?.debugLabel,
       'accounts.customization.reset',
-      reason: 'Down stops on the final row in the Appearance column.',
+    );
+    await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
+    await tester.pumpAndSettle();
+    expect(
+      FocusManager.instance.primaryFocus?.debugLabel,
+      'accounts.customization.reset',
+      reason: 'Reset stays the terminal action in the TV Appearance list.',
     );
     await tester.sendKeyEvent(LogicalKeyboardKey.arrowLeft);
     await tester.pumpAndSettle();
@@ -1111,7 +1150,7 @@ void main() {
     await tester.pumpAndSettle();
     expect(
       FocusManager.instance.primaryFocus?.debugLabel,
-      'accounts.customization.home-content.continue-watching',
+      'accounts.customization.input.click-sounds',
     );
     await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
     await tester.pumpAndSettle();
@@ -1127,8 +1166,15 @@ void main() {
     }
     expect(
       FocusManager.instance.primaryFocus?.debugLabel,
+      'accounts.customization.navigation-size',
+      reason: 'The final shelf row must continue into the Navigation card.',
+    );
+    await tester.sendKeyEvent(LogicalKeyboardKey.arrowUp);
+    await tester.pumpAndSettle();
+    expect(
+      FocusManager.instance.primaryFocus?.debugLabel,
       'accounts.shelf.${HomeShelf.values.last.name}',
-      reason: 'Down stops at the final visible shelf row.',
+      reason: 'Navigation size must return to the final shelf row on Up.',
     );
     expect(tester.takeException(), isNull);
   });
@@ -1218,7 +1264,7 @@ void main() {
       isTrue,
     );
 
-    await tester.sendKeyEvent(LogicalKeyboardKey.arrowRight);
+    await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
     await tester.pumpAndSettle();
     expect(
       FocusManager.instance.primaryFocus?.debugLabel,
@@ -1343,19 +1389,18 @@ void main() {
     await tester.pumpAndSettle();
 
     await selectSettingsArea(tester, 'system');
-    for (final key in [
-      LogicalKeyboardKey.arrowDown,
-      LogicalKeyboardKey.arrowDown,
+    for (final expected in const [
+      'accounts.system.setup',
+      'accounts.system.calibration',
+      'accounts.system.diagnostics',
+      'accounts.updates.automatic',
     ]) {
-      await tester.sendKeyEvent(key);
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
       await tester.pumpAndSettle();
+      expect(FocusManager.instance.primaryFocus?.debugLabel, expected);
     }
 
-    expect(
-      FocusManager.instance.primaryFocus?.debugLabel,
-      'accounts.updates.automatic',
-    );
-    await tester.sendKeyEvent(LogicalKeyboardKey.arrowRight);
+    await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
     await tester.pumpAndSettle();
     expect(
       FocusManager.instance.primaryFocus?.debugLabel,
@@ -1365,15 +1410,16 @@ void main() {
     await tester.pumpAndSettle();
     expect(
       FocusManager.instance.primaryFocus?.debugLabel,
-      'accounts.system.setup',
+      'accounts.updates.automatic',
     );
-    await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
+    await tester.sendKeyEvent(LogicalKeyboardKey.arrowUp);
     await tester.pumpAndSettle();
     expect(
       FocusManager.instance.primaryFocus?.debugLabel,
-      'accounts.updates.automatic',
+      'accounts.system.diagnostics',
     );
-    await tester.sendKeyEvent(LogicalKeyboardKey.arrowRight);
+    await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
+    await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
     await tester.pumpAndSettle();
     expect(
       FocusManager.instance.primaryFocus?.debugLabel,
@@ -1409,7 +1455,7 @@ void main() {
       FocusManager.instance.primaryFocus?.debugLabel,
       'accounts.system.clear-cache',
     );
-    await tester.sendKeyEvent(LogicalKeyboardKey.arrowRight);
+    await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
     await tester.pumpAndSettle();
     expect(
       FocusManager.instance.primaryFocus?.debugLabel,
@@ -1567,13 +1613,8 @@ void main() {
       await const FlutterSecureStorage().read(key: 'beta_update_access_key'),
       isNull,
     );
-    for (final key in [
-      LogicalKeyboardKey.arrowDown,
-      LogicalKeyboardKey.arrowDown,
-      LogicalKeyboardKey.arrowDown,
-      LogicalKeyboardKey.arrowDown,
-    ]) {
-      await tester.sendKeyEvent(key);
+    for (var index = 0; index < 6; index++) {
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
       await tester.pumpAndSettle();
     }
     expect(
@@ -1636,11 +1677,10 @@ void main() {
     expect(donationRect.left, greaterThan(donationQrRect.right));
     expect(donationQrRect.top, greaterThan(discordQrRect.bottom));
 
-    await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
-    await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
-    await tester.sendKeyEvent(LogicalKeyboardKey.arrowRight);
-    await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
-    await tester.pumpAndSettle();
+    for (var index = 0; index < 6; index++) {
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
+      await tester.pumpAndSettle();
+    }
     expect(
       FocusManager.instance.primaryFocus?.debugLabel,
       'accounts.system.discord-qr',
@@ -1667,14 +1707,32 @@ void main() {
   });
 
   testWidgets('Accounts expose Discord Rich Presence actions', (tester) async {
-    FlutterSecureStorage.setMockInitialValues({});
+    FlutterSecureStorage.setMockInitialValues({
+      'discord_rich_presence_access_token': 'test-access',
+      'discord_rich_presence_refresh_token': 'test-refresh',
+      'discord_rich_presence_token_type': '1',
+      'discord_rich_presence_expires_at': DateTime.now()
+          .add(const Duration(days: 7))
+          .millisecondsSinceEpoch
+          .toString(),
+      'discord_rich_presence_scopes': 'openid sdk.social_layer_presence',
+      'discord_rich_presence_enabled': 'true',
+    });
     tester.view.physicalSize = const Size(1280, 720);
     tester.view.devicePixelRatio = 1;
     addTearDown(tester.view.resetPhysicalSize);
     addTearDown(tester.view.resetDevicePixelRatio);
 
     await tester.pumpWidget(
-      const ProviderScope(child: MaterialApp(home: AccountsScreen())),
+      ProviderScope(
+        overrides: [
+          isTelevisionProvider.overrideWithValue(true),
+          discordPresencePlatformProvider.overrideWithValue(
+            const _SettingsDiscordFocusPlatform(),
+          ),
+        ],
+        child: const MaterialApp(home: TvShortcuts(child: AccountsScreen())),
+      ),
     );
     await tester.pumpAndSettle();
     await tester.tap(find.text('Accounts'));
@@ -1689,6 +1747,36 @@ void main() {
     await tester.ensureVisible(discordActions);
     await tester.pumpAndSettle();
     expect(tester.getSize(discordActions).width, greaterThan(0));
+
+    final primaryAction = find.byWidgetPredicate(
+      (widget) =>
+          widget is TvFocusable &&
+          widget.focusNode?.debugLabel == 'accounts.system.discord-presence',
+    );
+    final unlinkAction = find.byWidgetPredicate(
+      (widget) =>
+          widget is TvFocusable &&
+          widget.focusNode?.debugLabel == 'accounts.system.discord-unlink',
+    );
+    expect(primaryAction, findsOneWidget);
+    expect(unlinkAction, findsOneWidget);
+    await tester.ensureVisible(primaryAction);
+    tester.widget<TvFocusable>(primaryAction).focusNode!.requestFocus();
+    await tester.pumpAndSettle();
+
+    await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
+    await tester.pumpAndSettle();
+    expect(
+      FocusManager.instance.primaryFocus?.debugLabel,
+      'accounts.system.discord-unlink',
+      reason: 'TV Discord actions must form one vertical list.',
+    );
+    await tester.sendKeyEvent(LogicalKeyboardKey.arrowUp);
+    await tester.pumpAndSettle();
+    expect(
+      FocusManager.instance.primaryFocus?.debugLabel,
+      'accounts.system.discord-presence',
+    );
     expect(tester.takeException(), isNull);
   });
 
@@ -2258,12 +2346,8 @@ void main() {
       );
       expect(tester.testTextInput.isVisible, isFalse);
 
-      for (final key in [
-        LogicalKeyboardKey.arrowDown,
-        LogicalKeyboardKey.arrowDown,
-        LogicalKeyboardKey.arrowDown,
-      ]) {
-        await tester.sendKeyEvent(key);
+      for (var index = 0; index < 6; index++) {
+        await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
         await tester.pumpAndSettle();
       }
       expect(
@@ -2272,12 +2356,8 @@ void main() {
       );
       expect(tester.testTextInput.isVisible, isFalse);
 
-      for (final key in [
-        LogicalKeyboardKey.arrowUp,
-        LogicalKeyboardKey.arrowUp,
-        LogicalKeyboardKey.arrowUp,
-      ]) {
-        await tester.sendKeyEvent(key);
+      for (var index = 0; index < 6; index++) {
+        await tester.sendKeyEvent(LogicalKeyboardKey.arrowUp);
         await tester.pumpAndSettle();
       }
       expect(
@@ -2321,4 +2401,37 @@ class _ClassicSettingsController extends SettingsPreferencesController {
 
   @override
   Future<void> load() async {}
+}
+
+class _SettingsDiscordFocusPlatform implements DiscordPresencePlatform {
+  const _SettingsDiscordFocusPlatform();
+
+  @override
+  Stream<DiscordBridgeEvent> get events => const Stream.empty();
+
+  @override
+  Future<Map<Object?, Object?>> sdkInfo() async => const {
+    'available': true,
+    'status': 'disconnected',
+    'version': 'test',
+  };
+
+  @override
+  Future<DiscordTokenBundle> authenticate() => throw UnimplementedError();
+
+  @override
+  Future<void> cancelAuthentication() async {}
+
+  @override
+  Future<DiscordTokenBundle> refreshToken(String refreshToken) =>
+      throw UnimplementedError();
+
+  @override
+  Future<void> connect(DiscordTokenBundle token) async {}
+
+  @override
+  Future<bool> revoke(String token) async => true;
+
+  @override
+  Future<void> disconnect() async {}
 }

--- a/test/app_update_release_date_ui_test.dart
+++ b/test/app_update_release_date_ui_test.dart
@@ -112,7 +112,10 @@ void main() {
       ),
     );
 
-    await tester.tap(find.text('2.0.10 Beta'));
+    final installedRelease = find.text('2.0.10 Beta');
+    await tester.ensureVisible(installedRelease);
+    await tester.pumpAndSettle();
+    await tester.tap(installedRelease);
     await tester.pumpAndSettle();
     expect(find.text('2.0.9 Beta'), findsOneWidget);
     expect(

--- a/test/settings_restyle_contract_test.dart
+++ b/test/settings_restyle_contract_test.dart
@@ -47,9 +47,6 @@ void main() {
   double verticalGap(WidgetTester tester, String upper, String lower) =>
       cardRect(tester, lower).top - cardRect(tester, upper).bottom;
 
-  double horizontalGap(WidgetTester tester, String left, String right) =>
-      cardRect(tester, right).left - cardRect(tester, left).right;
-
   testWidgets('all five Settings tabs expose the restyled card contract', (
     tester,
   ) async {
@@ -58,11 +55,11 @@ void main() {
     const cardsByArea = <String, List<String>>{
       'appearance': [
         'appearance-theme-display-card',
-        'appearance-navigation-card',
         'appearance-home-screen-card',
         'appearance-display-options-card',
         'appearance-input-feedback-card',
         'appearance-home-shelves-card',
+        'appearance-navigation-card',
       ],
       'playback': [
         'settings-card-playback-captions',
@@ -263,48 +260,75 @@ void main() {
     }
   });
 
-  testWidgets('TV Settings use one consistent card gutter across every area', (
+  testWidgets('TV Settings use one full-width card list in every area', (
     tester,
   ) async {
     await pumpSettings(tester);
 
-    const pairs = <String, (String, String)>{
-      'appearance': (
+    const cardsByArea = <String, List<String>>{
+      'appearance': [
         'appearance-theme-display-card',
         'appearance-home-screen-card',
-      ),
-      'playback': (
+        'appearance-display-options-card',
+        'appearance-input-feedback-card',
+        'appearance-home-shelves-card',
+        'appearance-navigation-card',
+      ],
+      'playback': [
         'settings-card-playback-captions',
         'settings-card-playback-player',
-      ),
-      'services': (
+      ],
+      'services': [
         'settings-card-services-debrid',
         'settings-card-services-sources',
-      ),
-      'accounts': (
+        'settings-card-services-autopick',
+        'settings-card-services-features',
+        'settings-card-services-privacy',
+      ],
+      'accounts': [
         'settings-card-accounts-tracking',
+        'settings-card-accounts-profiles',
         'settings-card-accounts-behavior',
-      ),
-      'system': (
+        'settings-card-accounts-discord',
+      ],
+      'system': [
         'settings-card-system-support',
         'settings-card-system-updates',
-      ),
+        'settings-card-system-community',
+        'settings-card-system-storage',
+        'settings-card-system-legal',
+        'settings-card-system-privacy-diagnostics',
+      ],
     };
 
-    for (final entry in pairs.entries) {
+    for (final entry in cardsByArea.entries) {
       await selectArea(tester, entry.key);
-      final left = cardRect(tester, entry.value.$1);
-      final right = cardRect(tester, entry.value.$2);
-      expect(
-        (left.top - right.top).abs(),
-        lessThanOrEqualTo(1),
-        reason: '${entry.key} columns must start on the same baseline.',
+      final list = tester.getRect(
+        find.byKey(const ValueKey('settings-content-list')),
       );
-      expect(
-        horizontalGap(tester, entry.value.$1, entry.value.$2),
-        closeTo(8, 1),
-        reason: '${entry.key} must use the shared TV card gutter.',
-      );
+      final first = cardRect(tester, entry.value.first);
+      expect(first.left, closeTo(list.left, 1));
+      expect(first.right, closeTo(list.right, 1));
+
+      for (var index = 0; index < entry.value.length; index++) {
+        final current = cardRect(tester, entry.value[index]);
+        expect(
+          current.left,
+          closeTo(first.left, 1),
+          reason: '${entry.key} cards must share one left edge.',
+        );
+        expect(
+          current.width,
+          closeTo(first.width, 1),
+          reason: '${entry.key} cards must use the full list width.',
+        );
+        if (index == 0) continue;
+        expect(
+          verticalGap(tester, entry.value[index - 1], entry.value[index]),
+          closeTo(8, 1),
+          reason: '${entry.key} cards must use the shared TV list gap.',
+        );
+      }
     }
 
     final tabRects = [
@@ -320,68 +344,6 @@ void main() {
     for (var index = 1; index < tabRects.length; index++) {
       expect(tabRects[index].width, closeTo(tabRects.first.width, 1));
       expect(tabRects[index].left - tabRects[index - 1].right, closeTo(8, 1));
-    }
-  });
-
-  testWidgets('TV Settings stack cards continuously in each visual column', (
-    tester,
-  ) async {
-    await pumpSettings(tester);
-
-    const columnsByArea = <String, List<List<String>>>{
-      'appearance': [
-        [
-          'appearance-theme-display-card',
-          'appearance-navigation-card',
-          'appearance-home-shelves-card',
-        ],
-        [
-          'appearance-home-screen-card',
-          'appearance-display-options-card',
-          'appearance-input-feedback-card',
-        ],
-      ],
-      'services': [
-        [
-          'settings-card-services-debrid',
-          'settings-card-services-autopick',
-          'settings-card-services-features',
-        ],
-        ['settings-card-services-sources', 'settings-card-services-privacy'],
-      ],
-      'accounts': [
-        ['settings-card-accounts-tracking', 'settings-card-accounts-profiles'],
-        ['settings-card-accounts-behavior', 'settings-card-accounts-discord'],
-      ],
-      'system': [
-        [
-          'settings-card-system-support',
-          'settings-card-system-community',
-          'settings-card-system-privacy-diagnostics',
-        ],
-        [
-          'settings-card-system-updates',
-          'settings-card-system-storage',
-          'settings-card-system-legal',
-        ],
-      ],
-    };
-
-    for (final entry in columnsByArea.entries) {
-      await selectArea(tester, entry.key);
-      for (final column in entry.value) {
-        for (var index = 1; index < column.length; index++) {
-          final previous = cardRect(tester, column[index - 1]);
-          final current = cardRect(tester, column[index]);
-          expect((current.left - previous.left).abs(), lessThanOrEqualTo(1));
-          expect((current.width - previous.width).abs(), lessThanOrEqualTo(1));
-          expect(
-            verticalGap(tester, column[index - 1], column[index]),
-            closeTo(8, 1),
-            reason: '${entry.key} cards must stack without a blank lane.',
-          );
-        }
-      }
     }
   });
 
@@ -458,6 +420,23 @@ void main() {
       ),
       closeTo(18, .5),
     );
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('wide non-TV layouts retain their responsive columns', (
+    tester,
+  ) async {
+    await pumpSettings(
+      tester,
+      size: const Size(1280, 720),
+      isTelevision: false,
+    );
+
+    final theme = cardRect(tester, 'appearance-theme-display-card');
+    final home = cardRect(tester, 'appearance-home-screen-card');
+    expect((theme.top - home.top).abs(), lessThanOrEqualTo(1));
+    expect(home.left, greaterThan(theme.right));
+    expect(theme.width, lessThan(home.right - theme.left));
     expect(tester.takeException(), isNull);
   });
 }

--- a/tool/release/native_playback_manifest.json
+++ b/tool/release/native_playback_manifest.json
@@ -375,10 +375,10 @@
     {
       "path": "lib/arm64-v8a/libapp.so",
       "size": 12256144,
-      "sha256": "96e62a565da9654c17da4a2b010947c7c38e67e454e06375f164af9bce3cdb90",
-      "origin": "TetoTV Flutter application AOT 2.0.50",
+      "sha256": "84f8b185da7257cc0666588863105c80efe2aac775efbd13f4a829cb24da78dc",
+      "origin": "TetoTV Flutter application AOT 2.0.51",
       "license": "MIT",
-      "sourceLocator": "Git tag v2.0.50",
+      "sourceLocator": "Git tag v2.0.51",
       "noticeLocator": "LICENSE"
     },
     {
@@ -423,7 +423,7 @@
       "sha256": "dc05f53278b2733094f12aeaed54c080329309762ce49e6de4118e4bfb0fff55",
       "origin": "TetoTV source build of media-kit Android helper at 42054e5d479f39ccbb0ae604862e2bcaf59b74c2",
       "license": "MIT",
-      "sourceLocator": "TetoTV-v2.0.50-native-playback-sources.zip: sources/media-kit-android-helper-42054e5d479f39ccbb0ae604862e2bcaf59b74c2.zip",
+      "sourceLocator": "TetoTV-v2.0.51-native-playback-sources.zip: sources/media-kit-android-helper-42054e5d479f39ccbb0ae604862e2bcaf59b74c2.zip",
       "noticeLocator": "assets/legal/native/MEDIA_KIT_ANDROID_HELPER_LICENSE.txt; assets/legal/native/NATIVE_PLAYBACK_NOTICE.txt"
     },
     {
@@ -432,7 +432,7 @@
       "sha256": "a7399d0be70844e5ee94cc5b1acc1516571113c50561fe0a5d05b49101c53ef2",
       "origin": "TetoTV source build of the pinned mpv and FFmpeg native playback stack",
       "license": "LGPL-3.0-or-later (conservative combined classification) plus component terms",
-      "sourceLocator": "TetoTV-v2.0.50-native-playback-sources.zip and tool/native/build_native_playback.sh",
+      "sourceLocator": "TetoTV-v2.0.51-native-playback-sources.zip and tool/native/build_native_playback.sh",
       "noticeLocator": "assets/legal/native/NATIVE_PLAYBACK_NOTICE.txt and its referenced exact license assets"
     },
     {
@@ -450,16 +450,16 @@
       "sha256": "263ba714570fb3acfc308cce52776b00506ec8809d225617e52352336144cfa2",
       "origin": "TetoTV source build of the pinned libtorrent4j and libtorrent-rasterbar stack",
       "license": "Mixed MIT, BSD, Boost-1.0, Apache-2.0, and MPL-2.0 component terms",
-      "sourceLocator": "TetoTV-v2.0.50-native-playback-sources.zip and tool/native/build_native_playback.sh",
+      "sourceLocator": "TetoTV-v2.0.51-native-playback-sources.zip and tool/native/build_native_playback.sh",
       "noticeLocator": "assets/legal/native/DIRECT_TORRENT_NATIVE_NOTICE.txt and its referenced exact license assets"
     },
     {
       "path": "lib/armeabi-v7a/libapp.so",
-      "size": 13402700,
-      "sha256": "ffe270a23c7234681765311bcf84737fe62edbf3863c9607a9358df70debbc3b",
-      "origin": "TetoTV Flutter application AOT 2.0.50",
+      "size": 13419084,
+      "sha256": "acf6a2ea7014231fc7940d6b5f705ff56c14406e0b2dafef352ed384ca152ae2",
+      "origin": "TetoTV Flutter application AOT 2.0.51",
       "license": "MIT",
-      "sourceLocator": "Git tag v2.0.50",
+      "sourceLocator": "Git tag v2.0.51",
       "noticeLocator": "LICENSE"
     },
     {
@@ -504,7 +504,7 @@
       "sha256": "8820a12e07bb3dc45f5b4286acf6918827fba4c265767e7f1cc8f07215c84b6a",
       "origin": "TetoTV source build of media-kit Android helper at 42054e5d479f39ccbb0ae604862e2bcaf59b74c2",
       "license": "MIT",
-      "sourceLocator": "TetoTV-v2.0.50-native-playback-sources.zip: sources/media-kit-android-helper-42054e5d479f39ccbb0ae604862e2bcaf59b74c2.zip",
+      "sourceLocator": "TetoTV-v2.0.51-native-playback-sources.zip: sources/media-kit-android-helper-42054e5d479f39ccbb0ae604862e2bcaf59b74c2.zip",
       "noticeLocator": "assets/legal/native/MEDIA_KIT_ANDROID_HELPER_LICENSE.txt; assets/legal/native/NATIVE_PLAYBACK_NOTICE.txt"
     },
     {
@@ -513,7 +513,7 @@
       "sha256": "d5a220fdf41edde10f161f86addc846ae9cb18137ea48e4db541cd703fec5092",
       "origin": "TetoTV source build of the pinned mpv and FFmpeg native playback stack",
       "license": "LGPL-3.0-or-later (conservative combined classification) plus component terms",
-      "sourceLocator": "TetoTV-v2.0.50-native-playback-sources.zip and tool/native/build_native_playback.sh",
+      "sourceLocator": "TetoTV-v2.0.51-native-playback-sources.zip and tool/native/build_native_playback.sh",
       "noticeLocator": "assets/legal/native/NATIVE_PLAYBACK_NOTICE.txt and its referenced exact license assets"
     },
     {
@@ -531,7 +531,7 @@
       "sha256": "ba0a19d2730969b8e6107db1847888ea8d3b8cafd14a535a3259dd04f8b28d60",
       "origin": "TetoTV source build of the pinned libtorrent4j and libtorrent-rasterbar stack",
       "license": "Mixed MIT, BSD, Boost-1.0, Apache-2.0, and MPL-2.0 component terms",
-      "sourceLocator": "TetoTV-v2.0.50-native-playback-sources.zip and tool/native/build_native_playback.sh",
+      "sourceLocator": "TetoTV-v2.0.51-native-playback-sources.zip and tool/native/build_native_playback.sh",
       "noticeLocator": "assets/legal/native/DIRECT_TORRENT_NATIVE_NOTICE.txt and its referenced exact license assets"
     }
   ],


### PR DESCRIPTION
## Summary
- replace side-by-side TV Settings cards with one full-width vertical list
- keep the existing compact TV sizing and unchanged phone/tablet behavior
- make D-pad traversal follow the visible list without skipping linked-account, source, caption, update, storage, or legal controls
- prepare Beta 2.0.51 (Android build 410028)

## Verification
- flutter analyze
- flutter test: 1,916 passed, 17 skipped
- Android testDebugUnitTest
- Android app lintDebug
- signed release APK verification
- native redistribution/source-bundle verification
- release payload verification