### PR TITLE
Add searchable collapsible TV settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 
 <p align="center">
   <a href="https://github.com/LindersOSX/TetoTV-Beta/releases/latest"><strong>Download Beta</strong></a>
-  · <a href="docs/RELEASE_NOTES_2.0.51.md">What's new</a>
+  · <a href="docs/RELEASE_NOTES_2.0.52.md">What's new</a>
   · <a href="https://github.com/LindersOSX/TetoTV-Beta/issues/new">Report an issue</a>
   · <a href="https://discord.gg/juC6k7d4WY">Discord</a>
   · <a href="https://www.youtube.com/@TetoTVApp">YouTube</a>
@@ -85,10 +85,10 @@ TetoTV runs directly on the Android device with no companion server required for
 | Channel | Version | Best for |
 | --- | --- | --- |
 | Public | Not published | Source and release-readiness documents are available, but no Public APK is currently offered |
-| Beta | [2.0.51](docs/RELEASE_NOTES_2.0.51.md) | Testing the phone-inspired single-list TV Settings layout, linear remote navigation, and unchanged mobile layout before a separately reviewed Public release |
+| Beta | [2.0.52](docs/RELEASE_NOTES_2.0.52.md) | Testing searchable, collapsible TV Settings with exact remote navigation while preserving the existing phone and tablet layouts before a separately reviewed Public release |
 
 > [!WARNING]
-> Beta 2.0.51 uses the repository's explicit unreviewed-Beta exception. Its native-library and corresponding-source material did not receive independent license review, and automated integrity checks are not a legal compliance determination. Read the [complete Beta disclosure](docs/RELEASE_NOTES_2.0.51.md). This exception does not apply to a future Public release.
+> Beta 2.0.52 uses the repository's explicit unreviewed-Beta exception. Its native-library and corresponding-source material did not receive independent license review, and automated integrity checks are not a legal compliance determination. Read the [complete Beta disclosure](docs/RELEASE_NOTES_2.0.52.md). This exception does not apply to a future Public release.
 
 The Public updater repository intentionally has no release while the Public build is held for review. Existing Beta installations continue to update from the Beta repository. Android never permits an in-place install of an APK with a lower build code; Developer Mode does not bypass that platform rule.
 

--- a/docs/BUILD_WINDOWS.md
+++ b/docs/BUILD_WINDOWS.md
@@ -220,39 +220,39 @@ APK containing both supported application ABIs.
 Public and Beta updates use anonymous GitHub requests. No Beta key, GitHub
 token, update-proxy URL, or update-specific Dart define is required. Every
 published APK uses the production signing identity. No Public APK is currently
-published. Beta 2.0.51 uses Android build code `410028`. Flutter reuses
+published. Beta 2.0.52 uses Android build code `410029`. Flutter reuses
 `app-release.apk`, so copy and rename the Beta artifact immediately after the
 build:
 
 ```powershell
-New-Item -ItemType Directory -Force .\build\fire-tv\v2.0.51 | Out-Null
+New-Item -ItemType Directory -Force .\build\fire-tv\v2.0.52 | Out-Null
 
-# Beta 2.0.51
+# Beta 2.0.52
 flutter build apk --release --target-platform android-arm,android-arm64 `
-  --build-name 2.0.51 --build-number 410028 --no-tree-shake-icons
+  --build-name 2.0.52 --build-number 410029 --no-tree-shake-icons
 Copy-Item .\build\app\outputs\flutter-apk\app-release.apk `
-  .\build\fire-tv\v2.0.51\TetoTV-v2.0.51-universal.apk
+  .\build\fire-tv\v2.0.52\TetoTV-v2.0.52-universal.apk
 
 .\tool\release\verify_release_apk.ps1 `
   -Channel Beta `
-  -ApkPath .\build\fire-tv\v2.0.51\TetoTV-v2.0.51-universal.apk
+  -ApkPath .\build\fire-tv\v2.0.52\TetoTV-v2.0.52-universal.apk
 
 .\tool\release\verify_native_redistribution.ps1 `
   -RequireResolvedBinaries `
   -ResolvedBinaryDirectory .\build\native-playback\outputs `
-  -StageBundle -ReleaseTag v2.0.51
+  -StageBundle -ReleaseTag v2.0.52
 
 .\tool\release\new_release_checksums.ps1 `
-  -ApkPath .\build\fire-tv\v2.0.51\TetoTV-v2.0.51-universal.apk `
-  -NativeSourcePath .\build\release-compliance\v2.0.51\TetoTV-v2.0.51-native-playback-sources.zip `
-  -OutputPath .\build\fire-tv\v2.0.51\SHA256SUMS
+  -ApkPath .\build\fire-tv\v2.0.52\TetoTV-v2.0.52-universal.apk `
+  -NativeSourcePath .\build\release-compliance\v2.0.52\TetoTV-v2.0.52-native-playback-sources.zip `
+  -OutputPath .\build\fire-tv\v2.0.52\SHA256SUMS
 
 .\tool\release\verify_release_payloads.ps1 `
   -Channel Beta `
-  -ApkPath .\build\fire-tv\v2.0.51\TetoTV-v2.0.51-universal.apk `
-  -NativeSourcePath .\build\release-compliance\v2.0.51\TetoTV-v2.0.51-native-playback-sources.zip `
-  -ChecksumsPath .\build\fire-tv\v2.0.51\SHA256SUMS `
-  -ReleaseNotesPath .\docs\RELEASE_NOTES_2.0.51.md
+  -ApkPath .\build\fire-tv\v2.0.52\TetoTV-v2.0.52-universal.apk `
+  -NativeSourcePath .\build\release-compliance\v2.0.52\TetoTV-v2.0.52-native-playback-sources.zip `
+  -ChecksumsPath .\build\fire-tv\v2.0.52\SHA256SUMS `
+  -ReleaseNotesPath .\docs\RELEASE_NOTES_2.0.52.md
 ```
 
 The final payload check requires all five exact, source-built native JARs

--- a/docs/RELEASE_NOTES_2.0.52.md
+++ b/docs/RELEASE_NOTES_2.0.52.md
@@ -1,0 +1,33 @@
+# TetoTV 2.0.52 Beta
+
+> [!WARNING]
+> No independent native-license review: This Beta has not received independent native-library licensing review. Automated checks verify the APK, native-source bundle, notices, pinned inputs, and checksums, but do not establish legal compliance or reproducible builds.
+
+This Beta makes the phone-inspired TV Settings list faster to navigate by adding search and collapsible sections while leaving the existing phone and tablet Settings experience unchanged.
+
+## What's changed
+
+- TV Settings now includes a compact search field at the top of the screen. Results identify and open the matching category and section, then focus the requested control when it is currently available.
+- An `Expand all` / `Collapse all` action sits between search and the profile picker. It applies only to the currently active Settings category so other categories keep their own section state.
+- Every TV Settings card can be collapsed to its section title and expanded again without removing any existing setting or category.
+- Appearance, Playback, Services, Accounts, and System keep the same phone-inspired, full-width vertical card list and compact TV sizing introduced in the previous Beta.
+- D-pad navigation now follows the visible interface exactly: search, the active-area expand/collapse action, profile picker, category tabs, section headers, and every mounted setting form one predictable path.
+- Moving Down from the final control in an expanded section enters the next section header. Moving Up from a section's first control returns to that section header, while Left keeps a deterministic path back to the Settings navigation rail.
+- Search jumps account for conditional controls such as connected accounts, developer update tools, download options, and Beta-only diagnostics, falling back to the matching section header when a requested control is not currently available.
+- Phone and tablet Settings retain their existing responsive layout, sizing, and direct controls; TV-only search and collapsible card behavior are not shown there.
+- Existing privacy, update, source-safety, and three-asset release requirements remain unchanged.
+- AI-assisted development disclosure: AI tools assisted with implementation, design iteration, documentation, tests, and review. The project owner directed the work, validated the changes, and remains responsible for this release.
+
+## Release assets
+
+- `TetoTV-v2.0.52-universal.apk`
+- `TetoTV-v2.0.52-native-playback-sources.zip`
+- `SHA256SUMS`
+
+## Beta notes
+
+- This is a Beta-channel build with Android build code `410029`.
+- No Public APK is being published with this release.
+- Android does not permit an in-place install over an APK with a higher build code. A future Public counterpart must use build code `410029` or newer for data-preserving channel switching.
+
+<!-- tetotv-android-version-code: 410029 -->

--- a/docs/UPDATE_CHANNELS.md
+++ b/docs/UPDATE_CHANNELS.md
@@ -35,11 +35,11 @@ Beta reads completed 2.x releases from:
 https://api.github.com/repos/LindersOSX/TetoTV-Beta/releases/latest
 ```
 
-The current Beta source build is `v2.0.51` with Android build code `410028`.
+The current Beta source build is `v2.0.52` with Android build code `410029`.
 Its release title is:
 
 ```text
-TetoTV 2.0.51 Beta - Android TV / Google TV / Fire TV
+TetoTV 2.0.52 Beta - Android TV / Google TV / Fire TV
 ```
 
 Publish it as a normal, non-draft, non-prerelease GitHub release so
@@ -72,7 +72,7 @@ proxy.
 Release notes must include the exact asset names and this build-code marker:
 
 ```html
-<!-- tetotv-android-version-code: 410028 -->
+<!-- tetotv-android-version-code: 410029 -->
 ```
 
 When build-code metadata is present, the updater rejects a known lower build
@@ -94,10 +94,10 @@ These rules apply equally on phones, Android TV, Google TV, and Fire TV.
 
 ## Switching and rollback
 
-The current Beta uses build code `410028`. No Public counterpart is available.
+The current Beta uses build code `410029`. No Public counterpart is available.
 An older Public install can move to this Beta when Android accepts the higher
 build code, but it cannot move back in place until a future Public build uses
-code `410028` or higher. Uninstalling first permits an older APK but deletes
+code `410029` or higher. Uninstalling first permits an older APK but deletes
 local application data. Developer Mode and in-app settings cannot override
 this Android rule.
 

--- a/lib/core/widgets/teto_top_level_shell.dart
+++ b/lib/core/widgets/teto_top_level_shell.dart
@@ -11,6 +11,13 @@ import 'package:go_router/go_router.dart';
 typedef TetoTopLevelBuilder =
     Widget Function(BuildContext context, TetoTopLevelLayout layout);
 
+typedef TetoTopLevelTvHeaderBuilder =
+    Widget Function(
+      BuildContext context,
+      TetoTopLevelLayout layout,
+      FocusNode profileFocusNode,
+    );
+
 enum TetoTopLevelNavigationPlacement {
   classicTop,
   televisionRail,
@@ -61,6 +68,10 @@ class TetoTopLevelShell extends ConsumerStatefulWidget {
     this.fallbackContentFocusNode,
     this.autofocusRail = false,
     this.onActiveDestinationPressed,
+    this.tvHeaderBuilder,
+    this.tvHeaderFocusNodes = const <FocusNode>[],
+    this.onTvProfileLeft,
+    this.onTvProfileDown,
     this.resizeToAvoidBottomInset = true,
     super.key,
   });
@@ -72,6 +83,10 @@ class TetoTopLevelShell extends ConsumerStatefulWidget {
   final TetoTopLevelBuilder builder;
   final bool autofocusRail;
   final VoidCallback? onActiveDestinationPressed;
+  final TetoTopLevelTvHeaderBuilder? tvHeaderBuilder;
+  final List<FocusNode> tvHeaderFocusNodes;
+  final VoidCallback? onTvProfileLeft;
+  final VoidCallback? onTvProfileDown;
   final bool resizeToAvoidBottomInset;
 
   @override
@@ -124,7 +139,11 @@ class _TetoTopLevelShellState extends ConsumerState<TetoTopLevelShell> {
   void _observeContentMetrics(ScrollMetrics metrics) {
     if (metrics.axis != Axis.vertical) return;
     _profileShouldBeVisibleAtTop = metrics.pixels <= .5;
-    if (!_profileShouldBeVisibleAtTop && _profileFocusNode.hasFocus) {
+    final hiddenHeaderOwnsFocus = widget.tvHeaderFocusNodes.any(
+      (node) => node.hasFocus,
+    );
+    if (!_profileShouldBeVisibleAtTop &&
+        (_profileFocusNode.hasFocus || hiddenHeaderOwnsFocus)) {
       if (_railFocusNode.context != null) {
         _railFocusNode.requestFocus();
       } else {
@@ -247,6 +266,32 @@ class _TetoTopLevelShellState extends ConsumerState<TetoTopLevelShell> {
                     metrics: railMetrics,
                   ),
                 ),
+                if (usesTvRail &&
+                    _profileShouldBeVisibleAtTop &&
+                    widget.tvHeaderBuilder != null)
+                  Positioned(
+                    left: railWidth + (size.width >= 1400 ? 34 : 28),
+                    right:
+                        (size.width >= 1400 ? 30 : 22) +
+                        52 +
+                        (size.width >= 1400 ? 14 : 10),
+                    // Search and section controls are 44px high; center them
+                    // against the adjacent 52px profile switcher.
+                    top: 16,
+                    child: Align(
+                      alignment: Alignment.topRight,
+                      child: ConstrainedBox(
+                        constraints: BoxConstraints(
+                          maxWidth: size.width >= 1400 ? 760 : 620,
+                        ),
+                        child: widget.tvHeaderBuilder!(
+                          context,
+                          layout,
+                          _profileFocusNode,
+                        ),
+                      ),
+                    ),
+                  ),
                 // Use the latest observed scroll metrics directly. A layout
                 // mode change can rebuild before the coalesced setState runs;
                 // this prevents a Classic-at-top -> Modern transition from
@@ -262,14 +307,23 @@ class _TetoTopLevelShellState extends ConsumerState<TetoTopLevelShell> {
                         focusNode: _profileFocusNode,
                         compactAvatar: true,
                         onKeyEvent: (_, event) {
-                          final returnsToContent =
-                              event.logicalKey ==
-                                  LogicalKeyboardKey.arrowLeft ||
+                          final isLeft =
+                              event.logicalKey == LogicalKeyboardKey.arrowLeft;
+                          final isDown =
                               event.logicalKey == LogicalKeyboardKey.arrowDown;
-                          if (!returnsToContent) return KeyEventResult.ignored;
+                          if (!isLeft && !isDown) {
+                            return KeyEventResult.ignored;
+                          }
                           if (event is KeyDownEvent ||
                               event is KeyRepeatEvent) {
-                            _focusContent();
+                            if (isLeft && widget.onTvProfileLeft != null) {
+                              widget.onTvProfileLeft!();
+                            } else if (isDown &&
+                                widget.onTvProfileDown != null) {
+                              widget.onTvProfileDown!();
+                            } else {
+                              _focusContent();
+                            }
                           }
                           return KeyEventResult.handled;
                         },

--- a/lib/features/home/presentation/main_navigation_bar.dart
+++ b/lib/features/home/presentation/main_navigation_bar.dart
@@ -233,7 +233,13 @@ class _HomeSideNavigationState extends ConsumerState<HomeSideNavigation> {
   ) {
     if (event.logicalKey == LogicalKeyboardKey.arrowRight) {
       if (event is KeyDownEvent || event is KeyRepeatEvent) {
-        if (_repeatGate.accept(event)) widget.onExitRight();
+        if (_repeatGate.accept(event)) {
+          // Focus leaves the rail on this packet, so its KeyUp is delivered to
+          // the content target instead. Reset now rather than carrying a stale
+          // held-key state into the next time the viewer returns to the rail.
+          _repeatGate.reset();
+          widget.onExitRight();
+        }
       } else if (event is KeyUpEvent) {
         _repeatGate.accept(event);
       }

--- a/lib/features/settings/presentation/accounts_screen.dart
+++ b/lib/features/settings/presentation/accounts_screen.dart
@@ -7,6 +7,7 @@ import 'package:anime_tv/core/platform/android_tv_bridge.dart';
 import 'package:anime_tv/core/storage/tetotv_database.dart';
 import 'package:anime_tv/core/theme/app_theme.dart';
 import 'package:anime_tv/core/tv/tv_focusable.dart';
+import 'package:anime_tv/core/tv/tv_navigation.dart';
 import 'package:anime_tv/core/tv/tv_shelf_focus.dart';
 import 'package:anime_tv/core/widgets/teto_top_level_shell.dart';
 import 'package:anime_tv/core/widgets/tv_text_input.dart';
@@ -46,6 +47,332 @@ final directTorrentSettingsCapabilityReaderProvider =
 
 enum _SettingsArea { appearance, playback, services, accounts, system }
 
+extension _SettingsAreaMetadata on _SettingsArea {
+  String get label => switch (this) {
+    _SettingsArea.appearance => 'Appearance',
+    _SettingsArea.playback => 'Playback',
+    _SettingsArea.services => 'Services',
+    _SettingsArea.accounts => 'Accounts',
+    _SettingsArea.system => 'System',
+  };
+}
+
+enum _SettingsSection {
+  themeDisplay,
+  homeScreen,
+  displayOptions,
+  inputFeedback,
+  homeShelves,
+  navigation,
+  closedCaptions,
+  playerControls,
+  debridStreaming,
+  sourcesStreamOrder,
+  automaticSourceSelection,
+  librariesFeatures,
+  streamingPrivacy,
+  animeTracking,
+  profiles,
+  progressNotifications,
+  discordRichPresence,
+  deviceSupport,
+  appUpdates,
+  community,
+  storageReset,
+  aboutLegal,
+  privacyDiagnostics,
+}
+
+extension _SettingsSectionMetadata on _SettingsSection {
+  _SettingsArea get area => switch (this) {
+    _SettingsSection.themeDisplay ||
+    _SettingsSection.homeScreen ||
+    _SettingsSection.displayOptions ||
+    _SettingsSection.inputFeedback ||
+    _SettingsSection.homeShelves ||
+    _SettingsSection.navigation => _SettingsArea.appearance,
+    _SettingsSection.closedCaptions ||
+    _SettingsSection.playerControls => _SettingsArea.playback,
+    _SettingsSection.debridStreaming ||
+    _SettingsSection.sourcesStreamOrder ||
+    _SettingsSection.automaticSourceSelection ||
+    _SettingsSection.librariesFeatures ||
+    _SettingsSection.streamingPrivacy => _SettingsArea.services,
+    _SettingsSection.animeTracking ||
+    _SettingsSection.profiles ||
+    _SettingsSection.progressNotifications ||
+    _SettingsSection.discordRichPresence => _SettingsArea.accounts,
+    _SettingsSection.deviceSupport ||
+    _SettingsSection.appUpdates ||
+    _SettingsSection.community ||
+    _SettingsSection.storageReset ||
+    _SettingsSection.aboutLegal ||
+    _SettingsSection.privacyDiagnostics => _SettingsArea.system,
+  };
+
+  String get slug => switch (this) {
+    _SettingsSection.themeDisplay => 'theme-display',
+    _SettingsSection.homeScreen => 'home-screen',
+    _SettingsSection.displayOptions => 'display-options',
+    _SettingsSection.inputFeedback => 'input-feedback',
+    _SettingsSection.homeShelves => 'home-shelves',
+    _SettingsSection.navigation => 'navigation',
+    _SettingsSection.closedCaptions => 'closed-captions',
+    _SettingsSection.playerControls => 'player-controls',
+    _SettingsSection.debridStreaming => 'debrid-streaming',
+    _SettingsSection.sourcesStreamOrder => 'sources-stream-order',
+    _SettingsSection.automaticSourceSelection => 'automatic-source-selection',
+    _SettingsSection.librariesFeatures => 'libraries-features',
+    _SettingsSection.streamingPrivacy => 'streaming-privacy',
+    _SettingsSection.animeTracking => 'anime-tracking',
+    _SettingsSection.profiles => 'profiles',
+    _SettingsSection.progressNotifications => 'progress-notifications',
+    _SettingsSection.discordRichPresence => 'discord-rich-presence',
+    _SettingsSection.deviceSupport => 'device-support',
+    _SettingsSection.appUpdates => 'app-updates',
+    _SettingsSection.community => 'community',
+    _SettingsSection.storageReset => 'storage-reset',
+    _SettingsSection.aboutLegal => 'about-legal',
+    _SettingsSection.privacyDiagnostics => 'privacy-diagnostics',
+  };
+
+  String get title => switch (this) {
+    _SettingsSection.themeDisplay => 'Theme & display',
+    _SettingsSection.homeScreen => 'Home screen',
+    _SettingsSection.displayOptions => 'Display options',
+    _SettingsSection.inputFeedback => 'Input & feedback',
+    _SettingsSection.homeShelves => 'Home shelves',
+    _SettingsSection.navigation => 'Navigation',
+    _SettingsSection.closedCaptions => 'Closed captions',
+    _SettingsSection.playerControls => 'Player controls',
+    _SettingsSection.debridStreaming => 'Debrid streaming',
+    _SettingsSection.sourcesStreamOrder => 'Sources & stream order',
+    _SettingsSection.automaticSourceSelection => 'Automatic source selection',
+    _SettingsSection.librariesFeatures => 'Libraries & features',
+    _SettingsSection.streamingPrivacy => 'Streaming privacy',
+    _SettingsSection.animeTracking => 'Anime tracking',
+    _SettingsSection.profiles => 'Profiles',
+    _SettingsSection.progressNotifications => 'Progress & notifications',
+    _SettingsSection.discordRichPresence => 'Discord Rich Presence',
+    _SettingsSection.deviceSupport => 'Device & support',
+    _SettingsSection.appUpdates => 'App updates',
+    _SettingsSection.community => 'Community',
+    _SettingsSection.storageReset => 'Storage & reset',
+    _SettingsSection.aboutLegal => 'About & legal',
+    _SettingsSection.privacyDiagnostics => 'Privacy & diagnostics',
+  };
+
+  List<String> get searchLabels => switch (this) {
+    _SettingsSection.themeDisplay => const [
+      'Theme & display',
+      'Theme Studio',
+      'Title language',
+      'Show title style',
+      'Colors',
+      'Appearance',
+    ],
+    _SettingsSection.homeScreen => const [
+      'Home screen',
+      'Featured hero',
+      'Poster metadata',
+      'Continue watching',
+    ],
+    _SettingsSection.displayOptions => const [
+      'Display options',
+      'Interface scale',
+      'Content density',
+      'Thumbnail size',
+      'Layout style',
+      'Default landing page',
+      'Card details',
+    ],
+    _SettingsSection.inputFeedback => const [
+      'Input & feedback',
+      'On-screen keyboard',
+      'Built-in keyboard',
+      'Device keyboard',
+      'Navigation sounds',
+      'Click sounds',
+    ],
+    _SettingsSection.homeShelves => const [
+      'Home shelves',
+      'Continue watching',
+      'Watch history',
+      'Recently released',
+      'Trending now',
+      'Plan to watch',
+      'Airing soon',
+      'Recently completed',
+    ],
+    _SettingsSection.navigation => const [
+      'Navigation',
+      'Navigation size',
+      'Menu order',
+      'Reset appearance and navigation',
+      'Settings placement',
+      'Home',
+      'Search',
+      'My List',
+      'Discover',
+      'Calendar',
+      'Watch Party',
+      'Downloads',
+    ],
+    _SettingsSection.closedCaptions => const [
+      'Closed captions',
+      'Subtitles',
+      'Text color',
+      'Caption background',
+      'Text size',
+    ],
+    _SettingsSection.playerControls => const [
+      'Player controls',
+      'Default player',
+      'Preferred audio',
+      'Open externally',
+      'Rewind',
+      'Fast-forward',
+      'Auto-skip intros',
+      'Auto-skip outros',
+      'Filler episode labels',
+    ],
+    _SettingsSection.debridStreaming => const [
+      'Debrid streaming',
+      'Debrid provider',
+      'Real-Debrid',
+      'TorBox',
+      'AllDebrid',
+      'Premiumize',
+      'Connect debrid',
+    ],
+    _SettingsSection.sourcesStreamOrder => const [
+      'Sources & stream order',
+      'Debrid streams',
+      'Web streams',
+      'Direct torrent',
+      'Extension marketplace',
+      'Debrid sort',
+      'Source priority',
+      'Web quality',
+    ],
+    _SettingsSection.automaticSourceSelection => const [
+      'Automatic source selection',
+      'Auto-pick sources',
+      'Source order',
+      'Quality order',
+      'Audio preference',
+    ],
+    _SettingsSection.librariesFeatures => const [
+      'Libraries & features',
+      'Local sources',
+      'Jellyfin',
+      'Plex',
+      'Watch Party',
+      'Offline downloads',
+      'Download manager',
+    ],
+    _SettingsSection.streamingPrivacy => const [
+      'Streaming privacy',
+      'Privacy',
+      'Playback privacy',
+      'Direct peer torrents',
+    ],
+    _SettingsSection.animeTracking => const [
+      'Anime tracking',
+      'Anime-list provider',
+      'AniList',
+      'MyAnimeList',
+      'MAL',
+      'Connect tracker',
+    ],
+    _SettingsSection.profiles => const [
+      'Profiles',
+      'Local profiles',
+      'Manage viewers',
+      'Profile switcher',
+    ],
+    _SettingsSection.progressNotifications => const [
+      'Progress & notifications',
+      'Episode progress',
+      'Tracking threshold',
+      'Sub alerts',
+      'Simulcast alerts',
+      'Dub alerts',
+      'Notifications',
+    ],
+    _SettingsSection.discordRichPresence => const [
+      'Discord Rich Presence',
+      'Discord',
+      'Activity status',
+      'Link Discord',
+    ],
+    _SettingsSection.deviceSupport => const [
+      'Device & support',
+      'Run setup again',
+      'Device calibration',
+      'Diagnostics',
+      'Setup',
+    ],
+    _SettingsSection.appUpdates => const [
+      'App updates',
+      'Automatic updates',
+      'Check for updates',
+      'Update channel',
+      'Release history',
+      'Developer mode',
+      'Downgrade',
+    ],
+    _SettingsSection.community => const [
+      'Community',
+      'TetoTV Discord',
+      'Support',
+      'Donate',
+    ],
+    _SettingsSection.storageReset => const [
+      'Storage & reset',
+      'Clear cache',
+      'Reset app',
+      'First-time setup',
+    ],
+    _SettingsSection.aboutLegal => const [
+      'About & legal',
+      'Privacy policy',
+      'Open-source licenses',
+      'Third-party notices',
+      'Attribution',
+    ],
+    _SettingsSection.privacyDiagnostics => const [
+      'Privacy & diagnostics',
+      'Anonymous crash reports',
+      'Anonymous live count',
+      'Telemetry',
+      'Usage reporting',
+    ],
+  };
+}
+
+class _SettingsSearchMatch {
+  const _SettingsSearchMatch({
+    required this.section,
+    required this.matchedLabel,
+    required this.score,
+  });
+
+  final _SettingsSection section;
+  final String matchedLabel;
+  final int score;
+}
+
+String _normalizeSettingsSearchText(String value) =>
+    value.toLowerCase().replaceAll(RegExp(r'[^a-z0-9]+'), ' ').trim();
+
+String _settingsSearchResultSlug(String value) =>
+    _normalizeSettingsSearchText(value).replaceAll(' ', '-');
+
+String _settingsSearchResultKey(_SettingsSearchMatch match) =>
+    'settings-search-result-${match.section.slug}-'
+    '${_settingsSearchResultSlug(match.matchedLabel)}';
+
 enum _CustomizationSection {
   homeShelves,
   display,
@@ -81,6 +408,26 @@ class _AccountsScreenState extends ConsumerState<AccountsScreen> {
   final _torBoxTokenController = TextEditingController();
   final _allDebridTokenController = TextEditingController();
   final _premiumizeTokenController = TextEditingController();
+  final _settingsSearchController = TextEditingController();
+  final _settingsSearchFocus = FocusNode(debugLabel: 'accounts.search');
+  final _settingsToggleAllFocus = FocusNode(
+    debugLabel: 'accounts.sections.toggle-all',
+  );
+  late final List<FocusNode> _settingsSearchResultFocusNodes = List.generate(
+    6,
+    (index) => FocusNode(debugLabel: 'accounts.search.result.$index'),
+  );
+  late final Map<_SettingsSection, FocusNode> _settingsSectionFocusNodes = {
+    for (final section in _SettingsSection.values)
+      section: FocusNode(
+        debugLabel: 'accounts.settings-section.${section.slug}',
+      ),
+  };
+  final Set<_SettingsSection> _expandedSettingsSections = {
+    ..._SettingsSection.values,
+  };
+  bool _settingsSearchResultsVisible = false;
+  bool _settingsSearchEditing = false;
   final _backFocus = FocusNode(debugLabel: 'accounts.back');
   final _contentFocus = FocusNode(debugLabel: 'accounts.content');
   final _titleLanguageFocus = FocusNode(debugLabel: 'accounts.title-language');
@@ -195,6 +542,9 @@ class _AccountsScreenState extends ConsumerState<AccountsScreen> {
   );
   final _playerControlsSectionFocus = FocusNode(
     debugLabel: 'accounts.section.player-controls',
+  );
+  final _fillerIndicatorsFocus = FocusNode(
+    debugLabel: 'accounts.playback.filler-indicators',
   );
   final _customizationResetFocus = FocusNode(
     debugLabel: 'accounts.customization.reset',
@@ -362,6 +712,387 @@ class _AccountsScreenState extends ConsumerState<AccountsScreen> {
     );
   }
 
+  List<_SettingsSection> _sectionsForArea(_SettingsArea area) => [
+    for (final section in _SettingsSection.values)
+      if (section.area == area) section,
+  ];
+
+  bool get _allActiveSettingsSectionsExpanded =>
+      _sectionsForArea(_activeArea).every(_expandedSettingsSections.contains);
+
+  void _setSettingsSectionExpanded(_SettingsSection section, bool expanded) {
+    setState(() {
+      if (expanded) {
+        _expandedSettingsSections.add(section);
+      } else {
+        _expandedSettingsSections.remove(section);
+      }
+    });
+  }
+
+  void _toggleAllSettingsSections() {
+    final sections = _sectionsForArea(_activeArea);
+    final collapse = sections.every(_expandedSettingsSections.contains);
+    setState(() {
+      if (collapse) {
+        _expandedSettingsSections.removeAll(sections);
+      } else {
+        _expandedSettingsSections.addAll(sections);
+      }
+    });
+  }
+
+  bool _settingsSearchLabelIsAvailable(_SettingsSection section, String label) {
+    final normalized = _normalizeSettingsSearchText(label);
+    final preferences = ref.read(settingsPreferencesProvider);
+    if (section == _SettingsSection.automaticSourceSelection &&
+        const {
+          'source order',
+          'quality order',
+          'audio preference',
+        }.contains(normalized)) {
+      return preferences.autoPickSourceEnabled;
+    }
+    if (section == _SettingsSection.librariesFeatures &&
+        normalized == 'download manager') {
+      return preferences.offlineDownloadsEnabled;
+    }
+    if (section == _SettingsSection.appUpdates &&
+        normalized == 'release history') {
+      return ref.read(appUpdateControllerProvider).developerMode;
+    }
+    if (section == _SettingsSection.privacyDiagnostics &&
+        normalized == 'anonymous live count') {
+      return ref.read(isInstalledBetaBuildProvider);
+    }
+    return true;
+  }
+
+  List<_SettingsSearchMatch> get _settingsSearchMatches {
+    final query = _normalizeSettingsSearchText(_settingsSearchController.text);
+    if (query.isEmpty) return const [];
+    final queryWords = query.split(' ').where((word) => word.isNotEmpty);
+    final matches = <_SettingsSearchMatch>[];
+    for (final section in _SettingsSection.values) {
+      _SettingsSearchMatch? best;
+      for (final label in section.searchLabels) {
+        if (!_settingsSearchLabelIsAvailable(section, label)) continue;
+        final normalizedLabel = _normalizeSettingsSearchText(label);
+        final searchable =
+            '$normalizedLabel ${section.area.label.toLowerCase()}';
+        if (!queryWords.every(searchable.contains)) continue;
+        final score = normalizedLabel == query
+            ? 0
+            : normalizedLabel.startsWith(query)
+            ? 1
+            : section.title == label
+            ? 2
+            : 3;
+        final candidate = _SettingsSearchMatch(
+          section: section,
+          matchedLabel: label,
+          score: score,
+        );
+        if (best == null ||
+            candidate.score < best.score ||
+            (candidate.score == best.score &&
+                candidate.matchedLabel.length < best.matchedLabel.length)) {
+          best = candidate;
+        }
+      }
+      if (best != null) matches.add(best);
+    }
+    matches.sort((left, right) {
+      final byScore = left.score.compareTo(right.score);
+      if (byScore != 0) return byScore;
+      final byArea = left.section.area.index.compareTo(
+        right.section.area.index,
+      );
+      if (byArea != 0) return byArea;
+      return left.section.index.compareTo(right.section.index);
+    });
+    return matches.take(_settingsSearchResultFocusNodes.length).toList();
+  }
+
+  void _handleSettingsSearchChanged(String value) {
+    // Rebuild for every query, not only when the empty/non-empty state flips;
+    // otherwise results would remain frozen after the first typed term.
+    setState(() => _settingsSearchResultsVisible = value.trim().isNotEmpty);
+  }
+
+  void _handleSettingsSearchEditingChanged(bool editing) {
+    if (_settingsSearchEditing == editing) return;
+    setState(() => _settingsSearchEditing = editing);
+  }
+
+  void _exitSettingsSearchHeaderDown() {
+    if (_settingsSearchResultsVisible ||
+        _settingsSearchController.text.isNotEmpty) {
+      _settingsSearchController.clear();
+      setState(() => _settingsSearchResultsVisible = false);
+    }
+    requestTvFocusAndReveal(_areaFocusNodes[_activeArea]!);
+  }
+
+  FocusNode? get _firstHomeShelfFocusNode {
+    final shelves = ref.read(homeShelfOrderProvider);
+    return shelves.isEmpty ? null : _shelfFocusNodes[shelves.first];
+  }
+
+  FocusNode? _firstFocusNodeForSection(_SettingsSection section) =>
+      switch (section) {
+        _SettingsSection.themeDisplay => _customizationFocus,
+        _SettingsSection.homeScreen => _featuredHomeContentFocus,
+        _SettingsSection.displayOptions => _displaySectionFocus,
+        _SettingsSection.inputFeedback => _inputFeedbackSectionFocus,
+        _SettingsSection.homeShelves => _firstHomeShelfFocusNode,
+        _SettingsSection.navigation => _navigationSizeFocus,
+        _SettingsSection.closedCaptions => _captionTextColorFocus,
+        _SettingsSection.playerControls => _playerControlsSectionFocus,
+        _SettingsSection.debridStreaming => _debridProviderFocus,
+        _SettingsSection.sourcesStreamOrder => _debridStreamsFocus,
+        _SettingsSection.automaticSourceSelection => _autoPickEnabledFocus,
+        _SettingsSection.librariesFeatures => _localMediaFocus,
+        _SettingsSection.streamingPrivacy => null,
+        _SettingsSection.animeTracking => _trackingProviderFocus,
+        _SettingsSection.profiles => _localProfilesFocus,
+        _SettingsSection.progressNotifications => _trackingThresholdFocus,
+        _SettingsSection.discordRichPresence => _discordPresenceFocus,
+        _SettingsSection.deviceSupport => _setupFocus,
+        _SettingsSection.appUpdates => _automaticUpdatesFocus,
+        _SettingsSection.community => _discordQrFocus,
+        _SettingsSection.storageReset => _clearCacheFocus,
+        _SettingsSection.aboutLegal => _privacyFocus,
+        _SettingsSection.privacyDiagnostics => _anonymousCrashReportingFocus,
+      };
+
+  FocusNode? _lastFocusNodeForSection(
+    _SettingsSection section,
+    SettingsPreferences preferences,
+  ) {
+    FocusNode? lastMounted(Iterable<FocusNode?> candidates) {
+      for (final candidate in candidates) {
+        if (candidate?.context?.mounted == true) return candidate;
+      }
+      return null;
+    }
+
+    final selectedDebridNodes = switch (preferences.debridProvider) {
+      DebridService.realDebrid => <FocusNode?>[
+        _tokenSaveFocus,
+        _tokenFocus,
+        _debridConnectFocus,
+      ],
+      DebridService.torBox => <FocusNode?>[
+        _torBoxSaveFocus,
+        _torBoxTokenFocus,
+        _torBoxActionFocus,
+      ],
+      DebridService.allDebrid => <FocusNode?>[
+        _allDebridSaveFocus,
+        _allDebridTokenFocus,
+        _allDebridActionFocus,
+      ],
+      DebridService.premiumize => <FocusNode?>[
+        _premiumizeSaveFocus,
+        _premiumizeTokenFocus,
+        _premiumizeActionFocus,
+      ],
+    };
+    final selectedTrackingNodes =
+        preferences.trackingProvider == TrackingProvider.anilist
+        ? <FocusNode?>[
+            _anilistSaveFocus,
+            _anilistTokenFocus,
+            _trackingDisconnectFocus,
+            _anilistFocus,
+          ]
+        : <FocusNode?>[
+            _malSaveFocus,
+            _malTokenFocus,
+            _trackingDisconnectFocus,
+            _malFocus,
+          ];
+    return switch (section) {
+      _SettingsSection.themeDisplay => _showTitleStyleFocus,
+      _SettingsSection.homeScreen => _continueWatchingFocus,
+      _SettingsSection.displayOptions => _cardDetailsFocus,
+      _SettingsSection.inputFeedback => _clickSoundsFocus,
+      _SettingsSection.homeShelves => lastMounted(
+        ref
+            .read(homeShelfOrderProvider)
+            .reversed
+            .map((shelf) => _shelfFocusNodes[shelf]),
+      ),
+      _SettingsSection.navigation => _customizationResetFocus,
+      _SettingsSection.closedCaptions => _captionTextSizeFocus,
+      _SettingsSection.playerControls => _fillerIndicatorsFocus,
+      _SettingsSection.debridStreaming => lastMounted(selectedDebridNodes),
+      _SettingsSection.sourcesStreamOrder => _webQualityFocus,
+      _SettingsSection.automaticSourceSelection => lastMounted([
+        _autoPickAudioFocus,
+        _autoPickQualityFocus,
+        _autoPickSourceFocus,
+        _autoPickEnabledFocus,
+      ]),
+      _SettingsSection.librariesFeatures => lastMounted([
+        _downloadManagerFocus,
+        _offlineDownloadsFocus,
+        _watchTogetherFocus,
+        _localMediaFocus,
+      ]),
+      _SettingsSection.streamingPrivacy => null,
+      _SettingsSection.animeTracking => lastMounted(selectedTrackingNodes),
+      _SettingsSection.profiles => _localProfilesFocus,
+      _SettingsSection.progressNotifications => _dubEpisodeNotificationsFocus,
+      _SettingsSection.discordRichPresence => lastMounted([
+        _discordDisconnectFocus,
+        _discordPresenceFocus,
+      ]),
+      _SettingsSection.deviceSupport => _diagnosticsFocus,
+      _SettingsSection.appUpdates => lastMounted([
+        _releaseHistoryFocus,
+        _updateChannelFocus,
+        _checkUpdatesFocus,
+        _automaticUpdatesFocus,
+      ]),
+      _SettingsSection.community => lastMounted([
+        _donateFocus,
+        _donationQrFocus,
+        _discordFocus,
+        _discordQrFocus,
+      ]),
+      _SettingsSection.storageReset => _resetAppFocus,
+      _SettingsSection.aboutLegal => _legalFocus,
+      _SettingsSection.privacyDiagnostics => lastMounted([
+        _anonymousUsageCountFocus,
+        _anonymousCrashReportingFocus,
+      ]),
+    };
+  }
+
+  FocusNode? _focusNodeForSettingsSearchMatch(_SettingsSearchMatch match) {
+    final label = _normalizeSettingsSearchText(match.matchedLabel);
+    final sectionHeader = _settingsSectionFocusNodes[match.section];
+    if (label == _normalizeSettingsSearchText(match.section.title)) {
+      return sectionHeader;
+    }
+    return switch (label) {
+      'theme studio' || 'colors' || 'appearance' => _customizationFocus,
+      'title language' => _titleLanguageFocus,
+      'show title style' => _showTitleStyleFocus,
+      'featured hero' => _featuredHomeContentFocus,
+      'poster metadata' => _posterMetadataFocus,
+      'continue watching' =>
+        match.section == _SettingsSection.homeShelves
+            ? _shelfFocusNodes[HomeShelf.tracking]
+            : _continueWatchingFocus,
+      'watch history' => _shelfFocusNodes[HomeShelf.history],
+      'recently released' => _shelfFocusNodes[HomeShelf.recentlyReleased],
+      'trending now' => _shelfFocusNodes[HomeShelf.trending],
+      'plan to watch' => _shelfFocusNodes[HomeShelf.planned],
+      'airing soon' => _shelfFocusNodes[HomeShelf.airing],
+      'recently completed' => _shelfFocusNodes[HomeShelf.completed],
+      'card details' => _cardDetailsFocus,
+      'on screen keyboard' ||
+      'built in keyboard' ||
+      'device keyboard' => _inputFeedbackSectionFocus,
+      'click sounds' => _clickSoundsFocus,
+      'home' ||
+      'search' ||
+      'my list' ||
+      'discover' ||
+      'calendar' ||
+      'downloads' => _menuOrderFocus,
+      'watch party' =>
+        match.section == _SettingsSection.librariesFeatures
+            ? _watchTogetherFocus
+            : _menuOrderFocus,
+      'navigation size' => _navigationSizeFocus,
+      'menu order' || 'settings placement' => _menuOrderFocus,
+      'reset appearance and navigation' => _customizationResetFocus,
+      'text color' => _captionTextColorFocus,
+      'text size' => _captionTextSizeFocus,
+      'default player' => _playerControlsSectionFocus,
+      'filler episode labels' => _fillerIndicatorsFocus,
+      'debrid provider' ||
+      'real debrid' ||
+      'torbox' ||
+      'alldebrid' ||
+      'premiumize' ||
+      'connect debrid' => _debridProviderFocus,
+      'debrid streams' => _debridStreamsFocus,
+      'web streams' => _webStreamsFocus,
+      'direct torrent' => _directTorrentFocus,
+      'extension marketplace' => _marketplaceFocus,
+      'debrid sort' => _debridSortFocus,
+      'source priority' => _sourcePriorityFocus,
+      'web quality' => _webQualityFocus,
+      'auto pick sources' => _autoPickEnabledFocus,
+      'source order' => _autoPickSourceFocus,
+      'quality order' => _autoPickQualityFocus,
+      'audio preference' => _autoPickAudioFocus,
+      'local sources' || 'jellyfin' || 'plex' => _localMediaFocus,
+      'offline downloads' => _offlineDownloadsFocus,
+      'download manager' => _downloadManagerFocus,
+      'anime list provider' ||
+      'anilist' ||
+      'myanimelist' ||
+      'mal' ||
+      'connect tracker' => _trackingProviderFocus,
+      'local profiles' ||
+      'manage viewers' ||
+      'profile switcher' => _localProfilesFocus,
+      'episode progress' || 'tracking threshold' => _trackingThresholdFocus,
+      'sub alerts' ||
+      'simulcast alerts' ||
+      'notifications' => _subEpisodeNotificationsFocus,
+      'dub alerts' => _dubEpisodeNotificationsFocus,
+      'discord' || 'activity status' || 'link discord' => _discordPresenceFocus,
+      'run setup again' || 'setup' => _setupFocus,
+      'device calibration' => _calibrationFocus,
+      'diagnostics' => _diagnosticsFocus,
+      'automatic updates' => _automaticUpdatesFocus,
+      'check for updates' => _checkUpdatesFocus,
+      'update channel' ||
+      'developer mode' ||
+      'downgrade' => _updateChannelFocus,
+      'release history' => _releaseHistoryFocus,
+      'tetotv discord' || 'support' => _discordFocus,
+      'donate' => _donateFocus,
+      'clear cache' => _clearCacheFocus,
+      'reset app' || 'first time setup' => _resetAppFocus,
+      'privacy policy' => _privacyFocus,
+      'open source licenses' ||
+      'third party notices' ||
+      'attribution' => _legalFocus,
+      'anonymous crash reports' || 'telemetry' => _anonymousCrashReportingFocus,
+      'anonymous live count' || 'usage reporting' => _anonymousUsageCountFocus,
+      // Labels without a dedicated retained FocusNode land on their exact
+      // section header instead of pretending a neighboring row is the match.
+      _ => sectionHeader,
+    };
+  }
+
+  Future<void> _openSettingsSearchMatch(_SettingsSearchMatch match) async {
+    setState(() {
+      _activeArea = match.section.area;
+      _expandedSettingsSections.add(match.section);
+      _settingsSearchResultsVisible = false;
+      _settingsSearchController.clear();
+      _systemActivationCount = 0;
+    });
+    await WidgetsBinding.instance.endOfFrame;
+    if (!mounted) return;
+    var target = _focusNodeForSettingsSearchMatch(match);
+    if (target?.context?.mounted != true) {
+      target = _settingsSectionFocusNodes[match.section];
+    }
+    if (target?.context?.mounted == true) {
+      requestTvFocusAndReveal(target!);
+    }
+  }
+
   @override
   void initState() {
     super.initState();
@@ -447,6 +1178,15 @@ class _AccountsScreenState extends ConsumerState<AccountsScreen> {
     _torBoxTokenController.dispose();
     _allDebridTokenController.dispose();
     _premiumizeTokenController.dispose();
+    _settingsSearchController.dispose();
+    _settingsSearchFocus.dispose();
+    _settingsToggleAllFocus.dispose();
+    for (final node in _settingsSearchResultFocusNodes) {
+      node.dispose();
+    }
+    for (final node in _settingsSectionFocusNodes.values) {
+      node.dispose();
+    }
     _backFocus.dispose();
     _contentFocus.dispose();
     _titleLanguageFocus.dispose();
@@ -488,6 +1228,7 @@ class _AccountsScreenState extends ConsumerState<AccountsScreen> {
     _captionTextColorFocus.dispose();
     _captionTextSizeFocus.dispose();
     _playerControlsSectionFocus.dispose();
+    _fillerIndicatorsFocus.dispose();
     _customizationResetFocus.dispose();
     _setupFocus.dispose();
     _calibrationFocus.dispose();
@@ -631,8 +1372,30 @@ class _AccountsScreenState extends ConsumerState<AccountsScreen> {
       for (final area in _SettingsArea.values) _areaFocusNodes[area]!,
     ];
     final areaIndex = current == null ? -1 : areaNodes.indexOf(current);
+    final activeSections = _sectionsForArea(_activeArea);
+    final activeSectionNodes = [
+      for (final section in activeSections)
+        _settingsSectionFocusNodes[section]!,
+    ];
+    final activeSectionIndex = current == null
+        ? -1
+        : activeSectionNodes.indexOf(current);
+    final activeSectionFirstContentNodes = [
+      for (final section in activeSections) _firstFocusNodeForSection(section),
+    ];
+    final firstContentSectionIndex = current == null
+        ? -1
+        : activeSectionFirstContentNodes.indexOf(current);
+    final activeSectionLastContentNodes = [
+      for (final section in activeSections)
+        _lastFocusNodeForSection(section, preferences),
+    ];
+    final lastContentSectionIndex = current == null
+        ? -1
+        : activeSectionLastContentNodes.indexOf(current);
     final leftEdgeNodes = <FocusNode>{
       areaNodes.first,
+      ...activeSectionNodes,
       _homeShelvesSectionFocus,
       _displaySectionFocus,
       _cardDetailsFocus,
@@ -738,36 +1501,72 @@ class _AccountsScreenState extends ConsumerState<AccountsScreen> {
           areaIndex < areaNodes.length - 1) {
         target = areaNodes[areaIndex + 1];
       }
+      if (key == LogicalKeyboardKey.arrowUp && tvListLayout) {
+        target = _settingsSearchFocus;
+      }
       if (key == LogicalKeyboardKey.arrowDown) {
-        target = switch (_activeArea) {
-          _SettingsArea.appearance => _customizationFocus,
-          _SettingsArea.playback => _captionTextColorFocus,
-          _SettingsArea.services => _debridProviderFocus,
-          _SettingsArea.accounts => _trackingProviderFocus,
-          _SettingsArea.system => _setupFocus,
-        };
+        target = tvListLayout
+            ? activeSectionNodes.first
+            : switch (_activeArea) {
+                _SettingsArea.appearance => _customizationFocus,
+                _SettingsArea.playback => _captionTextColorFocus,
+                _SettingsArea.services => _debridProviderFocus,
+                _SettingsArea.accounts => _trackingProviderFocus,
+                _SettingsArea.system => _setupFocus,
+              };
+      }
+    } else if (activeSectionIndex >= 0) {
+      if (key == LogicalKeyboardKey.arrowUp) {
+        target = activeSectionIndex == 0
+            ? _areaFocusNodes[_activeArea]
+            : activeSectionNodes[activeSectionIndex - 1];
+      }
+      if (key == LogicalKeyboardKey.arrowDown) {
+        final section = activeSections[activeSectionIndex];
+        final firstChild = _expandedSettingsSections.contains(section)
+            ? _firstFocusNodeForSection(section)
+            : null;
+        target = firstChild?.context?.mounted == true
+            ? firstChild
+            : activeSectionIndex < activeSectionNodes.length - 1
+            ? activeSectionNodes[activeSectionIndex + 1]
+            : null;
+        if (target == null) return KeyEventResult.handled;
       }
     } else if (shelfIndex >= 0) {
       if (key == LogicalKeyboardKey.arrowUp) {
         if (shelfIndex > 0) {
           target = shelfNodes[shelfIndex - 1];
         } else {
-          target = tvListLayout ? _clickSoundsFocus : _continueWatchingFocus;
+          target = tvListLayout
+              ? _settingsSectionFocusNodes[_SettingsSection.homeShelves]
+              : _continueWatchingFocus;
         }
       }
       if (key == LogicalKeyboardKey.arrowDown) {
         if (shelfIndex < shelfNodes.length - 1) {
           target = shelfNodes[shelfIndex + 1];
         } else if (tvListLayout) {
-          target = _navigationSizeFocus;
+          target = _settingsSectionFocusNodes[_SettingsSection.navigation];
         } else {
           return KeyEventResult.handled;
         }
       }
     }
 
-    if (areaIndex >= 0 || shelfIndex >= 0) {
+    if (areaIndex >= 0 || activeSectionIndex >= 0 || shelfIndex >= 0) {
       // Settings-area and Home-shelf navigation were handled above.
+    } else if (tvListLayout &&
+        key == LogicalKeyboardKey.arrowDown &&
+        lastContentSectionIndex >= 0) {
+      if (lastContentSectionIndex == activeSectionNodes.length - 1) {
+        return KeyEventResult.handled;
+      }
+      target = activeSectionNodes[lastContentSectionIndex + 1];
+    } else if (tvListLayout &&
+        key == LogicalKeyboardKey.arrowUp &&
+        firstContentSectionIndex >= 0) {
+      target = activeSectionNodes[firstContentSectionIndex];
     } else if (current == _featuredHomeContentFocus) {
       if (key == LogicalKeyboardKey.arrowLeft && !tvListLayout) {
         target = _customizationFocus;
@@ -1328,9 +2127,8 @@ class _AccountsScreenState extends ConsumerState<AccountsScreen> {
         target = _automaticUpdatesFocus;
       }
       if (key == LogicalKeyboardKey.arrowDown) {
-        target = ref.read(appUpdateControllerProvider).developerMode
-            ? _updateChannelFocus
-            : _discordQrFocus;
+        // Update channel is visible in both standard and Developer Mode.
+        target = _updateChannelFocus;
       }
     } else if (current == _updateChannelFocus) {
       if (key == LogicalKeyboardKey.arrowUp) target = _checkUpdatesFocus;
@@ -1623,6 +2421,28 @@ class _AccountsScreenState extends ConsumerState<AccountsScreen> {
     final downloads = ref.watch(downloadManagerProvider);
     final isTelevision = ref.watch(isTelevisionProvider);
     final showAnonymousUsageCount = ref.watch(isInstalledBetaBuildProvider);
+    final collapsibleSettings =
+        isTelevision &&
+        preferences.interfaceMode != InterfaceMode.phone &&
+        MediaQuery.sizeOf(context).width >= 840;
+
+    Widget settingsSectionCard({
+      Key? key,
+      required _SettingsSection section,
+      required String subtitle,
+      required Widget child,
+    }) => _SettingsSectionCard(
+      key: key,
+      section: section,
+      title: section.title,
+      subtitle: subtitle,
+      collapsible: collapsibleSettings,
+      expanded: _expandedSettingsSections.contains(section),
+      focusNode: _settingsSectionFocusNodes[section],
+      onExpandedChanged: (expanded) =>
+          _setSettingsSectionExpanded(section, expanded),
+      child: child,
+    );
 
     Widget customizationPanel(
       Set<_CustomizationSection> visibleSections, {
@@ -1646,6 +2466,7 @@ class _AccountsScreenState extends ConsumerState<AccountsScreen> {
       captionTextColorFocusNode: _captionTextColorFocus,
       captionTextSizeFocusNode: _captionTextSizeFocus,
       playerControlsSectionFocusNode: _playerControlsSectionFocus,
+      fillerIndicatorsFocusNode: _fillerIndicatorsFocus,
       resetFocusNode: _customizationResetFocus,
       expandedSections: _expandedCustomizationSections,
       onSectionExpandedChanged: _setCustomizationSectionExpanded,
@@ -1699,9 +2520,9 @@ class _AccountsScreenState extends ConsumerState<AccountsScreen> {
       ],
     );
 
-    Widget automaticSourceSelectionCard() => _SettingsSectionCard(
+    Widget automaticSourceSelectionCard() => settingsSectionCard(
       key: const ValueKey('settings-card-services-autopick'),
-      title: 'Automatic source selection',
+      section: _SettingsSection.automaticSourceSelection,
       subtitle:
           'Prioritize source type, quality, and audio when TetoTV chooses for you.',
       child: _AutoPickSourcePanel(
@@ -1743,9 +2564,9 @@ class _AccountsScreenState extends ConsumerState<AccountsScreen> {
       ),
     );
 
-    Widget librariesAndFeaturesCard() => _SettingsSectionCard(
+    Widget librariesAndFeaturesCard() => settingsSectionCard(
       key: const ValueKey('settings-card-services-features'),
-      title: 'Libraries & features',
+      section: _SettingsSection.librariesFeatures,
       subtitle: 'Manage local libraries, Watch Party, and offline viewing.',
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.stretch,
@@ -1779,16 +2600,16 @@ class _AccountsScreenState extends ConsumerState<AccountsScreen> {
       ),
     );
 
-    Widget streamingPrivacyCard() => _SettingsSectionCard(
+    Widget streamingPrivacyCard() => settingsSectionCard(
       key: const ValueKey('settings-card-services-privacy'),
-      title: 'Streaming privacy',
+      section: _SettingsSection.streamingPrivacy,
       subtitle: 'Control privacy-sensitive source and playback behavior.',
       child: _StreamingPrivacyPanel(preferences: preferences),
     );
 
-    Widget discordPresenceCard() => _SettingsSectionCard(
+    Widget discordPresenceCard() => settingsSectionCard(
       key: const ValueKey('settings-card-accounts-discord'),
-      title: 'Discord Rich Presence',
+      section: _SettingsSection.discordRichPresence,
       subtitle: 'Control the optional Discord activity shown while you watch.',
       child: _DiscordPresencePanel(
         state: discordPresence,
@@ -1823,9 +2644,9 @@ class _AccountsScreenState extends ConsumerState<AccountsScreen> {
       ),
     );
 
-    Widget communityCard() => _SettingsSectionCard(
+    Widget communityCard() => settingsSectionCard(
       key: const ValueKey('settings-card-system-community'),
-      title: 'Community',
+      section: _SettingsSection.community,
       subtitle:
           'Join the TetoTV Discord for announcements, support, and feature requests.',
       child: _CommunityPanels(
@@ -1837,9 +2658,9 @@ class _AccountsScreenState extends ConsumerState<AccountsScreen> {
       ),
     );
 
-    Widget storageAndResetCard() => _SettingsSectionCard(
+    Widget storageAndResetCard() => settingsSectionCard(
       key: const ValueKey('settings-card-system-storage'),
-      title: 'Storage & reset',
+      section: _SettingsSection.storageReset,
       subtitle: 'Remove temporary files or return TetoTV to first-time setup.',
       child: _StorageResetPanel(
         forceSingleColumn: isTelevision,
@@ -1848,9 +2669,9 @@ class _AccountsScreenState extends ConsumerState<AccountsScreen> {
       ),
     );
 
-    Widget legalNoticesCard() => _SettingsSectionCard(
+    Widget legalNoticesCard() => settingsSectionCard(
       key: const ValueKey('settings-card-system-legal'),
-      title: 'About & legal',
+      section: _SettingsSection.aboutLegal,
       subtitle: 'Privacy, attribution, and open-source notices.',
       child: _LegalNoticesPanel(
         privacyFocusNode: _privacyFocus,
@@ -1858,9 +2679,9 @@ class _AccountsScreenState extends ConsumerState<AccountsScreen> {
       ),
     );
 
-    Widget privacyAndDiagnosticsCard() => _SettingsSectionCard(
+    Widget privacyAndDiagnosticsCard() => settingsSectionCard(
       key: const ValueKey('settings-card-system-privacy-diagnostics'),
-      title: 'Privacy & diagnostics',
+      section: _SettingsSection.privacyDiagnostics,
       subtitle:
           'Control optional privacy-safe reporting and Beta activity signals.',
       child: Column(
@@ -1915,10 +2736,47 @@ class _AccountsScreenState extends ConsumerState<AccountsScreen> {
     return TetoTopLevelShell(
       preferences: preferences,
       activeDestination: TopNavigationDestination.settings,
-      firstContentFocusNode: _activeArea == _SettingsArea.appearance
+      firstContentFocusNode: collapsibleSettings
+          ? _settingsSearchFocus
+          : _activeArea == _SettingsArea.appearance
           ? _customizationFocus
           : _areaFocusNodes[_activeArea]!,
+      fallbackContentFocusNode: _areaFocusNodes[_activeArea],
       autofocusRail: widget.autofocusNavigation,
+      tvHeaderFocusNodes: [
+        _settingsSearchFocus,
+        _settingsToggleAllFocus,
+        ..._settingsSearchResultFocusNodes,
+      ],
+      tvHeaderBuilder: (context, layout, profileFocusNode) {
+        return _SettingsSearchHeader(
+          controller: _settingsSearchController,
+          searchFocusNode: _settingsSearchFocus,
+          toggleAllFocusNode: _settingsToggleAllFocus,
+          resultFocusNodes: _settingsSearchResultFocusNodes,
+          results: _settingsSearchMatches,
+          resultsVisible: _settingsSearchResultsVisible,
+          editing: _settingsSearchEditing,
+          activeArea: _activeArea,
+          allExpanded: _allActiveSettingsSectionsExpanded,
+          onChanged: _handleSettingsSearchChanged,
+          onEditingChanged: _handleSettingsSearchEditingChanged,
+          onToggleAll: _toggleAllSettingsSections,
+          onResultSelected: (match) =>
+              unawaited(_openSettingsSearchMatch(match)),
+          onExitLeft: layout.focusRail,
+          onExitRight: () {
+            if (profileFocusNode.context?.mounted == true) {
+              profileFocusNode.requestFocus();
+            } else {
+              _areaFocusNodes[_activeArea]!.requestFocus();
+            }
+          },
+          onExitDown: _exitSettingsSearchHeaderDown,
+        );
+      },
+      onTvProfileLeft: _settingsToggleAllFocus.requestFocus,
+      onTvProfileDown: _exitSettingsSearchHeaderDown,
       resizeToAvoidBottomInset: true,
       builder: (context, layout) => Focus(
         focusNode: _contentFocus,
@@ -2018,6 +2876,9 @@ class _AccountsScreenState extends ConsumerState<AccountsScreen> {
                       inputFeedbackFirstFocusNode: _inputFeedbackSectionFocus,
                       clickSoundsFocusNode: _clickSoundsFocus,
                       shelfFocusNodes: _shelfFocusNodes,
+                      expandedSections: _expandedSettingsSections,
+                      sectionFocusNodes: _settingsSectionFocusNodes,
+                      onSectionExpandedChanged: _setSettingsSectionExpanded,
                       onOpenThemeStudio: () =>
                           context.push(ThemeStudioScreen.routePath),
                       onOpenMenuOrder: _openMenuOrderDialog,
@@ -2046,18 +2907,18 @@ class _AccountsScreenState extends ConsumerState<AccountsScreen> {
                     ],
                     _SettingsResponsiveColumns(
                       forceSingleColumn: layout.usesTvRail,
-                      left: _SettingsSectionCard(
+                      left: settingsSectionCard(
                         key: const ValueKey('settings-card-playback-captions'),
-                        title: 'Closed captions',
+                        section: _SettingsSection.closedCaptions,
                         subtitle:
                             'Style subtitles for comfortable viewing on every screen.',
                         child: customizationPanel(const {
                           _CustomizationSection.closedCaptions,
                         }, showReset: false),
                       ),
-                      right: _SettingsSectionCard(
+                      right: settingsSectionCard(
                         key: const ValueKey('settings-card-playback-player'),
-                        title: 'Player controls',
+                        section: _SettingsSection.playerControls,
                         subtitle:
                             'Choose audio, skipping, seeking, and playback behavior.',
                         child: customizationPanel(const {
@@ -2081,11 +2942,11 @@ class _AccountsScreenState extends ConsumerState<AccountsScreen> {
                       forceSingleColumn: layout.usesTvRail,
                       left: _SettingsCardLane(
                         children: [
-                          _SettingsSectionCard(
+                          settingsSectionCard(
                             key: const ValueKey(
                               'settings-card-services-debrid',
                             ),
-                            title: 'Debrid streaming',
+                            section: _SettingsSection.debridStreaming,
                             subtitle:
                                 'Choose and securely connect the provider used to resolve streams.',
                             child: Column(
@@ -2283,11 +3144,11 @@ class _AccountsScreenState extends ConsumerState<AccountsScreen> {
                       ),
                       right: _SettingsCardLane(
                         children: [
-                          _SettingsSectionCard(
+                          settingsSectionCard(
                             key: const ValueKey(
                               'settings-card-services-sources',
                             ),
-                            title: 'Sources & stream order',
+                            section: _SettingsSection.sourcesStreamOrder,
                             subtitle:
                                 'Choose which source types are searched and how results are ranked.',
                             child: Column(
@@ -2373,11 +3234,11 @@ class _AccountsScreenState extends ConsumerState<AccountsScreen> {
                       forceSingleColumn: layout.usesTvRail,
                       left: _SettingsCardLane(
                         children: [
-                          _SettingsSectionCard(
+                          settingsSectionCard(
                             key: const ValueKey(
                               'settings-card-accounts-tracking',
                             ),
-                            title: 'Anime tracking',
+                            section: _SettingsSection.animeTracking,
                             subtitle:
                                 'Connect a list provider and keep episode progress synchronized.',
                             child: Column(
@@ -2471,11 +3332,11 @@ class _AccountsScreenState extends ConsumerState<AccountsScreen> {
                               ],
                             ),
                           ),
-                          _SettingsSectionCard(
+                          settingsSectionCard(
                             key: const ValueKey(
                               'settings-card-accounts-profiles',
                             ),
-                            title: 'Profiles',
+                            section: _SettingsSection.profiles,
                             subtitle:
                                 'Manage local viewers and their separate preferences.',
                             child: _LocalProfilesPanel(
@@ -2487,11 +3348,11 @@ class _AccountsScreenState extends ConsumerState<AccountsScreen> {
                       ),
                       right: _SettingsCardLane(
                         children: [
-                          _SettingsSectionCard(
+                          settingsSectionCard(
                             key: const ValueKey(
                               'settings-card-accounts-behavior',
                             ),
-                            title: 'Progress & notifications',
+                            section: _SettingsSection.progressNotifications,
                             subtitle:
                                 'Choose when progress syncs and which episode alerts appear.',
                             child: Column(
@@ -2582,9 +3443,9 @@ class _AccountsScreenState extends ConsumerState<AccountsScreen> {
                       forceSingleColumn: layout.usesTvRail,
                       left: _SettingsCardLane(
                         children: [
-                          _SettingsSectionCard(
+                          settingsSectionCard(
                             key: const ValueKey('settings-card-system-support'),
-                            title: 'Device & support',
+                            section: _SettingsSection.deviceSupport,
                             subtitle:
                                 'Setup, device compatibility, calibration, and diagnostics.',
                             child: Column(
@@ -2624,9 +3485,9 @@ class _AccountsScreenState extends ConsumerState<AccountsScreen> {
                       ),
                       right: _SettingsCardLane(
                         children: [
-                          _SettingsSectionCard(
+                          settingsSectionCard(
                             key: const ValueKey('settings-card-system-updates'),
-                            title: 'App updates',
+                            section: _SettingsSection.appUpdates,
                             subtitle:
                                 'Stable public releases download directly to this device.',
                             child: Column(
@@ -2849,6 +3710,461 @@ class _SettingsAreaTabs extends StatelessWidget {
   }
 }
 
+class _SettingsSearchHeader extends StatelessWidget {
+  const _SettingsSearchHeader({
+    required this.controller,
+    required this.searchFocusNode,
+    required this.toggleAllFocusNode,
+    required this.resultFocusNodes,
+    required this.results,
+    required this.resultsVisible,
+    required this.editing,
+    required this.activeArea,
+    required this.allExpanded,
+    required this.onChanged,
+    required this.onEditingChanged,
+    required this.onToggleAll,
+    required this.onResultSelected,
+    required this.onExitLeft,
+    required this.onExitRight,
+    required this.onExitDown,
+  });
+
+  final TextEditingController controller;
+  final FocusNode searchFocusNode;
+  final FocusNode toggleAllFocusNode;
+  final List<FocusNode> resultFocusNodes;
+  final List<_SettingsSearchMatch> results;
+  final bool resultsVisible;
+  final bool editing;
+  final _SettingsArea activeArea;
+  final bool allExpanded;
+  final ValueChanged<String> onChanged;
+  final ValueChanged<bool> onEditingChanged;
+  final VoidCallback onToggleAll;
+  final ValueChanged<_SettingsSearchMatch> onResultSelected;
+  final VoidCallback onExitLeft;
+  final VoidCallback onExitRight;
+  final VoidCallback onExitDown;
+
+  @override
+  Widget build(BuildContext context) {
+    final search = Expanded(
+      child: TvTextInput(
+        key: const ValueKey('settings-search-field'),
+        controller: controller,
+        focusNode: searchFocusNode,
+        autofocus: true,
+        labelText: 'Search settings',
+        hintText: 'Search settings',
+        keyboardTitle: 'Search settings',
+        variant: TvTextInputVariant.headerSearch,
+        compactHeader: true,
+        onChanged: onChanged,
+        onSubmitted: onChanged,
+        onEditingChanged: onEditingChanged,
+        onExitLeft: onExitLeft,
+        onExitRight: toggleAllFocusNode.requestFocus,
+        onExitDown: () {
+          if (resultsVisible && results.isNotEmpty) {
+            resultFocusNodes.first.requestFocus();
+          } else {
+            onExitDown();
+          }
+        },
+      ),
+    );
+    final content = Column(
+      key: const ValueKey('settings-tv-header-tools'),
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Row(
+          crossAxisAlignment: CrossAxisAlignment.center,
+          children: [
+            search,
+            const SizedBox(width: 10),
+            _SettingsToggleAllButton(
+              key: const ValueKey('settings-toggle-all-sections'),
+              focusNode: toggleAllFocusNode,
+              label: allExpanded ? 'Collapse all' : 'Expand all',
+              semanticLabel:
+                  '${allExpanded ? 'Collapse' : 'Expand'} all ${activeArea.label} sections',
+              expanded: allExpanded,
+              onPressed: onToggleAll,
+              onExitLeft: searchFocusNode.requestFocus,
+              onExitRight: onExitRight,
+              onExitDown: onExitDown,
+            ),
+          ],
+        ),
+        if (resultsVisible) ...[
+          const SizedBox(height: 8),
+          // Match the search field exactly: 148px action + 10px gap occupy
+          // the right side of the toolbar at every supported TV width.
+          Padding(
+            padding: const EdgeInsets.only(right: 158),
+            child: _SettingsSearchResults(
+              results: results,
+              focusNodes: resultFocusNodes,
+              onSelected: onResultSelected,
+              onReturnToSearch: searchFocusNode.requestFocus,
+              onExitDown: onExitDown,
+            ),
+          ),
+        ],
+      ],
+    );
+    return Shortcuts(
+      // Keep this ancestry stable while the Android keyboard opens. Swapping
+      // between a bare child and Shortcuts would remount TvTextInput and end
+      // device-keyboard editing immediately. Empty shortcuts still let arrow
+      // keys move the text cursor while editing.
+      shortcuts: editing
+          ? const <ShortcutActivator, Intent>{}
+          : const <ShortcutActivator, Intent>{
+              SingleActivator(LogicalKeyboardKey.arrowLeft):
+                  DirectionalFocusIntent(TraversalDirection.left),
+              SingleActivator(LogicalKeyboardKey.arrowRight):
+                  DirectionalFocusIntent(TraversalDirection.right),
+              SingleActivator(LogicalKeyboardKey.arrowUp):
+                  DirectionalFocusIntent(TraversalDirection.up),
+              SingleActivator(LogicalKeyboardKey.arrowDown):
+                  DirectionalFocusIntent(TraversalDirection.down),
+            },
+      child: Actions(
+        actions: <Type, Action<Intent>>{
+          DirectionalFocusIntent: CallbackAction<DirectionalFocusIntent>(
+            onInvoke: (intent) {
+              final current = FocusManager.instance.primaryFocus;
+              if (current == searchFocusNode) {
+                switch (intent.direction) {
+                  case TraversalDirection.left:
+                    onExitLeft();
+                  case TraversalDirection.right:
+                    toggleAllFocusNode.requestFocus();
+                  case TraversalDirection.down:
+                    if (resultsVisible && results.isNotEmpty) {
+                      resultFocusNodes.first.requestFocus();
+                    } else {
+                      onExitDown();
+                    }
+                  case TraversalDirection.up:
+                    break;
+                }
+                return null;
+              }
+              if (current == toggleAllFocusNode) {
+                switch (intent.direction) {
+                  case TraversalDirection.left:
+                    searchFocusNode.requestFocus();
+                  case TraversalDirection.right:
+                    onExitRight();
+                  case TraversalDirection.down:
+                    onExitDown();
+                  case TraversalDirection.up:
+                    break;
+                }
+                return null;
+              }
+              final resultIndex = resultFocusNodes.indexOf(current!);
+              if (resultIndex >= 0 && resultIndex < results.length) {
+                switch (intent.direction) {
+                  case TraversalDirection.left:
+                    searchFocusNode.requestFocus();
+                  case TraversalDirection.up:
+                    (resultIndex == 0
+                            ? searchFocusNode
+                            : resultFocusNodes[resultIndex - 1])
+                        .requestFocus();
+                  case TraversalDirection.down:
+                    if (resultIndex == results.length - 1) {
+                      onExitDown();
+                    } else {
+                      resultFocusNodes[resultIndex + 1].requestFocus();
+                    }
+                  case TraversalDirection.right:
+                    break;
+                }
+              }
+              return null;
+            },
+          ),
+        },
+        child: content,
+      ),
+    );
+  }
+}
+
+class _SettingsToggleAllButton extends StatelessWidget {
+  const _SettingsToggleAllButton({
+    required this.focusNode,
+    required this.label,
+    required this.semanticLabel,
+    required this.expanded,
+    required this.onPressed,
+    required this.onExitLeft,
+    required this.onExitRight,
+    required this.onExitDown,
+    super.key,
+  });
+
+  final FocusNode focusNode;
+  final String label;
+  final String semanticLabel;
+  final bool expanded;
+  final VoidCallback onPressed;
+  final VoidCallback onExitLeft;
+  final VoidCallback onExitRight;
+  final VoidCallback onExitDown;
+
+  @override
+  Widget build(BuildContext context) => SizedBox(
+    width: 148,
+    height: 44,
+    child: Semantics(
+      button: true,
+      label: semanticLabel,
+      onTap: onPressed,
+      child: ExcludeSemantics(
+        child: TvFocusable(
+          focusNode: focusNode,
+          borderRadius: BorderRadius.circular(9),
+          focusScale: 1.01,
+          onKeyEvent: (_, event) => handleTvDirectionalFocusEvent(
+            event,
+            TvDirectionalFocusCallbacks(
+              left: onExitLeft,
+              right: onExitRight,
+              down: onExitDown,
+            ),
+          ),
+          onPressed: onPressed,
+          child: DecoratedBox(
+            decoration: BoxDecoration(
+              color: Colors.black.withValues(alpha: .76),
+              borderRadius: BorderRadius.circular(9),
+              border: Border.all(
+                color: context.appPalette.primaryText.withValues(alpha: .28),
+                width: 1.2,
+              ),
+            ),
+            child: Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 12),
+              child: Row(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  Icon(
+                    expanded
+                        ? Icons.unfold_less_rounded
+                        : Icons.unfold_more_rounded,
+                    size: 20,
+                  ),
+                  const SizedBox(width: 7),
+                  Flexible(
+                    child: Text(
+                      label,
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                      style: const TextStyle(
+                        fontSize: 13,
+                        fontWeight: FontWeight.w700,
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      ),
+    ),
+  );
+}
+
+class _SettingsSearchResults extends StatelessWidget {
+  const _SettingsSearchResults({
+    required this.results,
+    required this.focusNodes,
+    required this.onSelected,
+    required this.onReturnToSearch,
+    required this.onExitDown,
+  });
+
+  final List<_SettingsSearchMatch> results;
+  final List<FocusNode> focusNodes;
+  final ValueChanged<_SettingsSearchMatch> onSelected;
+  final VoidCallback onReturnToSearch;
+  final VoidCallback onExitDown;
+
+  @override
+  Widget build(BuildContext context) {
+    if (results.isEmpty) {
+      return Semantics(
+        liveRegion: true,
+        label: 'No matching settings found',
+        child: Container(
+          padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 13),
+          decoration: _settingsSearchResultsDecoration(context),
+          child: Text(
+            'No matching settings',
+            style: TextStyle(
+              color: context.appPalette.mutedText,
+              fontSize: 13,
+              fontWeight: FontWeight.w600,
+            ),
+          ),
+        ),
+      );
+    }
+    final availableHeight =
+        MediaQuery.sizeOf(context).height -
+        MediaQuery.viewInsetsOf(context).bottom -
+        92;
+    final maxResultsHeight = availableHeight.clamp(120.0, 330.0);
+    void focusResult(int index) {
+      requestTvFocusAndReveal(focusNodes[index]);
+    }
+
+    return Semantics(
+      container: true,
+      liveRegion: true,
+      label:
+          '${results.length} matching setting${results.length == 1 ? '' : 's'}',
+      child: ConstrainedBox(
+        constraints: BoxConstraints(maxHeight: maxResultsHeight),
+        child: Container(
+          padding: const EdgeInsets.all(6),
+          decoration: _settingsSearchResultsDecoration(context),
+          child: SingleChildScrollView(
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                for (var index = 0; index < results.length; index++)
+                  _SettingsSearchResultButton(
+                    key: ValueKey(_settingsSearchResultKey(results[index])),
+                    match: results[index],
+                    focusNode: focusNodes[index],
+                    onPressed: () => onSelected(results[index]),
+                    onExitLeft: onReturnToSearch,
+                    onExitUp: index == 0
+                        ? onReturnToSearch
+                        : () => focusResult(index - 1),
+                    onExitDown: index == results.length - 1
+                        ? onExitDown
+                        : () => focusResult(index + 1),
+                  ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+BoxDecoration _settingsSearchResultsDecoration(BuildContext context) =>
+    BoxDecoration(
+      color: Color.alphaBlend(
+        context.appPalette.accent.withValues(alpha: .08),
+        context.appPalette.background,
+      ),
+      borderRadius: BorderRadius.circular(10),
+      border: Border.all(color: _settingsBorderColor(context, .24)),
+      boxShadow: [
+        BoxShadow(
+          color: Colors.black.withValues(alpha: .52),
+          blurRadius: 18,
+          offset: const Offset(0, 8),
+        ),
+      ],
+    );
+
+class _SettingsSearchResultButton extends StatelessWidget {
+  const _SettingsSearchResultButton({
+    required this.match,
+    required this.focusNode,
+    required this.onPressed,
+    required this.onExitLeft,
+    required this.onExitUp,
+    required this.onExitDown,
+    super.key,
+  });
+
+  final _SettingsSearchMatch match;
+  final FocusNode focusNode;
+  final VoidCallback onPressed;
+  final VoidCallback onExitLeft;
+  final VoidCallback onExitUp;
+  final VoidCallback onExitDown;
+
+  @override
+  Widget build(BuildContext context) => Semantics(
+    button: true,
+    label:
+        '${match.matchedLabel}, ${match.section.area.label}, ${match.section.title}',
+    onTap: onPressed,
+    child: ExcludeSemantics(
+      child: TvFocusable(
+        focusNode: focusNode,
+        borderRadius: BorderRadius.circular(7),
+        focusScale: 1.01,
+        onKeyEvent: (_, event) => handleTvDirectionalFocusEvent(
+          event,
+          TvDirectionalFocusCallbacks(
+            left: onExitLeft,
+            up: onExitUp,
+            down: onExitDown,
+          ),
+        ),
+        onPressed: onPressed,
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 11, vertical: 8),
+          child: Row(
+            children: [
+              Icon(
+                Icons.search_rounded,
+                size: 18,
+                color: context.appPalette.secondaryAccent,
+              ),
+              const SizedBox(width: 10),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      match.matchedLabel,
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                      style: const TextStyle(
+                        fontSize: 13,
+                        fontWeight: FontWeight.w700,
+                      ),
+                    ),
+                    const SizedBox(height: 1),
+                    Text(
+                      '${match.section.area.label}  ›  ${match.section.title}',
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                      style: TextStyle(
+                        color: context.appPalette.mutedText,
+                        fontSize: 10.5,
+                        fontWeight: FontWeight.w600,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+              const Icon(Icons.arrow_forward_rounded, size: 16),
+            ],
+          ),
+        ),
+      ),
+    ),
+  );
+}
+
 class _SettingsResponsiveColumns extends StatelessWidget {
   const _SettingsResponsiveColumns({
     required this.left,
@@ -2910,19 +4226,37 @@ class _SettingsCardLane extends StatelessWidget {
 
 class _SettingsSectionCard extends StatelessWidget {
   const _SettingsSectionCard({
+    required this.section,
     required this.title,
     required this.subtitle,
     required this.child,
+    this.collapsible = false,
+    this.expanded = true,
+    this.focusNode,
+    this.onExpandedChanged,
     super.key,
   });
 
+  final _SettingsSection section;
   final String title;
   final String subtitle;
   final Widget child;
+  final bool collapsible;
+  final bool expanded;
+  final FocusNode? focusNode;
+  final ValueChanged<bool>? onExpandedChanged;
 
   @override
-  Widget build(BuildContext context) =>
-      _SettingsCardFrame(title: title, subtitle: subtitle, child: child);
+  Widget build(BuildContext context) => _SettingsCardFrame(
+    section: section,
+    title: title,
+    subtitle: subtitle,
+    collapsible: collapsible,
+    expanded: expanded,
+    focusNode: focusNode,
+    onExpandedChanged: onExpandedChanged,
+    child: child,
+  );
 }
 
 class _SettingsCardFrame extends StatelessWidget {
@@ -2930,44 +4264,121 @@ class _SettingsCardFrame extends StatelessWidget {
     required this.title,
     required this.child,
     this.subtitle,
+    this.section,
+    this.collapsible = false,
+    this.expanded = true,
+    this.focusNode,
+    this.onExpandedChanged,
   });
 
   final String title;
   final String? subtitle;
   final Widget child;
+  final _SettingsSection? section;
+  final bool collapsible;
+  final bool expanded;
+  final FocusNode? focusNode;
+  final ValueChanged<bool>? onExpandedChanged;
 
   @override
   Widget build(BuildContext context) {
     final tvScale = _usesTvSettingsScale(context);
+    final body = Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        if (subtitle case final detail?) ...[
+          SizedBox(height: tvScale ? 2 : 4),
+          Text(
+            detail,
+            style: TextStyle(
+              color: context.appPalette.mutedText,
+              fontSize: tvScale ? 11 : 11,
+              height: 1.3,
+            ),
+          ),
+        ],
+        SizedBox(height: tvScale ? 5 : 10),
+        DecoratedBox(
+          key: section == null
+              ? null
+              : ValueKey('settings-section-content-${section!.slug}'),
+          decoration: BoxDecoration(
+            color: context.appPalette.surface.withValues(alpha: .35),
+            borderRadius: BorderRadius.circular(8),
+            border: Border.all(color: _settingsBorderColor(context, .14)),
+          ),
+          child: _SettingsCardScope(child: child),
+        ),
+      ],
+    );
     return _Panel(
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          _AppearanceCardTitle(title),
-          if (subtitle case final detail?) ...[
-            SizedBox(height: tvScale ? 2 : 4),
-            Text(
-              detail,
-              style: TextStyle(
-                color: context.appPalette.mutedText,
-                fontSize: tvScale ? 11 : 11,
-                height: 1.3,
-              ),
-            ),
-          ],
-          SizedBox(height: tvScale ? 5 : 10),
-          DecoratedBox(
-            decoration: BoxDecoration(
-              color: context.appPalette.surface.withValues(alpha: .35),
-              borderRadius: BorderRadius.circular(8),
-              border: Border.all(color: _settingsBorderColor(context, .14)),
-            ),
-            child: _SettingsCardScope(child: child),
-          ),
+          if (collapsible && section != null)
+            _SettingsCollapsibleCardHeader(
+              key: ValueKey('settings-section-toggle-${section!.slug}'),
+              title: title,
+              expanded: expanded,
+              focusNode: focusNode,
+              onPressed: () => onExpandedChanged?.call(!expanded),
+            )
+          else
+            _AppearanceCardTitle(title),
+          if (!collapsible || expanded) body,
         ],
       ),
     );
   }
+}
+
+class _SettingsCollapsibleCardHeader extends StatelessWidget {
+  const _SettingsCollapsibleCardHeader({
+    required this.title,
+    required this.expanded,
+    required this.onPressed,
+    this.focusNode,
+    super.key,
+  });
+
+  final String title;
+  final bool expanded;
+  final VoidCallback onPressed;
+  final FocusNode? focusNode;
+
+  @override
+  Widget build(BuildContext context) => Semantics(
+    button: true,
+    expanded: expanded,
+    label: '$title, ${expanded ? 'expanded' : 'collapsed'}',
+    onTap: onPressed,
+    child: ExcludeSemantics(
+      child: TvFocusable(
+        focusNode: focusNode,
+        focusScale: 1.005,
+        borderRadius: BorderRadius.circular(7),
+        onPressed: onPressed,
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 2, vertical: 1),
+          child: Row(
+            children: [
+              Expanded(child: _AppearanceCardTitle(title)),
+              AnimatedRotation(
+                turns: expanded ? .5 : 0,
+                duration: const Duration(milliseconds: 140),
+                curve: Curves.easeOutCubic,
+                child: Icon(
+                  Icons.keyboard_arrow_down_rounded,
+                  size: _usesTvSettingsScale(context) ? 22 : 24,
+                  color: context.appPalette.mutedText,
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    ),
+  );
 }
 
 class _SettingsCardScope extends InheritedWidget {
@@ -3002,6 +4413,9 @@ class _AppearanceSettingsLayout extends StatelessWidget {
     required this.inputFeedbackFirstFocusNode,
     required this.clickSoundsFocusNode,
     required this.shelfFocusNodes,
+    required this.expandedSections,
+    required this.sectionFocusNodes,
+    required this.onSectionExpandedChanged,
     required this.onOpenThemeStudio,
     required this.onOpenMenuOrder,
     required this.onTitleLanguageChanged,
@@ -3030,6 +4444,10 @@ class _AppearanceSettingsLayout extends StatelessWidget {
   final FocusNode inputFeedbackFirstFocusNode;
   final FocusNode clickSoundsFocusNode;
   final Map<HomeShelf, FocusNode> shelfFocusNodes;
+  final Set<_SettingsSection> expandedSections;
+  final Map<_SettingsSection, FocusNode> sectionFocusNodes;
+  final void Function(_SettingsSection section, bool expanded)
+  onSectionExpandedChanged;
   final VoidCallback onOpenThemeStudio;
   final VoidCallback onOpenMenuOrder;
   final ValueChanged<TitleLanguagePreference> onTitleLanguageChanged;
@@ -3065,14 +4483,22 @@ class _AppearanceSettingsLayout extends StatelessWidget {
 
     final themeAndDisplay = _AppearanceCard(
       key: const ValueKey('appearance-theme-display-card'),
+      section: _SettingsSection.themeDisplay,
       title: 'Theme & display',
+      collapsible: usesTvListLayout,
+      expanded: expandedSections.contains(_SettingsSection.themeDisplay),
+      focusNode: sectionFocusNodes[_SettingsSection.themeDisplay],
+      onExpandedChanged: (expanded) =>
+          onSectionExpandedChanged(_SettingsSection.themeDisplay, expanded),
       children: [
         _AppearanceActionRow(
           key: const ValueKey('open-theme-studio'),
           label: 'Theme Studio',
           icon: Icons.palette_outlined,
           focusNode: themeStudioFocusNode,
-          autofocus: true,
+          // The fixed Settings search is the intentional entry point on TV.
+          // Phone/tablet keeps the existing direct-layout autofocus behavior.
+          autofocus: !usesTvListLayout,
           trailing: paletteDots(),
           showDivider: true,
           onPressed: onOpenThemeStudio,
@@ -3109,7 +4535,13 @@ class _AppearanceSettingsLayout extends StatelessWidget {
 
     final navigation = _AppearanceCard(
       key: const ValueKey('appearance-navigation-card'),
+      section: _SettingsSection.navigation,
       title: 'Navigation',
+      collapsible: usesTvListLayout,
+      expanded: expandedSections.contains(_SettingsSection.navigation),
+      focusNode: sectionFocusNodes[_SettingsSection.navigation],
+      onExpandedChanged: (expanded) =>
+          onSectionExpandedChanged(_SettingsSection.navigation, expanded),
       children: [
         _AppearanceSelectionRow<NavigationChromeSize>(
           key: const ValueKey('settings-appearance-navigation-size'),
@@ -3148,7 +4580,13 @@ class _AppearanceSettingsLayout extends StatelessWidget {
 
     final homeScreen = _AppearanceCard(
       key: const ValueKey('appearance-home-screen-card'),
+      section: _SettingsSection.homeScreen,
       title: 'Home screen',
+      collapsible: usesTvListLayout,
+      expanded: expandedSections.contains(_SettingsSection.homeScreen),
+      focusNode: sectionFocusNodes[_SettingsSection.homeScreen],
+      onExpandedChanged: (expanded) =>
+          onSectionExpandedChanged(_SettingsSection.homeScreen, expanded),
       children: [
         _AppearanceToggleRow(
           key: const ValueKey('settings-appearance-featured-hero'),
@@ -3181,7 +4619,13 @@ class _AppearanceSettingsLayout extends StatelessWidget {
 
     final displayOptions = _AppearanceCard(
       key: const ValueKey('appearance-display-options-card'),
+      section: _SettingsSection.displayOptions,
       title: 'Display options',
+      collapsible: usesTvListLayout,
+      expanded: expandedSections.contains(_SettingsSection.displayOptions),
+      focusNode: sectionFocusNodes[_SettingsSection.displayOptions],
+      onExpandedChanged: (expanded) =>
+          onSectionExpandedChanged(_SettingsSection.displayOptions, expanded),
       children: [
         _AppearanceSelectionRow<double>(
           label: 'Interface scale',
@@ -3283,7 +4727,13 @@ class _AppearanceSettingsLayout extends StatelessWidget {
 
     final inputAndFeedback = _AppearanceCard(
       key: const ValueKey('appearance-input-feedback-card'),
+      section: _SettingsSection.inputFeedback,
       title: 'Input & feedback',
+      collapsible: usesTvListLayout,
+      expanded: expandedSections.contains(_SettingsSection.inputFeedback),
+      focusNode: sectionFocusNodes[_SettingsSection.inputFeedback],
+      onExpandedChanged: (expanded) =>
+          onSectionExpandedChanged(_SettingsSection.inputFeedback, expanded),
       children: [
         _AppearanceSelectionRow<bool>(
           label: 'On-screen keyboard',
@@ -3319,9 +4769,15 @@ class _AppearanceSettingsLayout extends StatelessWidget {
 
     final homeShelvesPanel = _AppearanceCard(
       key: const ValueKey('appearance-home-shelves-card'),
+      section: _SettingsSection.homeShelves,
       title: 'Home shelves',
       subtitle:
           'Choose what appears on Home and move favorites toward the top.',
+      collapsible: usesTvListLayout,
+      expanded: expandedSections.contains(_SettingsSection.homeShelves),
+      focusNode: sectionFocusNodes[_SettingsSection.homeShelves],
+      onExpandedChanged: (expanded) =>
+          onSectionExpandedChanged(_SettingsSection.homeShelves, expanded),
       children: [
         for (var index = 0; index < homeShelfOrder.length; index++) ...[
           _HomeShelfRow(
@@ -3387,20 +4843,35 @@ class _AppearanceSettingsLayout extends StatelessWidget {
 
 class _AppearanceCard extends StatelessWidget {
   const _AppearanceCard({
+    required this.section,
     required this.title,
     required this.children,
     this.subtitle,
+    this.collapsible = false,
+    this.expanded = true,
+    this.focusNode,
+    this.onExpandedChanged,
     super.key,
   });
 
+  final _SettingsSection section;
   final String title;
   final String? subtitle;
   final List<Widget> children;
+  final bool collapsible;
+  final bool expanded;
+  final FocusNode? focusNode;
+  final ValueChanged<bool>? onExpandedChanged;
 
   @override
   Widget build(BuildContext context) => _SettingsCardFrame(
+    section: section,
     title: title,
     subtitle: subtitle,
+    collapsible: collapsible,
+    expanded: expanded,
+    focusNode: focusNode,
+    onExpandedChanged: onExpandedChanged,
     child: Column(children: children),
   );
 }
@@ -4028,6 +5499,7 @@ class _CustomizationPanel extends StatelessWidget {
     required this.captionTextColorFocusNode,
     required this.captionTextSizeFocusNode,
     required this.playerControlsSectionFocusNode,
+    required this.fillerIndicatorsFocusNode,
     required this.resetFocusNode,
     required this.expandedSections,
     required this.onSectionExpandedChanged,
@@ -4059,6 +5531,7 @@ class _CustomizationPanel extends StatelessWidget {
   final FocusNode captionTextColorFocusNode;
   final FocusNode captionTextSizeFocusNode;
   final FocusNode playerControlsSectionFocusNode;
+  final FocusNode fillerIndicatorsFocusNode;
   final FocusNode resetFocusNode;
   final Set<_CustomizationSection> expandedSections;
   final void Function(_CustomizationSection section, bool expanded)
@@ -4533,6 +6006,7 @@ class _CustomizationPanel extends StatelessWidget {
                       'Mark episodes identified as anime-original filler.',
                   icon: Icons.info_outline_rounded,
                   value: preferences.showFillerIndicators,
+                  focusNode: fillerIndicatorsFocusNode,
                   onChanged: controller.setShowFillerIndicators,
                 ),
               ],

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: 'none'
 # Public and Beta artifacts built from the same source use one monotonically
 # increasing Android versionCode. The project default carries the Beta display
 # version; the Public universal APK overrides the build name to the 1.x line.
-version: 2.0.51+410028
+version: 2.0.52+410029
 
 environment:
   sdk: ^3.12.2

--- a/test/accounts_focus_test.dart
+++ b/test/accounts_focus_test.dart
@@ -1,15 +1,19 @@
 import 'package:anime_tv/core/layout/adaptive_layout.dart';
 import 'package:anime_tv/core/platform/android_tv_bridge.dart';
+import 'package:anime_tv/features/auth/application/tracking_token_service.dart';
+import 'package:anime_tv/features/auth/domain/tracking_provider.dart';
 import 'package:anime_tv/features/settings/application/real_debrid_settings_controller.dart';
 import 'package:anime_tv/features/settings/application/home_shelf_preferences_controller.dart';
 import 'package:anime_tv/features/settings/application/app_update_controller.dart';
 import 'package:anime_tv/features/settings/application/settings_preferences_controller.dart';
+import 'package:anime_tv/features/settings/application/tracking_accounts_controller.dart';
 import 'package:anime_tv/features/settings/presentation/accounts_screen.dart';
 import 'package:anime_tv/features/discord/application/discord_presence_controller.dart';
 import 'package:anime_tv/features/streaming/data/real_debrid_models.dart';
 import 'package:anime_tv/core/theme/app_theme.dart';
 import 'package:anime_tv/core/tv/tv_focusable.dart';
 import 'package:anime_tv/core/tv/tv_shortcuts.dart';
+import 'package:anime_tv/core/widgets/tv_text_input.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -85,25 +89,23 @@ void main() {
     );
     await tester.pumpAndSettle();
 
-    expect(
-      FocusManager.instance.primaryFocus?.debugLabel,
-      'accounts.customization.first',
-    );
-    await tester.sendKeyEvent(LogicalKeyboardKey.arrowRight);
+    expect(FocusManager.instance.primaryFocus?.debugLabel, 'accounts.search');
+    await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
     await tester.pump();
     expect(
       FocusManager.instance.primaryFocus?.debugLabel,
-      'accounts.customization.first',
-      reason:
-          'A vertical Settings list must not jump to another card on Right.',
+      'accounts.area.appearance',
     );
     for (final expected in const [
+      'accounts.settings-section.theme-display',
+      'accounts.customization.first',
       'accounts.title-language',
       'accounts.show-title-style',
+      'accounts.settings-section.home-screen',
       'accounts.customization.home-content.featured',
       'accounts.customization.home-content.poster-metadata',
       'accounts.customization.home-content.continue-watching',
-      'accounts.section.display',
+      'accounts.settings-section.display-options',
     ]) {
       await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
       await tester.pump();
@@ -129,6 +131,12 @@ void main() {
     );
     await tester.sendKeyEvent(LogicalKeyboardKey.enter);
     await tester.pumpAndSettle();
+    await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
+    await tester.pump();
+    expect(
+      FocusManager.instance.primaryFocus?.debugLabel,
+      'accounts.settings-section.debrid-streaming',
+    );
     await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
     await tester.pump();
     expect(
@@ -166,7 +174,12 @@ void main() {
 
       await tester.pumpWidget(
         ProviderScope(
-          overrides: [isTelevisionProvider.overrideWithValue(true)],
+          overrides: [
+            isTelevisionProvider.overrideWithValue(true),
+            trackingAccountsControllerProvider.overrideWith(
+              (_) => _SettingsProfileController(),
+            ),
+          ],
           child: const MaterialApp(home: TvShortcuts(child: AccountsScreen())),
         ),
       );
@@ -180,10 +193,14 @@ void main() {
       expect(find.text('Settings'), findsNothing);
       expect(find.text('APPEARANCE'), findsNothing);
       expect(find.text('Expand all'), findsNothing);
-      expect(find.text('Collapse all'), findsNothing);
+      expect(find.text('Collapse all'), findsOneWidget);
       expect(
-        find.byKey(const ValueKey('customize-toggle-all-sections')),
-        findsNothing,
+        find.byKey(const ValueKey('settings-toggle-all-sections')),
+        findsOneWidget,
+      );
+      expect(
+        find.byKey(const ValueKey('settings-search-field')),
+        findsOneWidget,
       );
 
       final appearanceTab = find.byKey(
@@ -241,13 +258,575 @@ void main() {
       expect((homeCard.width - themeCard.width).abs(), lessThan(1));
       expect(homeCard.top, greaterThan(themeCard.bottom));
       expect(navigationCard.top, greaterThan(homeCard.bottom));
+      expect(FocusManager.instance.primaryFocus?.debugLabel, 'accounts.search');
+      expect(tester.takeException(), isNull);
+    },
+  );
+
+  testWidgets(
+    'TV Settings toolbar and collapsible headers follow D-pad order',
+    (tester) async {
+      FlutterSecureStorage.setMockInitialValues({});
+      tester.view.physicalSize = const Size(1280, 720);
+      tester.view.devicePixelRatio = 1;
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            isTelevisionProvider.overrideWithValue(true),
+            trackingAccountsControllerProvider.overrideWith(
+              (_) => _SettingsProfileController(),
+            ),
+          ],
+          child: const MaterialApp(home: TvShortcuts(child: AccountsScreen())),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      FocusNode focusFor(Finder keyed) {
+        final root = tester.widget(keyed);
+        if (root is TvTextInput) return root.focusNode!;
+        if (root is TvFocusable) return root.focusNode!;
+        final nested = find.descendant(
+          of: keyed,
+          matching: find.byType(TvFocusable),
+        );
+        expect(nested, findsOneWidget);
+        return tester.widget<TvFocusable>(nested).focusNode!;
+      }
+
+      final search = find.byKey(const ValueKey('settings-search-field'));
+      final toggleAll = find.byKey(
+        const ValueKey('settings-toggle-all-sections'),
+      );
+      final profile = find.byKey(const ValueKey('top-level-fixed-profile'));
+      final appearance = find.byKey(const ValueKey('settings-area-appearance'));
+      final themeHeader = find.byKey(
+        const ValueKey('settings-section-toggle-theme-display'),
+      );
+      final homeHeader = find.byKey(
+        const ValueKey('settings-section-toggle-home-screen'),
+      );
+      final firstThemeRow = find.byKey(const ValueKey('open-theme-studio'));
+
+      final searchFocus = focusFor(search);
+      final toggleAllFocus = focusFor(toggleAll);
+      final profileFocus = focusFor(profile);
+      final appearanceFocus = focusFor(appearance);
+      final themeHeaderFocus = focusFor(themeHeader);
+      final homeHeaderFocus = focusFor(homeHeader);
+      final firstThemeRowFocus = focusFor(firstThemeRow);
+      final settingsRailDetector = find.descendant(
+        of: find.byKey(const ValueKey('main-nav-settings')),
+        matching: find.byType(FocusableActionDetector),
+      );
+      final settingsRailFocus = tester
+          .widget<FocusableActionDetector>(settingsRailDetector)
+          .focusNode!;
+
+      settingsRailFocus.requestFocus();
+      await tester.pump();
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowRight);
+      await tester.pump();
+      expect(searchFocus.hasFocus, isTrue);
+
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowLeft);
+      await tester.pump();
+      expect(settingsRailFocus.hasFocus, isTrue);
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowRight);
+      await tester.pump();
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowRight);
+      await tester.pump();
       expect(
         FocusManager.instance.primaryFocus?.debugLabel,
-        'accounts.customization.first',
+        'accounts.sections.toggle-all',
+      );
+      expect(toggleAllFocus.hasFocus, isTrue);
+
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowLeft);
+      await tester.pump();
+      expect(searchFocus.hasFocus, isTrue);
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
+      await tester.pump();
+      expect(appearanceFocus.hasFocus, isTrue);
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowUp);
+      await tester.pump();
+      expect(searchFocus.hasFocus, isTrue);
+
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowRight);
+      await tester.pump();
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowRight);
+      await tester.pump();
+      expect(profileFocus.hasFocus, isTrue);
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowLeft);
+      await tester.pump();
+      expect(toggleAllFocus.hasFocus, isTrue);
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
+      await tester.pump();
+      expect(appearanceFocus.hasFocus, isTrue);
+
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
+      await tester.pump();
+      expect(themeHeaderFocus.hasFocus, isTrue);
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
+      await tester.pump();
+      expect(firstThemeRowFocus.hasFocus, isTrue);
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowUp);
+      await tester.pump();
+      expect(themeHeaderFocus.hasFocus, isTrue);
+
+      toggleAllFocus.requestFocus();
+      await tester.pump();
+      await tester.sendKeyEvent(LogicalKeyboardKey.enter);
+      await tester.pumpAndSettle();
+      expect(find.text('Expand all'), findsOneWidget);
+      themeHeaderFocus.requestFocus();
+      await tester.pump();
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
+      await tester.pump();
+      expect(homeHeaderFocus.hasFocus, isTrue);
+
+      themeHeaderFocus.requestFocus();
+      await tester.pump();
+      await tester.sendKeyEvent(LogicalKeyboardKey.enter);
+      await tester.pumpAndSettle();
+      expect(
+        find.byKey(const ValueKey('settings-section-content-theme-display')),
+        findsOneWidget,
+      );
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
+      await tester.pump();
+      expect(firstThemeRowFocus.hasFocus, isTrue);
+      expect(tester.takeException(), isNull);
+    },
+  );
+
+  testWidgets(
+    'TV Settings search opens the matching area and focuses its setting',
+    (tester) async {
+      FlutterSecureStorage.setMockInitialValues({
+        'input_use_built_in_keyboard': 'false',
+      });
+      tester.view.physicalSize = const Size(1280, 720);
+      tester.view.devicePixelRatio = 1;
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            isTelevisionProvider.overrideWithValue(true),
+            trackingAccountsControllerProvider.overrideWith(
+              (_) => _SettingsProfileController(),
+            ),
+          ],
+          child: const MaterialApp(home: TvShortcuts(child: AccountsScreen())),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      final search = find.byKey(const ValueKey('settings-search-field'));
+      final toggleAll = find.byKey(
+        const ValueKey('settings-toggle-all-sections'),
+      );
+      final profile = find.byKey(const ValueKey('top-level-fixed-profile'));
+      expect(search, findsOneWidget);
+      expect(toggleAll, findsOneWidget);
+      expect(profile, findsOneWidget);
+
+      final searchRect = tester.getRect(search);
+      expect(searchRect.width, greaterThan(searchRect.height * 3));
+      expect(tester.getRect(toggleAll).left, greaterThan(searchRect.right));
+      expect(
+        tester.getRect(profile).left,
+        greaterThan(tester.getRect(toggleAll).right),
+      );
+
+      final editable = find.descendant(
+        of: search,
+        matching: find.byType(EditableText),
+      );
+      expect(editable, findsOneWidget);
+      await tester.tap(editable);
+      await tester.pumpAndSettle();
+      expect(tester.testTextInput.isVisible, isTrue);
+      await tester.enterText(editable, 'Watch Party');
+      await tester.pumpAndSettle();
+      expect(
+        find.byKey(
+          const ValueKey('settings-search-result-navigation-watch-party'),
+        ),
+        findsOneWidget,
+      );
+      expect(
+        find.byKey(
+          const ValueKey(
+            'settings-search-result-libraries-features-watch-party',
+          ),
+        ),
+        findsOneWidget,
+      );
+
+      await tester.enterText(editable, 'Diagnostics');
+      await tester.pumpAndSettle();
+
+      final result = find.byKey(
+        const ValueKey('settings-search-result-device-support-diagnostics'),
+      );
+      final visibleResultKeys = find
+          .byWidgetPredicate(
+            (widget) =>
+                widget.key is ValueKey<String> &&
+                (widget.key! as ValueKey<String>).value.startsWith(
+                  'settings-search-result-',
+                ),
+          )
+          .evaluate()
+          .map((element) => element.widget.key)
+          .toList();
+      expect(
+        result,
+        findsOneWidget,
+        reason: 'Visible results: $visibleResultKeys',
+      );
+      await tester.tap(result);
+      await tester.pumpAndSettle();
+
+      expect(
+        find.byKey(const ValueKey('settings-card-system-support')),
+        findsOneWidget,
+      );
+      expect(
+        find.byKey(const ValueKey('settings-section-content-device-support')),
+        findsOneWidget,
+      );
+      expect(
+        FocusManager.instance.primaryFocus?.debugLabel,
+        'accounts.system.diagnostics',
       );
       expect(tester.takeException(), isNull);
     },
   );
+
+  testWidgets(
+    'TV Settings search sizes results to the field and targets Home shelves',
+    (tester) async {
+      FlutterSecureStorage.setMockInitialValues({
+        'input_use_built_in_keyboard': 'false',
+      });
+      tester.view.physicalSize = const Size(1280, 720);
+      tester.view.devicePixelRatio = 1;
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            isTelevisionProvider.overrideWithValue(true),
+            trackingAccountsControllerProvider.overrideWith(
+              (_) => _SettingsProfileController(),
+            ),
+          ],
+          child: const MaterialApp(home: TvShortcuts(child: AccountsScreen())),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      final search = find.byKey(const ValueKey('settings-search-field'));
+      final editable = find.descendant(
+        of: search,
+        matching: find.byType(EditableText),
+      );
+      await tester.tap(editable);
+      await tester.pumpAndSettle();
+      await tester.enterText(editable, 'Recently released');
+      await tester.pumpAndSettle();
+
+      final result = find.byKey(
+        const ValueKey('settings-search-result-home-shelves-recently-released'),
+      );
+      expect(result, findsOneWidget);
+      final dropdown = find.ancestor(
+        of: result,
+        matching: find.byWidgetPredicate(
+          (widget) =>
+              widget is ConstrainedBox &&
+              widget.constraints.maxHeight >= 120 &&
+              widget.constraints.maxHeight <= 330,
+        ),
+      );
+      expect(dropdown, findsOneWidget);
+      expect(
+        (tester.getRect(dropdown).width - tester.getRect(search).width).abs(),
+        lessThanOrEqualTo(1),
+      );
+
+      final resultFocusable = find.descendant(
+        of: result,
+        matching: find.byType(TvFocusable),
+      );
+      expect(resultFocusable, findsOneWidget);
+      tester.widget<TvFocusable>(resultFocusable).focusNode!.requestFocus();
+      await tester.pumpAndSettle();
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
+      await tester.pumpAndSettle();
+
+      expect(result, findsNothing);
+      expect(tester.widget<TvTextInput>(search).controller.text, isEmpty);
+      expect(
+        FocusManager.instance.primaryFocus?.debugLabel,
+        'accounts.area.appearance',
+      );
+
+      await tester.tap(editable);
+      await tester.pumpAndSettle();
+      await tester.enterText(editable, 'Recently released');
+      await tester.pumpAndSettle();
+      final refreshedResult = find.byKey(
+        const ValueKey('settings-search-result-home-shelves-recently-released'),
+      );
+      expect(refreshedResult, findsOneWidget);
+      await tester.tap(refreshedResult);
+      await tester.pumpAndSettle();
+
+      expect(
+        find.byKey(const ValueKey('settings-section-content-home-shelves')),
+        findsOneWidget,
+      );
+      expect(
+        FocusManager.instance.primaryFocus?.debugLabel,
+        'accounts.shelf.recentlyReleased',
+      );
+      expect(tester.takeException(), isNull);
+    },
+  );
+
+  testWidgets(
+    'TV Settings profile Down closes search results before entering tabs',
+    (tester) async {
+      FlutterSecureStorage.setMockInitialValues({
+        'input_use_built_in_keyboard': 'false',
+      });
+      tester.view.physicalSize = const Size(1280, 720);
+      tester.view.devicePixelRatio = 1;
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            isTelevisionProvider.overrideWithValue(true),
+            trackingAccountsControllerProvider.overrideWith(
+              (_) => _SettingsProfileController(),
+            ),
+          ],
+          child: const MaterialApp(home: TvShortcuts(child: AccountsScreen())),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      final search = find.byKey(const ValueKey('settings-search-field'));
+      final editable = find.descendant(
+        of: search,
+        matching: find.byType(EditableText),
+      );
+      await tester.tap(editable);
+      await tester.pumpAndSettle();
+      await tester.enterText(editable, 'Diagnostics');
+      await tester.pumpAndSettle();
+
+      final result = find.byKey(
+        const ValueKey('settings-search-result-device-support-diagnostics'),
+      );
+      expect(result, findsOneWidget);
+
+      final profile = find.byKey(const ValueKey('top-level-fixed-profile'));
+      final profileFocusable = find.descendant(
+        of: profile,
+        matching: find.byType(TvFocusable),
+      );
+      tester.widget<TvFocusable>(profileFocusable).focusNode!.requestFocus();
+      await tester.pump();
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
+      await tester.pumpAndSettle();
+
+      expect(result, findsNothing);
+      expect(tester.widget<TvTextInput>(search).controller.text, isEmpty);
+      expect(
+        FocusManager.instance.primaryFocus?.debugLabel,
+        'accounts.area.appearance',
+      );
+      expect(tester.takeException(), isNull);
+    },
+  );
+
+  testWidgets('TV Settings sections collapse alone or all together', (
+    tester,
+  ) async {
+    FlutterSecureStorage.setMockInitialValues({});
+    tester.view.physicalSize = const Size(1280, 720);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [isTelevisionProvider.overrideWithValue(true)],
+        child: const MaterialApp(home: TvShortcuts(child: AccountsScreen())),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    const sectionSlugs = [
+      'theme-display',
+      'home-screen',
+      'display-options',
+      'input-feedback',
+      'home-shelves',
+      'navigation',
+    ];
+    for (final slug in sectionSlugs) {
+      expect(
+        find.byKey(ValueKey('settings-section-toggle-$slug')),
+        findsOneWidget,
+      );
+      expect(
+        find.byKey(ValueKey('settings-section-content-$slug')),
+        findsOneWidget,
+      );
+    }
+
+    final toggleAll = find.byKey(
+      const ValueKey('settings-toggle-all-sections'),
+    );
+    expect(
+      find.descendant(of: toggleAll, matching: find.text('Collapse all')),
+      findsOneWidget,
+    );
+    await tester.tap(toggleAll);
+    await tester.pumpAndSettle();
+
+    expect(
+      find.descendant(of: toggleAll, matching: find.text('Expand all')),
+      findsOneWidget,
+    );
+    for (final slug in sectionSlugs) {
+      expect(
+        find.byKey(ValueKey('settings-section-content-$slug')),
+        findsNothing,
+      );
+    }
+    expect(find.text('Theme & display'), findsOneWidget);
+    expect(find.text('Home screen'), findsOneWidget);
+    expect(find.text('Navigation'), findsWidgets);
+
+    final themeToggle = find.byKey(
+      const ValueKey('settings-section-toggle-theme-display'),
+    );
+    await tester.tap(themeToggle);
+    await tester.pumpAndSettle();
+    expect(
+      find.byKey(const ValueKey('settings-section-content-theme-display')),
+      findsOneWidget,
+    );
+    expect(find.text('Title language'), findsOneWidget);
+    expect(
+      find.byKey(const ValueKey('settings-section-content-home-screen')),
+      findsNothing,
+    );
+
+    await tester.tap(toggleAll);
+    await tester.pumpAndSettle();
+    expect(
+      find.descendant(of: toggleAll, matching: find.text('Collapse all')),
+      findsOneWidget,
+    );
+    for (final slug in sectionSlugs) {
+      expect(
+        find.byKey(ValueKey('settings-section-content-$slug')),
+        findsOneWidget,
+      );
+    }
+
+    await tester.tap(themeToggle);
+    await tester.pumpAndSettle();
+    expect(
+      find.byKey(const ValueKey('settings-section-content-theme-display')),
+      findsNothing,
+    );
+    expect(
+      find.byKey(const ValueKey('settings-section-content-home-screen')),
+      findsOneWidget,
+    );
+
+    await tester.tap(find.byKey(const ValueKey('settings-area-playback')));
+    await tester.pumpAndSettle();
+    expect(
+      find.byKey(const ValueKey('settings-section-content-closed-captions')),
+      findsOneWidget,
+      reason: 'Collapsing Appearance must not collapse another Settings tab.',
+    );
+    expect(
+      find.byKey(const ValueKey('settings-section-content-player-controls')),
+      findsOneWidget,
+    );
+
+    await tester.tap(toggleAll);
+    await tester.pumpAndSettle();
+    expect(
+      find.byKey(const ValueKey('settings-section-content-closed-captions')),
+      findsNothing,
+    );
+    expect(
+      find.byKey(const ValueKey('settings-section-content-player-controls')),
+      findsNothing,
+    );
+
+    await tester.tap(find.byKey(const ValueKey('settings-area-appearance')));
+    await tester.pumpAndSettle();
+    expect(
+      find.byKey(const ValueKey('settings-section-content-theme-display')),
+      findsNothing,
+    );
+    expect(
+      find.byKey(const ValueKey('settings-section-content-home-screen')),
+      findsOneWidget,
+      reason: 'The global control must preserve the other tab\'s card state.',
+    );
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('phone Settings keep the existing direct layout', (tester) async {
+    FlutterSecureStorage.setMockInitialValues({});
+    tester.view.physicalSize = const Size(390, 844);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [isTelevisionProvider.overrideWithValue(false)],
+        child: const MaterialApp(home: AccountsScreen()),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(const ValueKey('settings-search-field')), findsNothing);
+    expect(
+      find.byKey(const ValueKey('settings-toggle-all-sections')),
+      findsNothing,
+    );
+    expect(
+      find.byKey(const ValueKey('settings-section-toggle-theme-display')),
+      findsNothing,
+    );
+    expect(find.text('Theme Studio'), findsOneWidget);
+    expect(find.text('Title language'), findsOneWidget);
+    expect(find.text('Show title style'), findsOneWidget);
+    expect(tester.takeException(), isNull);
+  });
 
   testWidgets(
     'Settings option rows exit Left through the active Settings rail item',
@@ -268,10 +847,7 @@ void main() {
       );
       await tester.pumpAndSettle();
 
-      expect(
-        FocusManager.instance.primaryFocus?.debugLabel,
-        'accounts.customization.first',
-      );
+      expect(FocusManager.instance.primaryFocus?.debugLabel, 'accounts.search');
       await tester.sendKeyEvent(LogicalKeyboardKey.arrowLeft);
       await tester.pump();
       expect(
@@ -295,10 +871,7 @@ void main() {
 
       await tester.sendKeyEvent(LogicalKeyboardKey.arrowRight);
       await tester.pump();
-      expect(
-        FocusManager.instance.primaryFocus?.debugLabel,
-        'accounts.customization.first',
-      );
+      expect(FocusManager.instance.primaryFocus?.debugLabel, 'accounts.search');
       expect(tester.takeException(), isNull);
     },
   );
@@ -425,6 +998,12 @@ void main() {
     expect(
       FocusManager.instance.primaryFocus?.debugLabel,
       'accounts.streaming.auto-pick-audio',
+    );
+    await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
+    await tester.pumpAndSettle();
+    expect(
+      FocusManager.instance.primaryFocus?.debugLabel,
+      'accounts.settings-section.libraries-features',
     );
     await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
     await tester.pumpAndSettle();
@@ -596,8 +1175,16 @@ void main() {
       await tester.pumpAndSettle();
       expect(
         FocusManager.instance.primaryFocus?.debugLabel,
-        'accounts.streaming.offline-downloads',
-        reason: 'Down must stop on the last mounted Services control.',
+        'accounts.settings-section.streaming-privacy',
+        reason:
+            'The last Libraries & features row must continue to the final section header.',
+      );
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
+      await tester.pumpAndSettle();
+      expect(
+        FocusManager.instance.primaryFocus?.debugLabel,
+        'accounts.settings-section.streaming-privacy',
+        reason: 'Down must stop on the final Services section header.',
       );
 
       await tester.tap(find.text('Appearance'));
@@ -683,7 +1270,7 @@ void main() {
     );
   }
 
-  testWidgets('Home shelves remain directly available below the dashboard', (
+  testWidgets('Home shelves start expanded below the dashboard', (
     tester,
   ) async {
     FlutterSecureStorage.setMockInitialValues({});
@@ -698,9 +1285,12 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(
-      find.byKey(const ValueKey('inline-section-toggle-home-shelves')),
-      findsNothing,
-      reason: 'Appearance no longer hides settings in an accordion.',
+      find.byKey(const ValueKey('settings-section-toggle-home-shelves')),
+      findsOneWidget,
+    );
+    expect(
+      find.byKey(const ValueKey('settings-section-content-home-shelves')),
+      findsOneWidget,
     );
     expect(find.text('Home shelves'), findsOneWidget);
     expect(find.text('Continue watching'), findsNWidgets(2));
@@ -839,7 +1429,7 @@ void main() {
     await tester.pumpAndSettle();
   }
 
-  testWidgets('Appearance dashboard is direct and D-pad ordered', (
+  testWidgets('Appearance dashboard starts expanded and is D-pad ordered', (
     tester,
   ) async {
     FlutterSecureStorage.setMockInitialValues({});
@@ -856,10 +1446,10 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.text('Expand all'), findsNothing);
-    expect(find.text('Collapse all'), findsNothing);
+    expect(find.text('Collapse all'), findsOneWidget);
     expect(
-      find.byKey(const ValueKey('customize-toggle-all-sections')),
-      findsNothing,
+      find.byKey(const ValueKey('settings-toggle-all-sections')),
+      findsOneWidget,
     );
     for (final label in const [
       'Theme Studio',
@@ -871,17 +1461,18 @@ void main() {
     ]) {
       expect(find.text(label), findsOneWidget);
     }
-    expect(
-      FocusManager.instance.primaryFocus?.debugLabel,
-      'accounts.customization.first',
-    );
+    expect(FocusManager.instance.primaryFocus?.debugLabel, 'accounts.search');
     for (final expected in const [
+      'accounts.area.appearance',
+      'accounts.settings-section.theme-display',
+      'accounts.customization.first',
       'accounts.title-language',
       'accounts.show-title-style',
+      'accounts.settings-section.home-screen',
       'accounts.customization.home-content.featured',
       'accounts.customization.home-content.poster-metadata',
       'accounts.customization.home-content.continue-watching',
-      'accounts.section.display',
+      'accounts.settings-section.display-options',
     ]) {
       await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
       await tester.pumpAndSettle();
@@ -968,61 +1559,89 @@ void main() {
       greaterThan(tester.getTopLeft(find.text('Theme Studio')).dy),
     );
     expect(find.text('Expand all'), findsNothing);
-    expect(find.text('Collapse all'), findsNothing);
+    expect(find.text('Collapse all'), findsOneWidget);
     expect(tester.takeException(), isNull);
   });
 
-  testWidgets(
-    'Playback exposes direct polished rows without nested accordions',
-    (tester) async {
-      FlutterSecureStorage.setMockInitialValues({});
-      tester.view.physicalSize = const Size(960, 540);
-      tester.view.devicePixelRatio = 1;
-      addTearDown(tester.view.resetPhysicalSize);
-      addTearDown(tester.view.resetDevicePixelRatio);
+  testWidgets('Playback starts expanded with polished collapsible cards', (
+    tester,
+  ) async {
+    FlutterSecureStorage.setMockInitialValues({});
+    tester.view.physicalSize = const Size(960, 540);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
 
-      await tester.pumpWidget(
-        const ProviderScope(
-          child: MaterialApp(home: TvShortcuts(child: AccountsScreen())),
-        ),
-      );
-      await tester.pumpAndSettle();
+    await tester.pumpWidget(
+      const ProviderScope(
+        child: MaterialApp(home: TvShortcuts(child: AccountsScreen())),
+      ),
+    );
+    await tester.pumpAndSettle();
 
-      await tester.tap(find.text('Playback'));
-      await tester.pumpAndSettle();
+    await tester.tap(find.text('Playback'));
+    await tester.pumpAndSettle();
 
-      expect(
-        find.byKey(const ValueKey('inline-section-toggle-closed-captions')),
-        findsNothing,
-      );
-      expect(
-        find.byKey(const ValueKey('inline-section-toggle-player-controls')),
-        findsNothing,
-      );
-      expect(find.text('Text color'), findsOneWidget);
-      expect(find.text('Default player'), findsOneWidget);
+    expect(
+      find.byKey(const ValueKey('inline-section-toggle-closed-captions')),
+      findsNothing,
+    );
+    expect(
+      find.byKey(const ValueKey('inline-section-toggle-player-controls')),
+      findsNothing,
+    );
+    expect(
+      find.byKey(const ValueKey('settings-section-toggle-closed-captions')),
+      findsOneWidget,
+    );
+    expect(
+      find.byKey(const ValueKey('settings-section-toggle-player-controls')),
+      findsOneWidget,
+    );
+    expect(
+      find.byKey(const ValueKey('settings-section-content-closed-captions')),
+      findsOneWidget,
+    );
+    expect(
+      find.byKey(const ValueKey('settings-section-content-player-controls')),
+      findsOneWidget,
+    );
+    expect(find.text('Text color'), findsOneWidget);
+    expect(find.text('Default player'), findsOneWidget);
 
-      final playbackTab = tester.widget<TvFocusable>(
-        find.byKey(const ValueKey('settings-area-playback')),
-      );
-      playbackTab.focusNode!.requestFocus();
-      await tester.pump();
-      await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
-      await tester.pumpAndSettle();
-      expect(
-        FocusManager.instance.primaryFocus?.debugLabel,
-        'accounts.captions.text-color',
-      );
+    final playbackTab = tester.widget<TvFocusable>(
+      find.byKey(const ValueKey('settings-area-playback')),
+    );
+    playbackTab.focusNode!.requestFocus();
+    await tester.pump();
+    await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
+    await tester.pumpAndSettle();
+    expect(
+      FocusManager.instance.primaryFocus?.debugLabel,
+      'accounts.settings-section.closed-captions',
+    );
 
-      await tester.sendKeyEvent(LogicalKeyboardKey.arrowUp);
-      await tester.pumpAndSettle();
-      expect(
-        FocusManager.instance.primaryFocus?.debugLabel,
-        'accounts.area.playback',
-      );
-      expect(tester.takeException(), isNull);
-    },
-  );
+    await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
+    await tester.pumpAndSettle();
+    expect(
+      FocusManager.instance.primaryFocus?.debugLabel,
+      'accounts.captions.text-color',
+    );
+
+    await tester.sendKeyEvent(LogicalKeyboardKey.arrowUp);
+    await tester.pumpAndSettle();
+    expect(
+      FocusManager.instance.primaryFocus?.debugLabel,
+      'accounts.settings-section.closed-captions',
+    );
+    await tester.sendKeyEvent(LogicalKeyboardKey.arrowUp);
+    await tester.pumpAndSettle();
+    expect(
+      FocusManager.instance.primaryFocus?.debugLabel,
+      'accounts.area.playback',
+    );
+    expect(tester.takeException(), isNull);
+  });
 
   testWidgets(
     'advanced Appearance controls remain mounted below the dashboard',
@@ -1150,7 +1769,7 @@ void main() {
     await tester.pumpAndSettle();
     expect(
       FocusManager.instance.primaryFocus?.debugLabel,
-      'accounts.customization.input.click-sounds',
+      'accounts.settings-section.home-shelves',
     );
     await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
     await tester.pumpAndSettle();
@@ -1166,15 +1785,27 @@ void main() {
     }
     expect(
       FocusManager.instance.primaryFocus?.debugLabel,
+      'accounts.settings-section.navigation',
+      reason: 'The final shelf row must continue into the Navigation header.',
+    );
+    await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
+    await tester.pumpAndSettle();
+    expect(
+      FocusManager.instance.primaryFocus?.debugLabel,
       'accounts.customization.navigation-size',
-      reason: 'The final shelf row must continue into the Navigation card.',
     );
     await tester.sendKeyEvent(LogicalKeyboardKey.arrowUp);
     await tester.pumpAndSettle();
     expect(
       FocusManager.instance.primaryFocus?.debugLabel,
-      'accounts.shelf.${HomeShelf.values.last.name}',
-      reason: 'Navigation size must return to the final shelf row on Up.',
+      'accounts.settings-section.navigation',
+    );
+    await tester.sendKeyEvent(LogicalKeyboardKey.arrowUp);
+    await tester.pumpAndSettle();
+    expect(
+      FocusManager.instance.primaryFocus?.debugLabel,
+      'accounts.settings-section.home-shelves',
+      reason: 'Up from a section header must select the previous header.',
     );
     expect(tester.takeException(), isNull);
   });
@@ -1198,6 +1829,7 @@ void main() {
 
     await selectSettingsArea(tester, 'accounts');
     for (final key in [
+      LogicalKeyboardKey.arrowDown,
       LogicalKeyboardKey.arrowDown,
       LogicalKeyboardKey.arrowDown,
       LogicalKeyboardKey.arrowDown,
@@ -1232,6 +1864,9 @@ void main() {
 
     await selectSettingsArea(tester, 'accounts');
     for (final key in [
+      LogicalKeyboardKey.arrowDown,
+      LogicalKeyboardKey.arrowDown,
+      LogicalKeyboardKey.arrowDown,
       LogicalKeyboardKey.arrowDown,
       LogicalKeyboardKey.arrowDown,
       LogicalKeyboardKey.arrowDown,
@@ -1278,8 +1913,16 @@ void main() {
     await tester.pumpAndSettle();
     expect(
       FocusManager.instance.primaryFocus?.debugLabel,
-      'accounts.tracking.dub-notifications',
-      reason: 'Down stops when the Discord action is unavailable and disabled.',
+      'accounts.settings-section.discord-rich-presence',
+      reason:
+          'The last notification row must continue to the final section header.',
+    );
+    await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
+    await tester.pumpAndSettle();
+    expect(
+      FocusManager.instance.primaryFocus?.debugLabel,
+      'accounts.settings-section.discord-rich-presence',
+      reason: 'Down stops when the final section has no available action.',
     );
     expect(tester.takeException(), isNull);
   });
@@ -1360,6 +2003,12 @@ void main() {
     await selectSettingsArea(tester, 'services');
     await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
     await tester.pump();
+    expect(
+      FocusManager.instance.primaryFocus?.debugLabel,
+      'accounts.settings-section.debrid-streaming',
+    );
+    await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
+    await tester.pump();
     expect(find.text('Advanced: personal token'), findsNothing);
     expect(find.text('Connect by QR'), findsOneWidget);
     expect(find.text('Debrid provider'), findsWidgets);
@@ -1390,9 +2039,11 @@ void main() {
 
     await selectSettingsArea(tester, 'system');
     for (final expected in const [
+      'accounts.settings-section.device-support',
       'accounts.system.setup',
       'accounts.system.calibration',
       'accounts.system.diagnostics',
+      'accounts.settings-section.app-updates',
       'accounts.updates.automatic',
     ]) {
       await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
@@ -1416,14 +2067,33 @@ void main() {
     await tester.pumpAndSettle();
     expect(
       FocusManager.instance.primaryFocus?.debugLabel,
-      'accounts.system.diagnostics',
+      'accounts.settings-section.app-updates',
     );
-    await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
+    await tester.sendKeyEvent(LogicalKeyboardKey.arrowUp);
+    await tester.pumpAndSettle();
+    expect(
+      FocusManager.instance.primaryFocus?.debugLabel,
+      'accounts.settings-section.device-support',
+    );
+    for (var index = 0; index < 6; index++) {
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
+      await tester.pumpAndSettle();
+    }
+    expect(
+      FocusManager.instance.primaryFocus?.debugLabel,
+      'accounts.updates.check',
+    );
     await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
     await tester.pumpAndSettle();
     expect(
       FocusManager.instance.primaryFocus?.debugLabel,
-      'accounts.updates.check',
+      'accounts.updates.channel',
+    );
+    await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
+    await tester.pumpAndSettle();
+    expect(
+      FocusManager.instance.primaryFocus?.debugLabel,
+      'accounts.settings-section.community',
     );
     await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
     await tester.pumpAndSettle();
@@ -1453,6 +2123,12 @@ void main() {
     await tester.pumpAndSettle();
     expect(
       FocusManager.instance.primaryFocus?.debugLabel,
+      'accounts.settings-section.storage-reset',
+    );
+    await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
+    await tester.pumpAndSettle();
+    expect(
+      FocusManager.instance.primaryFocus?.debugLabel,
       'accounts.system.clear-cache',
     );
     await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
@@ -1460,6 +2136,12 @@ void main() {
     expect(
       FocusManager.instance.primaryFocus?.debugLabel,
       'accounts.system.reset-app',
+    );
+    await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
+    await tester.pumpAndSettle();
+    expect(
+      FocusManager.instance.primaryFocus?.debugLabel,
+      'accounts.settings-section.about-legal',
     );
     await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
     await tester.pumpAndSettle();
@@ -1613,7 +2295,7 @@ void main() {
       await const FlutterSecureStorage().read(key: 'beta_update_access_key'),
       isNull,
     );
-    for (var index = 0; index < 6; index++) {
+    for (var index = 0; index < 8; index++) {
       await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
       await tester.pumpAndSettle();
     }
@@ -1677,7 +2359,7 @@ void main() {
     expect(donationRect.left, greaterThan(donationQrRect.right));
     expect(donationQrRect.top, greaterThan(discordQrRect.bottom));
 
-    for (var index = 0; index < 6; index++) {
+    for (var index = 0; index < 10; index++) {
       await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
       await tester.pumpAndSettle();
     }
@@ -1965,6 +2647,7 @@ void main() {
     for (final key in [
       LogicalKeyboardKey.arrowDown,
       LogicalKeyboardKey.arrowDown,
+      LogicalKeyboardKey.arrowDown,
     ]) {
       await tester.sendKeyEvent(key);
       await tester.pumpAndSettle();
@@ -1978,22 +2661,38 @@ void main() {
     await tester.pumpAndSettle();
     expect(
       FocusManager.instance.primaryFocus?.debugLabel,
+      'accounts.settings-section.sources-stream-order',
+    );
+    await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
+    await tester.pumpAndSettle();
+    expect(
+      FocusManager.instance.primaryFocus?.debugLabel,
       'accounts.streaming.debrid',
     );
     await tester.sendKeyEvent(LogicalKeyboardKey.arrowUp);
     await tester.pumpAndSettle();
     expect(
       FocusManager.instance.primaryFocus?.debugLabel,
-      'accounts.debrid.connect',
+      'accounts.settings-section.sources-stream-order',
     );
-
-    await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
-    await tester.sendKeyEvent(LogicalKeyboardKey.arrowRight);
     await tester.sendKeyEvent(LogicalKeyboardKey.arrowUp);
     await tester.pumpAndSettle();
     expect(
       FocusManager.instance.primaryFocus?.debugLabel,
-      'accounts.debrid.connect',
+      'accounts.settings-section.debrid-streaming',
+    );
+
+    await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
+    await tester.pumpAndSettle();
+    expect(
+      FocusManager.instance.primaryFocus?.debugLabel,
+      'accounts.debrid.provider',
+    );
+    await tester.sendKeyEvent(LogicalKeyboardKey.arrowUp);
+    await tester.pumpAndSettle();
+    expect(
+      FocusManager.instance.primaryFocus?.debugLabel,
+      'accounts.settings-section.debrid-streaming',
     );
 
     expect(find.byKey(const ValueKey('settings-area-downloads')), findsNothing);
@@ -2050,7 +2749,7 @@ void main() {
     await tester.pumpAndSettle();
     expect(
       FocusManager.instance.primaryFocus?.debugLabel,
-      'accounts.streaming.download-manager',
+      'accounts.settings-section.streaming-privacy',
     );
     expect(tester.takeException(), isNull);
   });
@@ -2330,6 +3029,7 @@ void main() {
       await selectSettingsArea(tester, 'services');
       for (final key in [
         LogicalKeyboardKey.arrowDown,
+        LogicalKeyboardKey.arrowDown,
         LogicalKeyboardKey.enter,
         LogicalKeyboardKey.arrowDown,
         LogicalKeyboardKey.enter,
@@ -2346,7 +3046,7 @@ void main() {
       );
       expect(tester.testTextInput.isVisible, isFalse);
 
-      for (var index = 0; index < 6; index++) {
+      for (var index = 0; index < 7; index++) {
         await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
         await tester.pumpAndSettle();
       }
@@ -2358,6 +3058,14 @@ void main() {
 
       for (var index = 0; index < 6; index++) {
         await tester.sendKeyEvent(LogicalKeyboardKey.arrowUp);
+        await tester.pumpAndSettle();
+      }
+      expect(
+        FocusManager.instance.primaryFocus?.debugLabel,
+        'accounts.settings-section.debrid-streaming',
+      );
+      for (var index = 0; index < 3; index++) {
+        await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
         await tester.pumpAndSettle();
       }
       expect(
@@ -2390,6 +3098,29 @@ class _ConnectedRealDebridController extends RealDebridSettingsController {
   @override
   Future<void> load() async {}
 }
+
+class _SettingsProfileController extends TrackingAccountsController {
+  _SettingsProfileController()
+    : super(
+        _SettingsTrackingRef(),
+        TrackingTokenService(const FlutterSecureStorage()),
+      ) {
+    state = const TrackingAccountsState(
+      usernames: {TrackingProvider.anilist: 'Settings viewer'},
+      profiles: {
+        TrackingProvider.anilist: TrackingAccountProfile(
+          provider: TrackingProvider.anilist,
+          username: 'Settings viewer',
+        ),
+      },
+    );
+  }
+
+  @override
+  Future<void> load() async {}
+}
+
+class _SettingsTrackingRef extends Fake implements Ref {}
 
 class _ClassicSettingsController extends SettingsPreferencesController {
   _ClassicSettingsController() : super(const FlutterSecureStorage()) {

--- a/test/settings_restyle_contract_test.dart
+++ b/test/settings_restyle_contract_test.dart
@@ -100,8 +100,11 @@ void main() {
         );
       }
 
-      expect(find.text('Expand all'), findsNothing);
-      expect(find.text('Collapse all'), findsNothing);
+      expect(
+        find.byKey(const ValueKey('settings-toggle-all-sections')),
+        findsOneWidget,
+      );
+      expect(find.text('Collapse all'), findsOneWidget);
       expect(tester.takeException(), isNull);
     }
   });

--- a/tool/release/native_playback_manifest.json
+++ b/tool/release/native_playback_manifest.json
@@ -376,9 +376,9 @@
       "path": "lib/arm64-v8a/libapp.so",
       "size": 12256144,
       "sha256": "84f8b185da7257cc0666588863105c80efe2aac775efbd13f4a829cb24da78dc",
-      "origin": "TetoTV Flutter application AOT 2.0.51",
+      "origin": "TetoTV Flutter application AOT 2.0.52",
       "license": "MIT",
-      "sourceLocator": "Git tag v2.0.51",
+      "sourceLocator": "Git tag v2.0.52",
       "noticeLocator": "LICENSE"
     },
     {
@@ -423,7 +423,7 @@
       "sha256": "dc05f53278b2733094f12aeaed54c080329309762ce49e6de4118e4bfb0fff55",
       "origin": "TetoTV source build of media-kit Android helper at 42054e5d479f39ccbb0ae604862e2bcaf59b74c2",
       "license": "MIT",
-      "sourceLocator": "TetoTV-v2.0.51-native-playback-sources.zip: sources/media-kit-android-helper-42054e5d479f39ccbb0ae604862e2bcaf59b74c2.zip",
+      "sourceLocator": "TetoTV-v2.0.52-native-playback-sources.zip: sources/media-kit-android-helper-42054e5d479f39ccbb0ae604862e2bcaf59b74c2.zip",
       "noticeLocator": "assets/legal/native/MEDIA_KIT_ANDROID_HELPER_LICENSE.txt; assets/legal/native/NATIVE_PLAYBACK_NOTICE.txt"
     },
     {
@@ -432,7 +432,7 @@
       "sha256": "a7399d0be70844e5ee94cc5b1acc1516571113c50561fe0a5d05b49101c53ef2",
       "origin": "TetoTV source build of the pinned mpv and FFmpeg native playback stack",
       "license": "LGPL-3.0-or-later (conservative combined classification) plus component terms",
-      "sourceLocator": "TetoTV-v2.0.51-native-playback-sources.zip and tool/native/build_native_playback.sh",
+      "sourceLocator": "TetoTV-v2.0.52-native-playback-sources.zip and tool/native/build_native_playback.sh",
       "noticeLocator": "assets/legal/native/NATIVE_PLAYBACK_NOTICE.txt and its referenced exact license assets"
     },
     {
@@ -450,16 +450,16 @@
       "sha256": "263ba714570fb3acfc308cce52776b00506ec8809d225617e52352336144cfa2",
       "origin": "TetoTV source build of the pinned libtorrent4j and libtorrent-rasterbar stack",
       "license": "Mixed MIT, BSD, Boost-1.0, Apache-2.0, and MPL-2.0 component terms",
-      "sourceLocator": "TetoTV-v2.0.51-native-playback-sources.zip and tool/native/build_native_playback.sh",
+      "sourceLocator": "TetoTV-v2.0.52-native-playback-sources.zip and tool/native/build_native_playback.sh",
       "noticeLocator": "assets/legal/native/DIRECT_TORRENT_NATIVE_NOTICE.txt and its referenced exact license assets"
     },
     {
       "path": "lib/armeabi-v7a/libapp.so",
       "size": 13419084,
       "sha256": "acf6a2ea7014231fc7940d6b5f705ff56c14406e0b2dafef352ed384ca152ae2",
-      "origin": "TetoTV Flutter application AOT 2.0.51",
+      "origin": "TetoTV Flutter application AOT 2.0.52",
       "license": "MIT",
-      "sourceLocator": "Git tag v2.0.51",
+      "sourceLocator": "Git tag v2.0.52",
       "noticeLocator": "LICENSE"
     },
     {
@@ -504,7 +504,7 @@
       "sha256": "8820a12e07bb3dc45f5b4286acf6918827fba4c265767e7f1cc8f07215c84b6a",
       "origin": "TetoTV source build of media-kit Android helper at 42054e5d479f39ccbb0ae604862e2bcaf59b74c2",
       "license": "MIT",
-      "sourceLocator": "TetoTV-v2.0.51-native-playback-sources.zip: sources/media-kit-android-helper-42054e5d479f39ccbb0ae604862e2bcaf59b74c2.zip",
+      "sourceLocator": "TetoTV-v2.0.52-native-playback-sources.zip: sources/media-kit-android-helper-42054e5d479f39ccbb0ae604862e2bcaf59b74c2.zip",
       "noticeLocator": "assets/legal/native/MEDIA_KIT_ANDROID_HELPER_LICENSE.txt; assets/legal/native/NATIVE_PLAYBACK_NOTICE.txt"
     },
     {
@@ -513,7 +513,7 @@
       "sha256": "d5a220fdf41edde10f161f86addc846ae9cb18137ea48e4db541cd703fec5092",
       "origin": "TetoTV source build of the pinned mpv and FFmpeg native playback stack",
       "license": "LGPL-3.0-or-later (conservative combined classification) plus component terms",
-      "sourceLocator": "TetoTV-v2.0.51-native-playback-sources.zip and tool/native/build_native_playback.sh",
+      "sourceLocator": "TetoTV-v2.0.52-native-playback-sources.zip and tool/native/build_native_playback.sh",
       "noticeLocator": "assets/legal/native/NATIVE_PLAYBACK_NOTICE.txt and its referenced exact license assets"
     },
     {
@@ -531,7 +531,7 @@
       "sha256": "ba0a19d2730969b8e6107db1847888ea8d3b8cafd14a535a3259dd04f8b28d60",
       "origin": "TetoTV source build of the pinned libtorrent4j and libtorrent-rasterbar stack",
       "license": "Mixed MIT, BSD, Boost-1.0, Apache-2.0, and MPL-2.0 component terms",
-      "sourceLocator": "TetoTV-v2.0.51-native-playback-sources.zip and tool/native/build_native_playback.sh",
+      "sourceLocator": "TetoTV-v2.0.52-native-playback-sources.zip and tool/native/build_native_playback.sh",
       "noticeLocator": "assets/legal/native/DIRECT_TORRENT_NATIVE_NOTICE.txt and its referenced exact license assets"
     }
   ],


### PR DESCRIPTION
Adds a compact TV Settings search that opens the exact matching category and control, per-section collapse controls, and an active-category Expand/Collapse All action beside the profile picker. Preserves the existing phone and tablet Settings layouts and adds D-pad/focus regression coverage.\n\nValidation: full Flutter suite (1,921 passed / 17 skipped), focused Settings suite (50 passed), flutter analyze, Android unit tests, lintRelease, and compileReleaseKotlin.