### PR TITLE
Add persistent Preferred CC playback settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 
 <p align="center">
   <a href="https://github.com/LindersOSX/TetoTV-Beta/releases/latest"><strong>Download Beta</strong></a>
-  · <a href="docs/RELEASE_NOTES_2.0.52.md">What's new</a>
+  · <a href="docs/RELEASE_NOTES_2.0.53.md">What's new</a>
   · <a href="https://github.com/LindersOSX/TetoTV-Beta/issues/new">Report an issue</a>
   · <a href="https://discord.gg/juC6k7d4WY">Discord</a>
   · <a href="https://www.youtube.com/@TetoTVApp">YouTube</a>
@@ -73,7 +73,7 @@ TetoTV runs directly on the Android device with no companion server required for
 | Standalone use | Supported | No PC app or companion server is required for normal browsing and playback. |
 | User-supplied extensions | Optional | No extension or catalog is bundled, recommended, or endorsed. Compatibility depends on the service the user configures. |
 | AniList / MyAnimeList | Optional | Sync lists and progress, or use a local-only profile. |
-| MPV playback | Supported | Used for TetoTV's integrated playback experience. |
+| MPV playback | Supported | Integrated audio/caption selection remembers explicit choices between episodes; Playback settings include Preferred CC Automatic, On, and Off. |
 | Offline downloads | Beta | Individual episodes, whole-season queues, and offline playback. |
 | Debrid services | Optional | Users may connect a supported account for media they are authorized to access. |
 | Direct peer-to-peer playback | Optional beta | Off by default and requires an explicit privacy warning and opt-in. |
@@ -85,10 +85,10 @@ TetoTV runs directly on the Android device with no companion server required for
 | Channel | Version | Best for |
 | --- | --- | --- |
 | Public | Not published | Source and release-readiness documents are available, but no Public APK is currently offered |
-| Beta | [2.0.52](docs/RELEASE_NOTES_2.0.52.md) | Testing searchable, collapsible TV Settings with exact remote navigation while preserving the existing phone and tablet layouts before a separately reviewed Public release |
+| Beta | [2.0.53](docs/RELEASE_NOTES_2.0.53.md) | Testing persistent caption choices and a Preferred CC playback setting across episode changes, source fallback, and private-library playback |
 
 > [!WARNING]
-> Beta 2.0.52 uses the repository's explicit unreviewed-Beta exception. Its native-library and corresponding-source material did not receive independent license review, and automated integrity checks are not a legal compliance determination. Read the [complete Beta disclosure](docs/RELEASE_NOTES_2.0.52.md). This exception does not apply to a future Public release.
+> Beta 2.0.53 uses the repository's explicit unreviewed-Beta exception. Its native-library and corresponding-source material did not receive independent license review, and automated integrity checks are not a legal compliance determination. Read the [complete Beta disclosure](docs/RELEASE_NOTES_2.0.53.md). This exception does not apply to a future Public release.
 
 The Public updater repository intentionally has no release while the Public build is held for review. Existing Beta installations continue to update from the Beta repository. Android never permits an in-place install of an APK with a lower build code; Developer Mode does not bypass that platform rule.
 

--- a/docs/BUILD_WINDOWS.md
+++ b/docs/BUILD_WINDOWS.md
@@ -220,39 +220,39 @@ APK containing both supported application ABIs.
 Public and Beta updates use anonymous GitHub requests. No Beta key, GitHub
 token, update-proxy URL, or update-specific Dart define is required. Every
 published APK uses the production signing identity. No Public APK is currently
-published. Beta 2.0.52 uses Android build code `410029`. Flutter reuses
+published. Beta 2.0.53 uses Android build code `410030`. Flutter reuses
 `app-release.apk`, so copy and rename the Beta artifact immediately after the
 build:
 
 ```powershell
-New-Item -ItemType Directory -Force .\build\fire-tv\v2.0.52 | Out-Null
+New-Item -ItemType Directory -Force .\build\fire-tv\v2.0.53 | Out-Null
 
-# Beta 2.0.52
+# Beta 2.0.53
 flutter build apk --release --target-platform android-arm,android-arm64 `
-  --build-name 2.0.52 --build-number 410029 --no-tree-shake-icons
+  --build-name 2.0.53 --build-number 410030 --no-tree-shake-icons
 Copy-Item .\build\app\outputs\flutter-apk\app-release.apk `
-  .\build\fire-tv\v2.0.52\TetoTV-v2.0.52-universal.apk
+  .\build\fire-tv\v2.0.53\TetoTV-v2.0.53-universal.apk
 
 .\tool\release\verify_release_apk.ps1 `
   -Channel Beta `
-  -ApkPath .\build\fire-tv\v2.0.52\TetoTV-v2.0.52-universal.apk
+  -ApkPath .\build\fire-tv\v2.0.53\TetoTV-v2.0.53-universal.apk
 
 .\tool\release\verify_native_redistribution.ps1 `
   -RequireResolvedBinaries `
   -ResolvedBinaryDirectory .\build\native-playback\outputs `
-  -StageBundle -ReleaseTag v2.0.52
+  -StageBundle -ReleaseTag v2.0.53
 
 .\tool\release\new_release_checksums.ps1 `
-  -ApkPath .\build\fire-tv\v2.0.52\TetoTV-v2.0.52-universal.apk `
-  -NativeSourcePath .\build\release-compliance\v2.0.52\TetoTV-v2.0.52-native-playback-sources.zip `
-  -OutputPath .\build\fire-tv\v2.0.52\SHA256SUMS
+  -ApkPath .\build\fire-tv\v2.0.53\TetoTV-v2.0.53-universal.apk `
+  -NativeSourcePath .\build\release-compliance\v2.0.53\TetoTV-v2.0.53-native-playback-sources.zip `
+  -OutputPath .\build\fire-tv\v2.0.53\SHA256SUMS
 
 .\tool\release\verify_release_payloads.ps1 `
   -Channel Beta `
-  -ApkPath .\build\fire-tv\v2.0.52\TetoTV-v2.0.52-universal.apk `
-  -NativeSourcePath .\build\release-compliance\v2.0.52\TetoTV-v2.0.52-native-playback-sources.zip `
-  -ChecksumsPath .\build\fire-tv\v2.0.52\SHA256SUMS `
-  -ReleaseNotesPath .\docs\RELEASE_NOTES_2.0.52.md
+  -ApkPath .\build\fire-tv\v2.0.53\TetoTV-v2.0.53-universal.apk `
+  -NativeSourcePath .\build\release-compliance\v2.0.53\TetoTV-v2.0.53-native-playback-sources.zip `
+  -ChecksumsPath .\build\fire-tv\v2.0.53\SHA256SUMS `
+  -ReleaseNotesPath .\docs\RELEASE_NOTES_2.0.53.md
 ```
 
 The final payload check requires all five exact, source-built native JARs

--- a/docs/RELEASE_NOTES_2.0.53.md
+++ b/docs/RELEASE_NOTES_2.0.53.md
@@ -1,0 +1,33 @@
+# TetoTV 2.0.53 Beta
+
+> [!WARNING]
+> No independent native-license review: This Beta has not received independent native-library licensing review. Automated checks verify the APK, native-source bundle, notices, pinned inputs, and checksums, but do not establish legal compliance or reproducible builds.
+
+This Beta makes caption behavior predictable between episodes and gives viewers a clear default under Settings > Playback.
+
+## What's changed
+
+- Playback Settings now includes `Preferred CC` with `Automatic`, `On`, and `Off` choices on TVs, tablets, and phones.
+- A manual caption choice is remembered between episodes. TetoTV preserves the selected caption language and explicit On/Off intent instead of replacing it with a transient player default.
+- Private Plex, Jellyfin, and other unlinked-library playback remembers manual caption choices through the global Preferred CC setting even when no AniList series ID is available.
+- Source fallback, manual source changes, validated redirects, and prepared next episodes now carry caption intent and external-subtitle language metadata consistently.
+- Provider sidecars only override a remembered language when their reported language matches. Automatic mode can still accept the resolver's best available sidecar.
+- Media-open and subtitle-registration work is revision-bound so delayed events from the previous episode cannot select an old track or attach an old sidecar to the new stream.
+- Existing v2.0.52 playback rows safely discard transient caption state that was previously mistaken for an explicit viewer choice.
+- Searchable, collapsible TV Settings and the existing phone/tablet Settings layout remain unchanged apart from the new Preferred CC row under Playback.
+- Existing privacy, update, source-safety, and three-asset release requirements remain unchanged.
+- AI-assisted development disclosure: AI tools assisted with implementation, design iteration, documentation, tests, and review. The project owner directed the work, validated the changes, and remains responsible for this release.
+
+## Release assets
+
+- `TetoTV-v2.0.53-universal.apk`
+- `TetoTV-v2.0.53-native-playback-sources.zip`
+- `SHA256SUMS`
+
+## Beta notes
+
+- This is a Beta-channel build with Android build code `410030`.
+- No Public APK is being published with this release.
+- Android does not permit an in-place install over an APK with a higher build code. A future Public counterpart must use build code `410030` or newer for data-preserving channel switching.
+
+<!-- tetotv-android-version-code: 410030 -->

--- a/docs/UPDATE_CHANNELS.md
+++ b/docs/UPDATE_CHANNELS.md
@@ -35,11 +35,11 @@ Beta reads completed 2.x releases from:
 https://api.github.com/repos/LindersOSX/TetoTV-Beta/releases/latest
 ```
 
-The current Beta source build is `v2.0.52` with Android build code `410029`.
+The current Beta source build is `v2.0.53` with Android build code `410030`.
 Its release title is:
 
 ```text
-TetoTV 2.0.52 Beta - Android TV / Google TV / Fire TV
+TetoTV 2.0.53 Beta - Android TV / Google TV / Fire TV
 ```
 
 Publish it as a normal, non-draft, non-prerelease GitHub release so
@@ -72,7 +72,7 @@ proxy.
 Release notes must include the exact asset names and this build-code marker:
 
 ```html
-<!-- tetotv-android-version-code: 410029 -->
+<!-- tetotv-android-version-code: 410030 -->
 ```
 
 When build-code metadata is present, the updater rejects a known lower build
@@ -94,10 +94,10 @@ These rules apply equally on phones, Android TV, Google TV, and Fire TV.
 
 ## Switching and rollback
 
-The current Beta uses build code `410029`. No Public counterpart is available.
+The current Beta uses build code `410030`. No Public counterpart is available.
 An older Public install can move to this Beta when Android accepts the higher
 build code, but it cannot move back in place until a future Public build uses
-code `410029` or higher. Uninstalling first permits an older APK but deletes
+code `410030` or higher. Uninstalling first permits an older APK but deletes
 local application data. Developer Mode and in-app settings cannot override
 this Android rule.
 

--- a/lib/core/storage/tetotv_database.dart
+++ b/lib/core/storage/tetotv_database.dart
@@ -195,6 +195,10 @@ class SeriesPlaybackPreferences {
     'subtitleLanguage': subtitleLanguage,
     'subtitleEnabled': subtitleEnabled,
     'subtitlePreferenceSet': subtitlePreferenceSet,
+    // v2.0.52 could persist subtitlePreferenceSet from transient player state.
+    // This independent marker proves that the value came from the corrected
+    // explicit-intent serializer instead of that legacy behavior.
+    'subtitlePreferenceExplicit': subtitlePreferenceSet,
     'subtitleSize': subtitleSize,
     'subtitlePosition': subtitlePosition,
     'subtitleDelayMs': subtitleDelayMs,
@@ -214,32 +218,43 @@ class SeriesPlaybackPreferences {
     'preferredReleaseGroup': preferredReleaseGroup,
   };
 
-  factory SeriesPlaybackPreferences.fromJson(Map<String, dynamic> json) =>
-      SeriesPlaybackPreferences(
-        audioLanguage: json['audioLanguage'] as String? ?? 'eng',
-        audioPreferenceSet: json['audioPreferenceSet'] as bool? ?? false,
-        subtitleLanguage: json['subtitleLanguage'] as String? ?? 'eng',
-        subtitleEnabled: json['subtitleEnabled'] as bool? ?? true,
-        subtitlePreferenceSet: json['subtitlePreferenceSet'] as bool? ?? false,
-        subtitleSize: (json['subtitleSize'] as num?)?.toDouble() ?? 34,
-        subtitlePosition: json['subtitlePosition'] as int? ?? 100,
-        subtitleDelayMs: json['subtitleDelayMs'] as int? ?? 0,
-        audioDelayMs: json['audioDelayMs'] as int? ?? 0,
-        decoder: json['decoder'] as String? ?? 'hardware-safe',
-        videoFit: json['videoFit'] as String? ?? 'contain',
-        highContrastSubtitles: json['highContrastSubtitles'] as bool? ?? false,
-        autoplayNextEpisode: json['autoplayNextEpisode'] as bool? ?? true,
-        skipFillerEpisodes: json['skipFillerEpisodes'] as bool? ?? false,
-        preferredStreamLanguage:
-            json['preferredStreamLanguage'] as String? ?? 'dub',
-        preferredQuality: json['preferredQuality'] as String? ?? 'any',
-        preferredCodec: json['preferredCodec'] as String? ?? 'any',
-        preferredHdrMode: json['preferredHdrMode'] as String? ?? 'any',
-        allowBatchStreams: json['allowBatchStreams'] as bool? ?? true,
-        streamSortMode: json['streamSortMode'] as String? ?? 'compatibility',
-        preferredReleaseProvider: json['preferredReleaseProvider'] as String?,
-        preferredReleaseGroup: json['preferredReleaseGroup'] as String?,
-      );
+  factory SeriesPlaybackPreferences.fromJson(Map<String, dynamic> json) {
+    final hasExplicitSubtitlePreference =
+        json['subtitlePreferenceExplicit'] == true &&
+        json['subtitlePreferenceSet'] == true;
+    return SeriesPlaybackPreferences(
+      audioLanguage: json['audioLanguage'] as String? ?? 'eng',
+      audioPreferenceSet: json['audioPreferenceSet'] as bool? ?? false,
+      subtitleLanguage: hasExplicitSubtitlePreference
+          ? json['subtitleLanguage'] as String? ?? 'eng'
+          : 'eng',
+      subtitleEnabled: hasExplicitSubtitlePreference
+          ? json['subtitleEnabled'] as bool? ?? true
+          : true,
+      // Rows written before the explicit marker existed must not override
+      // the global Preferred CC default. New manual choices serialize both
+      // fields, so their On/Off/language intent remains authoritative.
+      subtitlePreferenceSet: hasExplicitSubtitlePreference,
+      subtitleSize: (json['subtitleSize'] as num?)?.toDouble() ?? 34,
+      subtitlePosition: json['subtitlePosition'] as int? ?? 100,
+      subtitleDelayMs: json['subtitleDelayMs'] as int? ?? 0,
+      audioDelayMs: json['audioDelayMs'] as int? ?? 0,
+      decoder: json['decoder'] as String? ?? 'hardware-safe',
+      videoFit: json['videoFit'] as String? ?? 'contain',
+      highContrastSubtitles: json['highContrastSubtitles'] as bool? ?? false,
+      autoplayNextEpisode: json['autoplayNextEpisode'] as bool? ?? true,
+      skipFillerEpisodes: json['skipFillerEpisodes'] as bool? ?? false,
+      preferredStreamLanguage:
+          json['preferredStreamLanguage'] as String? ?? 'dub',
+      preferredQuality: json['preferredQuality'] as String? ?? 'any',
+      preferredCodec: json['preferredCodec'] as String? ?? 'any',
+      preferredHdrMode: json['preferredHdrMode'] as String? ?? 'any',
+      allowBatchStreams: json['allowBatchStreams'] as bool? ?? true,
+      streamSortMode: json['streamSortMode'] as String? ?? 'compatibility',
+      preferredReleaseProvider: json['preferredReleaseProvider'] as String?,
+      preferredReleaseGroup: json['preferredReleaseGroup'] as String?,
+    );
+  }
 }
 
 class ProviderHealth {

--- a/lib/features/local_media/presentation/local_media_screen.dart
+++ b/lib/features/local_media/presentation/local_media_screen.dart
@@ -486,10 +486,17 @@ class _LocalMediaScreenState extends ConsumerState<LocalMediaScreen> {
   Future<void> _playJellyfin(JellyfinMediaItem item) async {
     final controller = ref.read(localMediaControllerProvider.notifier);
     final playSessionId = controller.createPlaybackSessionId();
-    final requestedAudio = ref.read(settingsPreferencesProvider).preferredAudio;
+    final settings = ref.read(settingsPreferencesProvider);
+    final requestedAudio = settings.preferredAudio;
     final plan = controller.playbackPlan(
       item,
       playSessionId: playSessionId,
+      preferredSubtitleLanguage: preferredCaptionLanguageForPreparation(
+        seriesLanguage: 'eng',
+        seriesPreferenceSet: false,
+        globalMode: settings.preferredCaptionMode,
+        globalLanguage: settings.preferredCaptionLanguage,
+      ),
       requestedAudio: requestedAudio,
     );
     await _openPlayer(

--- a/lib/features/player/presentation/player_failover_coordinator.dart
+++ b/lib/features/player/presentation/player_failover_coordinator.dart
@@ -18,6 +18,16 @@ class PlayerHandoffGate {
 
 enum PlayerFailoverClass { directWeb, debrid }
 
+/// An automatic recovery attempt may only continue while the source the
+/// attempt started for is still authoritative. A manual source selection
+/// temporarily owns that decision while it validates and opens its choice.
+bool playerFailoverGenerationIsActive({
+  required int expectedGeneration,
+  required int activeGeneration,
+  required bool manualSourceSelectionInProgress,
+}) =>
+    !manualSourceSelectionInProgress && expectedGeneration == activeGeneration;
+
 List<PlayerFailoverClass> playerFailoverClassOrder({
   required bool currentIsWeb,
 }) => currentIsWeb

--- a/lib/features/player/presentation/player_stream_source_picker.dart
+++ b/lib/features/player/presentation/player_stream_source_picker.dart
@@ -32,6 +32,7 @@ PlaybackStreamOption playbackOptionForWebStream(WebStreamResult result) {
       displayName: release.releaseName,
       headers: result.headers,
       externalSubtitle: result.subtitleUri,
+      externalSubtitleLanguage: result.subtitleLanguage,
       providerId: result.providerId,
       providerName: '${result.providerName} web stream',
       providerEpisodeIdentity: ProviderEpisodeIdentity.fromFields(

--- a/lib/features/player/presentation/tv_player_screen.dart
+++ b/lib/features/player/presentation/tv_player_screen.dart
@@ -81,6 +81,40 @@ const _playerMutationReleaseTimeout = Duration(seconds: 5);
 
 enum PlaybackDecoderMode { hardwareSafe, hardwareDirect, software }
 
+/// Decides whether a sidecar registered by a provider or private library may
+/// remain selected after the viewer's saved caption intent is reapplied.
+///
+/// Automatic mode may accept the resolver's best available sidecar. A manual
+/// global On choice and every explicit per-series choice must match the saved
+/// language so an unrelated provider default cannot replace it next episode.
+bool shouldKeepRegisteredExternalCaption({
+  required bool subtitlesEnabled,
+  required bool hasPerSeriesPreference,
+  required PreferredCaptionMode globalMode,
+  required String? externalLanguage,
+  required String requestedLanguage,
+}) {
+  if (!subtitlesEnabled) return false;
+  final languageMatches =
+      externalLanguage != null && externalLanguage == requestedLanguage;
+  if (hasPerSeriesPreference || globalMode == PreferredCaptionMode.enabled) {
+    return languageMatches;
+  }
+  return globalMode == PreferredCaptionMode.automatic;
+}
+
+/// Whether an asynchronous media-open attempt still owns the player state it
+/// was started for. A newer open or a source replacement must make the older
+/// attempt ineligible to publish success or transfer stream ownership.
+bool playerMediaOpenCanCommit({
+  required int expectedRevision,
+  required int activeRevision,
+  required Object expectedStream,
+  required Object activeStream,
+}) =>
+    expectedRevision == activeRevision &&
+    identical(expectedStream, activeStream);
+
 String _mpvColor(Color color) =>
     '#${color.toARGB32().toRadixString(16).padLeft(8, '0').toUpperCase()}';
 
@@ -575,8 +609,7 @@ class _TvPlayerScreenRouterState extends ConsumerState<TvPlayerScreen> {
       watchPartyPlayback: _watchPartyPlayback,
       libraryPlayback: widget.libraryPlayback,
       onLibraryEpisodeHandoff: widget.onLibraryEpisodeHandoff,
-      subtitle:
-          _activeLaunch.stream.externalSubtitle?.toString() ?? widget.subtitle,
+      subtitle: _activeLaunch.stream.externalSubtitle?.toString(),
       anilistMediaId: _anilistMediaId,
       malMediaId: _malMediaId,
       episode: _episodeNumber,
@@ -721,6 +754,8 @@ class _MpvTvPlayerScreenState extends ConsumerState<MpvTvPlayerScreen> {
   final Set<String> _failedDirectStreamKeys = {};
   final Set<ReleaseCandidate> _attemptedReleaseAlternatives = {};
   bool _failingOver = false;
+  bool _manualSourceSelectionInProgress = false;
+  int _sourceSelectionGeneration = 0;
   bool _prewarming = false;
   bool _prewarmed = false;
   final NextEpisodePrewarmRetryPolicy _prewarmRetry =
@@ -769,6 +804,7 @@ class _MpvTvPlayerScreenState extends ConsumerState<MpvTvPlayerScreen> {
   Duration? _pendingHandoffPosition;
   final PlayerReleaseCoordinator _handoffRelease = PlayerReleaseCoordinator();
   final Set<Future<void>> _playerMutationOperations = <Future<void>>{};
+  Future<void> _mediaOpenQueue = Future<void>.value();
   Duration? _pendingInheritedResume;
   bool _lastResumeSeekSucceeded = true;
   Duration _lastPlayablePosition = Duration.zero;
@@ -1080,9 +1116,7 @@ class _MpvTvPlayerScreenState extends ConsumerState<MpvTvPlayerScreen> {
         _decoderMode = PlaybackDecoderMode.software;
         _softwareFallbackUsed = true;
       }
-      if (!_seriesPreferences.subtitlePreferenceSet) {
-        _applyAutomaticSubtitleDefaultForRelease(_currentRelease);
-      }
+      _applyCaptionDefaultForRelease(_currentRelease);
       _watchPartyPlayback.updateRequestedAudio(_effectiveAudioPreference);
       if (!mounted || _engineHandoffInProgress) return;
       if (await _openConfiguredDefaultPlayer(appearance, resume: resume)) {
@@ -1097,11 +1131,12 @@ class _MpvTvPlayerScreenState extends ConsumerState<MpvTvPlayerScreen> {
         reasonCode: _softwareFallbackUsed ? 'codec_compatibility' : null,
       );
       try {
-        await _openMedia(
+        final opened = await _openMedia(
           resume: resume,
           propagateFailure: true,
           requireDecodedVideo: _animeFeaturesEnabled,
         );
+        if (!opened) return;
       } catch (error) {
         if (!mounted || _engineHandoffInProgress) return;
         await _tryNextStream(error.toString());
@@ -1281,7 +1316,6 @@ class _MpvTvPlayerScreenState extends ConsumerState<MpvTvPlayerScreen> {
       _reportLibraryPlayback();
       _publishWatchPartyPlayback();
     });
-    _tracksSubscription = _player.stream.tracks.listen(_onTracksChanged);
     _errorSubscription = _player.stream.error.listen((message) {
       // Reopening MPV can briefly replay the error which caused the reopen.
       // The in-flight mutation owns that result; starting source failover at
@@ -1382,13 +1416,29 @@ class _MpvTvPlayerScreenState extends ConsumerState<MpvTvPlayerScreen> {
   bool get _canApplyTrackSelection =>
       mounted && !_engineHandoffInProgress && !_playerReleasedForHandoff;
 
-  void _onTracksChanged(Tracks tracks) {
-    unawaited(_runTrackedTrackSelection(tracks));
+  void _onTracksChanged(int mediaRevision) {
+    unawaited(_runTrackedTrackSelection(mediaRevision));
   }
 
-  Future<void> _runTrackedTrackSelection(Tracks tracks) async {
+  Future<void> _runTrackedTrackSelection(int mediaRevision) async {
     try {
-      await _trackPlayerMutation(() => _selectPreferredTracks(tracks));
+      await _trackPlayerMutation(
+        () => _serializeMediaOpen(() async {
+          // A tracks event may have been queued before the previous media was
+          // replaced. Never trust its payload: the settled player snapshot is
+          // the only list that can belong to the active media revision. The
+          // shared media queue also prevents a checked track command from
+          // landing on media opened while that command was in flight.
+          await Future<void>.delayed(Duration.zero);
+          if (mediaRevision != _mediaOpenRevision || _mediaOpenInProgress) {
+            return;
+          }
+          await _selectPreferredTracks(
+            _player.state.tracks,
+            expectedMediaRevision: mediaRevision,
+          );
+        }),
+      );
     } catch (error, stackTrace) {
       if (_canApplyTrackSelection) {
         debugPrint('MPV track selection failed: $error\n$stackTrace');
@@ -1396,13 +1446,17 @@ class _MpvTvPlayerScreenState extends ConsumerState<MpvTvPlayerScreen> {
     }
   }
 
-  Future<void> _applyPreferredAudio(Tracks tracks) async {
+  Future<void> _applyPreferredAudio(
+    Tracks tracks, {
+    int? expectedMediaRevision,
+  }) async {
+    final mediaRevision = expectedMediaRevision ?? _mediaOpenRevision;
     if (_preferredAudioSelected ||
         _mediaOpenInProgress ||
+        mediaRevision != _mediaOpenRevision ||
         !_canApplyTrackSelection) {
       return;
     }
-    final mediaRevision = _mediaOpenRevision;
     final device = await AndroidTvBridge.instance.getDeviceProfile();
     // Device-profile lookup crosses the platform channel. The player route can
     // begin an engine handoff while it is pending, so never resume against a
@@ -1458,11 +1512,26 @@ class _MpvTvPlayerScreenState extends ConsumerState<MpvTvPlayerScreen> {
     );
   }
 
-  Future<void> _selectPreferredTracks(Tracks tracks) async {
-    await _applyPreferredAudio(tracks);
-    if (!_canApplyTrackSelection ||
-        _preferredSubtitleSelected ||
-        !_seriesPreferences.subtitleEnabled) {
+  Future<void> _applyPreferredSubtitle(
+    Tracks tracks, {
+    int? expectedMediaRevision,
+  }) async {
+    final mediaRevision = expectedMediaRevision ?? _mediaOpenRevision;
+    if (_preferredSubtitleSelected ||
+        _mediaOpenInProgress ||
+        mediaRevision != _mediaOpenRevision ||
+        !_canApplyTrackSelection) {
+      return;
+    }
+    if (!_seriesPreferences.subtitleEnabled) {
+      if (mediaRevision != _mediaOpenRevision || _mediaOpenInProgress) return;
+      await _player.setSubtitleTrack(SubtitleTrack.no());
+      if (mediaRevision != _mediaOpenRevision ||
+          _mediaOpenInProgress ||
+          !_canApplyTrackSelection) {
+        return;
+      }
+      _preferredSubtitleSelected = true;
       return;
     }
     final language = _seriesPreferences.subtitleLanguage.toLowerCase();
@@ -1497,12 +1566,39 @@ class _MpvTvPlayerScreenState extends ConsumerState<MpvTvPlayerScreen> {
                 ),
           );
     final preferred = matches.firstOrNull;
-    if (preferred == null || !_canApplyTrackSelection) return;
-    await _player.setSubtitleTrack(preferred);
+    if (preferred == null) {
+      // A container default in another language is not the viewer's saved
+      // caption choice. Disable it for this episode, but deliberately leave
+      // selection retryable so a matching track published later can recover.
+      if (_player.state.track.subtitle.id == 'no' || !_canApplyTrackSelection) {
+        return;
+      }
+      if (mediaRevision != _mediaOpenRevision || _mediaOpenInProgress) return;
+      await _player.setSubtitleTrack(SubtitleTrack.no());
+      return;
+    }
     if (!_canApplyTrackSelection) return;
+    if (mediaRevision != _mediaOpenRevision || _mediaOpenInProgress) return;
+    await _player.setSubtitleTrack(preferred);
+    if (mediaRevision != _mediaOpenRevision ||
+        _mediaOpenInProgress ||
+        !_canApplyTrackSelection) {
+      return;
+    }
     // Keep this retryable if libmpv rejected the command while its demuxer was
     // still publishing tracks.
     _preferredSubtitleSelected = true;
+  }
+
+  Future<void> _selectPreferredTracks(
+    Tracks tracks, {
+    int? expectedMediaRevision,
+  }) async {
+    final mediaRevision = expectedMediaRevision ?? _mediaOpenRevision;
+    if (mediaRevision != _mediaOpenRevision || _mediaOpenInProgress) return;
+    await _applyPreferredAudio(tracks, expectedMediaRevision: mediaRevision);
+    if (mediaRevision != _mediaOpenRevision || _mediaOpenInProgress) return;
+    await _applyPreferredSubtitle(tracks, expectedMediaRevision: mediaRevision);
   }
 
   void _applyAutomaticSubtitleDefaultForRelease(ReleaseCandidate release) {
@@ -1513,6 +1609,24 @@ class _MpvTvPlayerScreenState extends ConsumerState<MpvTvPlayerScreen> {
         _effectiveAudioPreference,
       ),
     );
+  }
+
+  void _applyCaptionDefaultForRelease(ReleaseCandidate release) {
+    if (_seriesPreferences.subtitlePreferenceSet) return;
+    final preferences = ref.read(settingsPreferencesProvider);
+    switch (preferences.preferredCaptionMode) {
+      case PreferredCaptionMode.automatic:
+        _applyAutomaticSubtitleDefaultForRelease(release);
+      case PreferredCaptionMode.enabled:
+        _seriesPreferences = _seriesPreferences.copyWith(
+          subtitleLanguage: preferences.preferredCaptionLanguage,
+          subtitleEnabled: true,
+        );
+      case PreferredCaptionMode.disabled:
+        _seriesPreferences = _seriesPreferences.copyWith(
+          subtitleEnabled: false,
+        );
+    }
   }
 
   void _onPosition(Duration position) {
@@ -2600,115 +2714,194 @@ class _MpvTvPlayerScreenState extends ConsumerState<MpvTvPlayerScreen> {
     } catch (_) {}
   }
 
-  Future<void> _openCurrentMedia({required bool play}) async {
+  Future<int?> _openCurrentMedia({
+    required bool play,
+    required StreamReady expectedStream,
+    required String expectedSource,
+    required Map<String, String> expectedHeaders,
+  }) async {
     final revision = ++_mediaOpenRevision;
     _mediaOpenInProgress = true;
     _preferredAudioSelected = false;
+    _preferredSubtitleSelected = false;
+    await _tracksSubscription?.cancel();
+    _tracksSubscription = null;
+    if (!playerMediaOpenCanCommit(
+          expectedRevision: revision,
+          activeRevision: _mediaOpenRevision,
+          expectedStream: expectedStream,
+          activeStream: _currentStream,
+        ) ||
+        !_canApplyTrackSelection) {
+      if (revision == _mediaOpenRevision) _mediaOpenInProgress = false;
+      return null;
+    }
     try {
-      await _player.open(Media(_source, httpHeaders: _httpHeaders), play: play);
+      await _player.open(
+        Media(expectedSource, httpHeaders: expectedHeaders),
+        play: play,
+      );
     } finally {
       if (revision == _mediaOpenRevision) {
         _mediaOpenInProgress = false;
       }
     }
-    if (revision != _mediaOpenRevision || !_canApplyTrackSelection) return;
+    if (!playerMediaOpenCanCommit(
+          expectedRevision: revision,
+          activeRevision: _mediaOpenRevision,
+          expectedStream: expectedStream,
+          activeStream: _currentStream,
+        ) ||
+        !_canApplyTrackSelection) {
+      return null;
+    }
+    _tracksSubscription = _player.stream.tracks.listen(
+      (_) => _onTracksChanged(revision),
+    );
     try {
       // Track events can arrive before Player.open completes. Re-read the
       // settled snapshot here so an early selection cannot be overwritten by
       // MPV finishing the open with the container's default track.
-      await _applyPreferredAudio(_player.state.tracks);
+      await _selectPreferredTracks(_player.state.tracks);
     } catch (error, stackTrace) {
       if (_canApplyTrackSelection) {
-        debugPrint('MPV startup audio selection failed: $error\n$stackTrace');
+        debugPrint('MPV startup track selection failed: $error\n$stackTrace');
       }
     }
+    return revision;
   }
 
-  Future<void> _openMedia({
+  Future<bool> _openMedia({
     Duration? resume,
     bool propagateFailure = false,
     bool requireDecodedVideo = false,
-  }) => _trackPlayerMutation(() async {
-    _mediaOpenVerifications++;
-    _completionHandled = false;
-    _libraryCompletionThresholdHandled = false;
-    _resetCompletionObservation(resume ?? Duration.zero);
-    final diagnosticOpenAttempt = ++_diagnosticStreamOpenAttempt;
-    final persistenceWasReady = _playbackPersistenceReady;
-    if (resume != null) _playbackPersistenceReady = false;
-    // Watchdogs from the previous candidate must not inspect or mutate a
-    // newly opening source. Verified opens restart fresh watchdogs below.
-    _videoWatchdog?.cancel();
-    _performanceWatchdog?.cancel();
-    if (requireDecodedVideo) {
-      // A retry can reuse this screen after the previous media already
-      // rendered. Only a frame from this open attempt may satisfy readiness.
-      _videoFrameSeen = false;
-    }
-    try {
-      await _configureNativePlayback();
-      await _openCurrentMedia(play: true);
-      await _applySubtitle();
-      if (resume != null) {
-        _lastResumeSeekSucceeded = await _restoreResumePosition(resume);
-      }
-      if (!mounted || _engineHandoffInProgress) return;
-      if (requireDecodedVideo) {
-        final readinessRevision = _mediaOpenRevision;
-        final mediaReady = await waitForPlayerMediaReadiness(
-          hasDecodedVideo: () =>
-              _videoFrameSeen && _mediaOpenRevision == readinessRevision,
-          isActive: () =>
-              mounted &&
+  }) async {
+    var opened = false;
+    final expectedStream = _currentStream;
+    final expectedSource = _source;
+    final expectedHeaders = Map<String, String>.of(_httpHeaders);
+    await _trackPlayerMutation(
+      () => _serializeMediaOpen(() async {
+        int? mediaRevision;
+
+        bool attemptIsActive() {
+          final revision = mediaRevision;
+          return mounted &&
               !_engineHandoffInProgress &&
-              _mediaOpenRevision == readinessRevision,
-          maxPolls: playerMediaReadinessMaxPolls(
-            isWebStream: _currentStream.isWebStream,
-            mediaContentType: _currentStream.mediaContentType,
-          ),
-        );
-        if (!mediaReady) {
-          // Route disposal and an intentional player handoff are cancellation,
-          // not evidence that the candidate itself failed. A competing media
-          // revision remains a real rejected attempt and must not be adopted.
-          if (!mounted || _engineHandoffInProgress) return;
-          throw const PlayerMediaReadinessException();
+              !_playerReleasedForHandoff &&
+              identical(expectedStream, _currentStream) &&
+              (revision == null ||
+                  playerMediaOpenCanCommit(
+                    expectedRevision: revision,
+                    activeRevision: _mediaOpenRevision,
+                    expectedStream: expectedStream,
+                    activeStream: _currentStream,
+                  ));
         }
-      }
-      _recordDiagnosticStreamOpenResult(
-        attempt: diagnosticOpenAttempt,
-        succeeded: true,
-      );
-      _startVideoWatchdog();
-      _startPerformanceWatchdog();
-    } catch (error, stackTrace) {
-      final reasonCode = playbackDiagnosticFailureReasonCode(error);
-      _recordDiagnosticStreamOpenResult(
-        attempt: diagnosticOpenAttempt,
-        succeeded: false,
-        reasonCode: reasonCode,
-      );
-      if (_handleLibraryStartupFailure(error)) return;
-      if (propagateFailure) rethrow;
-      _recordDiagnosticOutcome(
-        PlaybackDiagnosticOutcome.failed,
-        reasonCode: reasonCode,
-      );
-      if (mounted && !_engineHandoffInProgress) {
-        unawaited(
-          recordAnonymousHandledError(
-            area: AnonymousErrorArea.playback,
-            error: error,
-            stack: stackTrace,
-          ),
-        );
-        setState(() => _playbackError = error.toString());
-      }
-    } finally {
-      if (persistenceWasReady) _playbackPersistenceReady = true;
-      _mediaOpenVerifications--;
-    }
-  });
+
+        if (!attemptIsActive()) return;
+
+        _mediaOpenVerifications++;
+        _completionHandled = false;
+        _libraryCompletionThresholdHandled = false;
+        _resetCompletionObservation(resume ?? Duration.zero);
+        final diagnosticOpenAttempt = ++_diagnosticStreamOpenAttempt;
+        final persistenceWasReady = _playbackPersistenceReady;
+        if (resume != null) _playbackPersistenceReady = false;
+        // Watchdogs from the previous candidate must not inspect or mutate a
+        // newly opening source. Verified opens restart fresh watchdogs below.
+        _videoWatchdog?.cancel();
+        _performanceWatchdog?.cancel();
+        if (requireDecodedVideo) {
+          // A retry can reuse this screen after the previous media already
+          // rendered. Only a frame from this open attempt may satisfy readiness.
+          _videoFrameSeen = false;
+        }
+        try {
+          await _configureNativePlayback();
+          if (!attemptIsActive()) return;
+          mediaRevision = await _openCurrentMedia(
+            play: true,
+            expectedStream: expectedStream,
+            expectedSource: expectedSource,
+            expectedHeaders: expectedHeaders,
+          );
+          if (mediaRevision == null || !attemptIsActive()) return;
+          await _applySubtitle(
+            expectedMediaRevision: mediaRevision,
+            expectedStream: expectedStream,
+          );
+          if (!attemptIsActive()) return;
+          if (resume != null) {
+            _lastResumeSeekSucceeded = await _restoreResumePosition(resume);
+            if (!attemptIsActive()) return;
+          }
+          if (requireDecodedVideo) {
+            final readinessRevision = mediaRevision;
+            final mediaReady = await waitForPlayerMediaReadiness(
+              hasDecodedVideo: () =>
+                  _videoFrameSeen &&
+                  playerMediaOpenCanCommit(
+                    expectedRevision: readinessRevision,
+                    activeRevision: _mediaOpenRevision,
+                    expectedStream: expectedStream,
+                    activeStream: _currentStream,
+                  ),
+              isActive: attemptIsActive,
+              maxPolls: playerMediaReadinessMaxPolls(
+                isWebStream: expectedStream.isWebStream,
+                mediaContentType: expectedStream.mediaContentType,
+              ),
+            );
+            if (!mediaReady) {
+              // Route disposal, handoff, and supersession are cancellation, not
+              // evidence that this candidate failed.
+              if (!attemptIsActive()) return;
+              throw const PlayerMediaReadinessException();
+            }
+          }
+          if (!attemptIsActive()) return;
+          _recordDiagnosticStreamOpenResult(
+            attempt: diagnosticOpenAttempt,
+            succeeded: true,
+          );
+          _startVideoWatchdog();
+          _startPerformanceWatchdog();
+          opened = true;
+        } catch (error, stackTrace) {
+          // A newer source owns player and lease state. The superseded attempt
+          // must not publish failure or make its caller adopt the old stream.
+          if (!attemptIsActive()) return;
+          final reasonCode = playbackDiagnosticFailureReasonCode(error);
+          _recordDiagnosticStreamOpenResult(
+            attempt: diagnosticOpenAttempt,
+            succeeded: false,
+            reasonCode: reasonCode,
+          );
+          if (_handleLibraryStartupFailure(error)) return;
+          if (propagateFailure) rethrow;
+          _recordDiagnosticOutcome(
+            PlaybackDiagnosticOutcome.failed,
+            reasonCode: reasonCode,
+          );
+          if (mounted && !_engineHandoffInProgress) {
+            unawaited(
+              recordAnonymousHandledError(
+                area: AnonymousErrorArea.playback,
+                error: error,
+                stack: stackTrace,
+              ),
+            );
+            setState(() => _playbackError = error.toString());
+          }
+        } finally {
+          if (persistenceWasReady) _playbackPersistenceReady = true;
+          _mediaOpenVerifications--;
+        }
+      }),
+    );
+    return opened;
+  }
 
   Future<void> _trackPlayerMutation(Future<void> Function() action) async {
     if (_engineHandoffInProgress) return;
@@ -2718,6 +2911,23 @@ class _MpvTvPlayerScreenState extends ConsumerState<MpvTvPlayerScreen> {
       await operation;
     } finally {
       _playerMutationOperations.remove(operation);
+    }
+  }
+
+  Future<void> _serializeMediaOpen(Future<void> Function() action) async {
+    final previous = _mediaOpenQueue;
+    final release = Completer<void>();
+    _mediaOpenQueue = release.future;
+    try {
+      try {
+        await previous;
+      } catch (_) {
+        // A failed predecessor must not poison every later retry.
+      }
+      if (_engineHandoffInProgress || _playerReleasedForHandoff) return;
+      await action();
+    } finally {
+      if (!release.isCompleted) release.complete();
     }
   }
 
@@ -2990,12 +3200,29 @@ class _MpvTvPlayerScreenState extends ConsumerState<MpvTvPlayerScreen> {
     }
   }
 
-  Future<void> _applySubtitle() async {
+  Future<void> _applySubtitle({
+    required int expectedMediaRevision,
+    required StreamReady expectedStream,
+  }) async {
+    bool revisionIsActive() =>
+        playerMediaOpenCanCommit(
+          expectedRevision: expectedMediaRevision,
+          activeRevision: _mediaOpenRevision,
+          expectedStream: expectedStream,
+          activeStream: _currentStream,
+        ) &&
+        !_mediaOpenInProgress &&
+        _canApplyTrackSelection;
+
+    if (!revisionIsActive()) return;
+    var externalSubtitleSelected = false;
+    String? externalSubtitleLanguage;
     final libraryTracks =
         widget.libraryPlayback?.request.externalSubtitleTracks ?? const [];
     if (libraryTracks.isNotEmpty) {
       try {
         final preferred = libraryTracks.first;
+        if (!revisionIsActive()) return;
         await _player.setSubtitleTrack(
           SubtitleTrack.uri(
             preferred.uri.toString(),
@@ -3003,9 +3230,19 @@ class _MpvTvPlayerScreenState extends ConsumerState<MpvTvPlayerScreen> {
             language: preferred.language,
           ),
         );
+        if (!revisionIsActive()) return;
+        externalSubtitleSelected = true;
+        final normalizedLanguage = canonicalPlayerTrackLanguage(
+          language: preferred.language,
+          title: preferred.label,
+        );
+        externalSubtitleLanguage = normalizedLanguage.isEmpty
+            ? null
+            : normalizedLanguage;
         final platform = _player.platform;
         if (platform is NativePlayer) {
           for (final track in libraryTracks.skip(1)) {
+            if (!revisionIsActive()) return;
             await platform.command([
               'sub-add',
               track.uri.toString(),
@@ -3016,37 +3253,89 @@ class _MpvTvPlayerScreenState extends ConsumerState<MpvTvPlayerScreen> {
           }
         }
       } catch (_) {
-        if (mounted && !_engineHandoffInProgress) {
+        if (revisionIsActive()) {
           _showTrackMessage('External captions could not be loaded');
         }
       }
     }
-    final subtitle =
-        _currentStream.externalSubtitle?.toString() ?? widget.subtitle;
+    if (!revisionIsActive()) return;
+    final subtitle = expectedStream.externalSubtitle?.toString();
     if (libraryTracks.isEmpty && subtitle != null && subtitle.isNotEmpty) {
       try {
+        final normalizedLanguage = canonicalPlayerLanguage(
+          expectedStream.externalSubtitleLanguage,
+        );
+        externalSubtitleLanguage = normalizedLanguage.isEmpty
+            ? null
+            : normalizedLanguage;
         if (subtitle.startsWith('asset:///')) {
           final assetKey = subtitle.substring('asset:///'.length);
           final data = await rootBundle.loadString(assetKey);
+          if (!revisionIsActive()) return;
           await _player.setSubtitleTrack(
-            SubtitleTrack.data(data, title: 'Bundled styled subtitles'),
+            SubtitleTrack.data(
+              data,
+              title: 'Bundled styled subtitles',
+              language: externalSubtitleLanguage,
+            ),
           );
         } else {
+          if (!revisionIsActive()) return;
           await _player.setSubtitleTrack(
-            SubtitleTrack.uri(subtitle, title: 'External subtitles'),
+            SubtitleTrack.uri(
+              subtitle,
+              title: 'External subtitles',
+              language: externalSubtitleLanguage,
+            ),
           );
         }
+        if (!revisionIsActive()) return;
+        externalSubtitleSelected = true;
       } catch (_) {
-        if (mounted && !_engineHandoffInProgress) {
+        if (revisionIsActive()) {
           _showTrackMessage('External captions could not be loaded');
         }
       }
     }
-    if (!_seriesPreferences.subtitleEnabled) {
-      // Register a safe external track before disabling display. libmpv keeps
-      // it in the selectable track list, so Dub-by-default playback can still
-      // turn CC on later instead of incorrectly reporting no captions.
-      await _player.setSubtitleTrack(SubtitleTrack.no());
+    if (!revisionIsActive()) return;
+    // Register external tracks before reapplying the saved per-series intent.
+    // Selecting an external track above can temporarily enable captions even
+    // when the viewer explicitly chose Off, so every registration pass must
+    // remain eligible for a final preference selection.
+    _preferredSubtitleSelected = false;
+    final requestedLanguage = canonicalPlayerLanguage(
+      _seriesPreferences.subtitleLanguage,
+    );
+    final keepRegisteredExternalCaption =
+        externalSubtitleSelected &&
+        shouldKeepRegisteredExternalCaption(
+          subtitlesEnabled: _seriesPreferences.subtitleEnabled,
+          hasPerSeriesPreference: _seriesPreferences.subtitlePreferenceSet,
+          globalMode: ref
+              .read(settingsPreferencesProvider)
+              .preferredCaptionMode,
+          externalLanguage: externalSubtitleLanguage,
+          requestedLanguage: requestedLanguage,
+        );
+    if (keepRegisteredExternalCaption) {
+      // An automatic On default may keep the resolver's chosen sidecar. An
+      // explicit per-series or global On language may keep it only when the
+      // provider or library supplied matching language metadata.
+      _preferredSubtitleSelected = true;
+      return;
+    }
+    try {
+      await _applyPreferredSubtitle(
+        _player.state.tracks,
+        expectedMediaRevision: expectedMediaRevision,
+      );
+    } catch (error, stackTrace) {
+      if (_canApplyTrackSelection) {
+        debugPrint(
+          'MPV post-registration caption selection failed: '
+          '$error\n$stackTrace',
+        );
+      }
     }
   }
 
@@ -3246,11 +3535,27 @@ class _MpvTvPlayerScreenState extends ConsumerState<MpvTvPlayerScreen> {
     bool notify = true,
     Duration? resumePosition,
   }) async {
-    if (!mounted || _engineHandoffInProgress || _failingOver) return;
+    if (!mounted ||
+        _engineHandoffInProgress ||
+        _failingOver ||
+        _manualSourceSelectionInProgress) {
+      return;
+    }
     // Private-library recovery is owned by the typed library route. Falling
     // through to anime provider discovery here could mix a private Plex,
     // Jellyfin, or device-file session with an unrelated catalog episode.
     if (widget.libraryPlayback != null) return;
+    final failoverGeneration = ++_sourceSelectionGeneration;
+
+    bool failoverIsActive() =>
+        mounted &&
+        !_engineHandoffInProgress &&
+        playerFailoverGenerationIsActive(
+          expectedGeneration: failoverGeneration,
+          activeGeneration: _sourceSelectionGeneration,
+          manualSourceSelectionInProgress: _manualSourceSelectionInProgress,
+        );
+
     final failoverReasonCode = playbackDiagnosticFailureReasonCode(reason);
     unawaited(
       _playbackDiagnostics.fallbackAttempted(
@@ -3271,13 +3576,13 @@ class _MpvTvPlayerScreenState extends ConsumerState<MpvTvPlayerScreen> {
         currentIsWeb: _currentStream.isWebStream,
       );
       final profile = await AndroidTvBridge.instance.getDeviceProfile();
-      if (!mounted || _engineHandoffInProgress) return;
+      if (!failoverIsActive()) return;
       await _recordStreamFailureBestEffort(
         deviceKey: profile.key,
         infoHash: _currentRelease.infoHash,
         reason: reason,
       );
-      if (!mounted || _engineHandoffInProgress) return;
+      if (!failoverIsActive()) return;
       Future<bool> tryReleaseCandidates(
         Iterable<ReleaseCandidate> candidates,
       ) async {
@@ -3300,7 +3605,7 @@ class _MpvTvPlayerScreenState extends ConsumerState<MpvTvPlayerScreen> {
               tokenService: tokenService,
             );
             resolvedStream = ready;
-            if (!mounted || _engineHandoffInProgress) {
+            if (!failoverIsActive()) {
               await resolvedStream?.playbackLease?.close();
               return false;
             }
@@ -3310,12 +3615,17 @@ class _MpvTvPlayerScreenState extends ConsumerState<MpvTvPlayerScreen> {
                 infoHash: candidate.infoHash,
                 reason: 'Fallback resolution returned no playable stream.',
               );
+              if (!failoverIsActive()) return false;
               continue;
+            }
+            if (!failoverIsActive()) {
+              await ready.playbackLease?.close();
+              return false;
             }
             _source = ready.uri.toString();
             _currentRelease = candidate;
             _currentStream = ready;
-            _applyAutomaticSubtitleDefaultForRelease(candidate);
+            _applyCaptionDefaultForRelease(candidate);
             _preferredAudioSelected = false;
             _preferredSubtitleSelected = false;
             _softwareFallbackUsed = false;
@@ -3330,16 +3640,35 @@ class _MpvTvPlayerScreenState extends ConsumerState<MpvTvPlayerScreen> {
               automatic: true,
               reasonCode: 'source_fallback',
             );
-            await _openMedia(
+            final opened = await _openMedia(
               resume: position,
               propagateFailure: true,
               requireDecodedVideo: true,
             );
-            if (!mounted || _engineHandoffInProgress) {
+            if (!opened ||
+                !failoverIsActive() ||
+                !identical(_currentStream, ready)) {
+              await ready.playbackLease?.close();
+              resolvedStream = null;
+              if (failoverIsActive() && identical(_currentStream, ready)) {
+                _source = previousSource;
+                _currentRelease = previousRelease;
+                _currentStream = previousStream;
+                _seriesPreferences = previousPreferences;
+                _preferredAudioSelected = previousAudioSelected;
+                _preferredSubtitleSelected = previousSubtitleSelected;
+                _softwareFallbackUsed = previousSoftwareFallbackUsed;
+                _decoderMode = previousDecoderMode;
+                _videoFrameSeen = previousVideoFrameSeen;
+              }
+              return false;
+            }
+            if (!failoverIsActive()) {
               await ready.playbackLease?.close();
               return false;
             }
             await widget.onStreamAdopted(ready, candidate);
+            if (!failoverIsActive()) return false;
             _invalidateNextEpisodePreparation();
             _resetSkipSegmentsForSourceChange();
             setState(() => _playbackError = null);
@@ -3351,8 +3680,15 @@ class _MpvTvPlayerScreenState extends ConsumerState<MpvTvPlayerScreen> {
             // Resolution may fail before `_currentStream` points at the new
             // candidate. Close only the lease created by this attempt; the
             // previous playing stream still owns its lease until adoption.
-            await resolvedStream?.playbackLease?.close();
-            if (!mounted || _engineHandoffInProgress) return false;
+            final attemptStream = resolvedStream;
+            final attemptStillOwnsState = attemptStream == null
+                ? identical(_currentStream, previousStream)
+                : identical(_currentStream, attemptStream);
+            if (attemptStream != null) {
+              await attemptStream.playbackLease?.close();
+            }
+            if (!failoverIsActive()) return false;
+            if (!attemptStillOwnsState) return false;
             _source = previousSource;
             _currentRelease = previousRelease;
             _currentStream = previousStream;
@@ -3379,7 +3715,7 @@ class _MpvTvPlayerScreenState extends ConsumerState<MpvTvPlayerScreen> {
 
       final currentQualityHeight = releaseQualityHeight(_currentRelease);
       await _waitForInFlightDirectDiscovery();
-      if (!mounted || _engineHandoffInProgress) return;
+      if (!failoverIsActive()) return;
       final allDirectCandidates = _remainingDirectFailoverCandidates();
       final allReleaseCandidates = _remainingReleaseFailoverCandidates();
       final audioRankTiers = playerFailoverAudioRankTiers([
@@ -3422,6 +3758,7 @@ class _MpvTvPlayerScreenState extends ConsumerState<MpvTvPlayerScreen> {
             final opened = switch (streamClass) {
               PlayerFailoverClass.directWeb => await _switchToNextDirectStream(
                 position,
+                expectedSourceGeneration: failoverGeneration,
                 candidates: directCandidates,
                 failoverReason: reason,
                 notify: notify,
@@ -3436,11 +3773,11 @@ class _MpvTvPlayerScreenState extends ConsumerState<MpvTvPlayerScreen> {
                     : false,
             };
             if (opened) return;
-            if (!mounted || _engineHandoffInProgress) return;
+            if (!failoverIsActive()) return;
           }
         }
       }
-      if (mounted && !_engineHandoffInProgress) {
+      if (failoverIsActive()) {
         final message =
             terminalFailure?.toString() ??
             'Every compatible stream failed. $reason';
@@ -3469,12 +3806,22 @@ class _MpvTvPlayerScreenState extends ConsumerState<MpvTvPlayerScreen> {
 
   Future<bool> _switchToNextDirectStream(
     Duration position, {
+    required int expectedSourceGeneration,
     Iterable<PlaybackStreamOption>? candidates,
     Object? failoverReason,
     bool notify = true,
     required String deviceKey,
   }) async {
-    if (!mounted || _engineHandoffInProgress) {
+    bool failoverIsActive() =>
+        mounted &&
+        !_engineHandoffInProgress &&
+        playerFailoverGenerationIsActive(
+          expectedGeneration: expectedSourceGeneration,
+          activeGeneration: _sourceSelectionGeneration,
+          manualSourceSelectionInProgress: _manualSourceSelectionInProgress,
+        );
+
+    if (!failoverIsActive()) {
       return false;
     }
     if (_currentStream.isWebStream) {
@@ -3488,7 +3835,7 @@ class _MpvTvPlayerScreenState extends ConsumerState<MpvTvPlayerScreen> {
     final opened = await openFirstViablePlayerCandidate(
       candidates: candidates ?? _remainingDirectFailoverCandidates(),
       resumePosition: position,
-      isActive: () => mounted && !_engineHandoffInProgress,
+      isActive: failoverIsActive,
       attempt: (candidate, resumePosition) async {
         _failedDirectStreamKeys.add(playbackStreamOptionAttemptKey(candidate));
         final previousSource = _source;
@@ -3504,7 +3851,7 @@ class _MpvTvPlayerScreenState extends ConsumerState<MpvTvPlayerScreen> {
         try {
           final option = await _preflightDirectStream(candidate, silent: true);
           preparedOption = option;
-          if (!mounted || _engineHandoffInProgress) {
+          if (!failoverIsActive()) {
             await option?.stream.playbackLease?.close();
             return false;
           }
@@ -3517,11 +3864,15 @@ class _MpvTvPlayerScreenState extends ConsumerState<MpvTvPlayerScreen> {
             await option.stream.playbackLease?.close();
             return false;
           }
+          if (!failoverIsActive()) {
+            await option.stream.playbackLease?.close();
+            return false;
+          }
           _failedDirectStreamKeys.add(playbackStreamOptionAttemptKey(option));
           _currentStream = option.stream;
           _currentRelease = option.release;
           _source = option.stream.uri.toString();
-          _applyAutomaticSubtitleDefaultForRelease(option.release);
+          _applyCaptionDefaultForRelease(option.release);
           _preferredAudioSelected = false;
           _preferredSubtitleSelected = false;
           _softwareFallbackUsed = false;
@@ -3535,16 +3886,36 @@ class _MpvTvPlayerScreenState extends ConsumerState<MpvTvPlayerScreen> {
             automatic: true,
             reasonCode: 'source_fallback',
           );
-          await _openMedia(
+          final opened = await _openMedia(
             resume: resumePosition,
             propagateFailure: true,
             requireDecodedVideo: true,
           );
-          if (!mounted || _engineHandoffInProgress) {
+          if (!opened ||
+              !failoverIsActive() ||
+              !identical(_currentStream, option.stream)) {
+            await option.stream.playbackLease?.close();
+            preparedOption = null;
+            if (failoverIsActive() &&
+                identical(_currentStream, option.stream)) {
+              _source = previousSource;
+              _currentRelease = previousRelease;
+              _currentStream = previousStream;
+              _seriesPreferences = previousPreferences;
+              _preferredAudioSelected = previousAudioSelected;
+              _preferredSubtitleSelected = previousSubtitleSelected;
+              _softwareFallbackUsed = previousSoftwareFallbackUsed;
+              _decoderMode = previousDecoderMode;
+              _videoFrameSeen = previousVideoFrameSeen;
+            }
+            return false;
+          }
+          if (!failoverIsActive()) {
             await option.stream.playbackLease?.close();
             return false;
           }
           await widget.onStreamAdopted(option.stream, option.release);
+          if (!failoverIsActive()) return false;
           _invalidateNextEpisodePreparation();
           _resetSkipSegmentsForSourceChange();
           preparedOption = null;
@@ -3558,8 +3929,13 @@ class _MpvTvPlayerScreenState extends ConsumerState<MpvTvPlayerScreen> {
           }
           return true;
         } catch (error) {
-          await preparedOption?.stream.playbackLease?.close();
-          if (!mounted || _engineHandoffInProgress) rethrow;
+          final attemptStream = preparedOption?.stream;
+          final attemptStillOwnsState = attemptStream == null
+              ? identical(_currentStream, previousStream)
+              : identical(_currentStream, attemptStream);
+          await attemptStream?.playbackLease?.close();
+          if (!failoverIsActive()) return false;
+          if (!attemptStillOwnsState) return false;
           _source = previousSource;
           _currentRelease = previousRelease;
           _currentStream = previousStream;
@@ -3683,12 +4059,12 @@ class _MpvTvPlayerScreenState extends ConsumerState<MpvTvPlayerScreen> {
       ),
     );
     try {
-      await _openMedia(
+      final opened = await _openMedia(
         resume: position,
         propagateFailure: true,
         requireDecodedVideo: _animeFeaturesEnabled,
       );
-      _showTrackMessage('Stream restarted');
+      if (opened) _showTrackMessage('Stream restarted');
     } catch (error) {
       if (mounted) setState(() => _playbackError = error.toString());
     }
@@ -4039,7 +4415,6 @@ class _MpvTvPlayerScreenState extends ConsumerState<MpvTvPlayerScreen> {
     final mediaId = _catalogAnilistMediaId;
     if (mediaId == null || !_seriesPreferencesReady) return;
     final audio = _player.state.track.audio;
-    final subtitle = _player.state.track.subtitle;
     // Some dual-audio containers label a stream (for example, "English
     // Dub") without setting its ISO language field. Persist the normalized
     // title in that case so the next episode does not silently fall back to
@@ -4050,16 +4425,8 @@ class _MpvTvPlayerScreenState extends ConsumerState<MpvTvPlayerScreen> {
       observedLanguage: audio.language,
       observedTitle: audio.title,
     );
-    final subtitleLanguage = canonicalPlayerLanguage(
-      subtitle.language ?? subtitle.title,
-    );
     _seriesPreferences = _seriesPreferences.copyWith(
       audioLanguage: audioLanguage,
-      subtitleLanguage: subtitleLanguage.isEmpty
-          ? _seriesPreferences.subtitleLanguage
-          : subtitleLanguage,
-      subtitleEnabled: subtitle.id != 'no',
-      subtitlePreferenceSet: true,
       subtitleSize: _subtitleSize,
       subtitlePosition: _subtitlePosition,
       subtitleDelayMs: _subtitleDelayMs,
@@ -4268,148 +4635,188 @@ class _MpvTvPlayerScreenState extends ConsumerState<MpvTvPlayerScreen> {
     PlaybackDecoderMode mode, {
     bool automatic = false,
     String? reason,
-  }) => _trackPlayerMutation(() async {
-    if (_changingDecoder || mode == _decoderMode) return;
-    final diagnosticReasonCode = automatic
-        ? playbackDiagnosticFailureReasonCode(reason)
-        : 'user_decoder_change';
-    if (automatic) {
+  }) => _trackPlayerMutation(
+    () => _serializeMediaOpen(() async {
+      if (_changingDecoder || mode == _decoderMode) return;
+      final diagnosticReasonCode = automatic
+          ? playbackDiagnosticFailureReasonCode(reason)
+          : 'user_decoder_change';
+      if (automatic) {
+        unawaited(
+          _playbackDiagnostics.fallbackAttempted(
+            fallbackKind: PlaybackDiagnosticFallbackKind.decoder,
+            sourceKind: _diagnosticSourceKind,
+            decoder: switch (mode) {
+              PlaybackDecoderMode.hardwareSafe =>
+                PlaybackDiagnosticDecoder.hardwareAdaptive,
+              PlaybackDecoderMode.hardwareDirect =>
+                PlaybackDiagnosticDecoder.hardwareDirect,
+              PlaybackDecoderMode.software =>
+                PlaybackDiagnosticDecoder.softwareCompatibility,
+            },
+            codec: _player.state.track.video.codec,
+            reasonCode: diagnosticReasonCode,
+            attempt: ++_diagnosticFallbackAttempt,
+          ),
+        );
+      }
+      _changingDecoder = true;
+      _decoderMode = mode;
+      _recordDiagnosticDecoderSelected(
+        automatic: automatic,
+        reasonCode: diagnosticReasonCode,
+      );
+      _softwareFallbackUsed = mode == PlaybackDecoderMode.software;
+      _videoWatchdog?.cancel();
+      final position = _effectiveHandoffPosition();
+      final wasPlaying = _player.state.playing;
+      final diagnosticOpenAttempt = ++_diagnosticStreamOpenAttempt;
+      final persistenceWasReady = _playbackPersistenceReady;
+      _playbackPersistenceReady = false;
+      try {
+        _resetCompletionObservation(position);
+        final platform = _player.platform;
+        if (platform is NativePlayer) {
+          await platform.setProperty('hwdec', hwdecForPlaybackMode(mode));
+          await platform.setProperty('hwdec-software-fallback', '1');
+          await _configureNativeAudioPreference(platform);
+        }
+        _preferredAudioSelected = false;
+        _preferredSubtitleSelected = false;
+        _videoFrameSeen = false;
+        final expectedStream = _currentStream;
+        final mediaRevision = await _openCurrentMedia(
+          play: automatic || wasPlaying,
+          expectedStream: expectedStream,
+          expectedSource: _source,
+          expectedHeaders: Map<String, String>.of(_httpHeaders),
+        );
+        if (mediaRevision == null) return;
+        _recordDiagnosticStreamOpenResult(
+          attempt: diagnosticOpenAttempt,
+          succeeded: true,
+        );
+        if (position > Duration.zero) await _restoreResumePosition(position);
+        if (!playerMediaOpenCanCommit(
+          expectedRevision: mediaRevision,
+          activeRevision: _mediaOpenRevision,
+          expectedStream: expectedStream,
+          activeStream: _currentStream,
+        )) {
+          return;
+        }
+        await _applySubtitle(
+          expectedMediaRevision: mediaRevision,
+          expectedStream: expectedStream,
+        );
+        await _applyPlayerTuning();
+        await _saveDecoderPreference();
+        _startVideoWatchdog();
+        _startPerformanceWatchdog();
+        if (mounted) {
+          setState(() => _playbackError = null);
+          _showTrackMessage(
+            automatic
+                ? reason ??
+                      'Video failed to start; software compatibility enabled'
+                : '${playbackDecoderLabel(mode)} enabled',
+          );
+        }
+      } catch (error) {
+        final failureReasonCode = playbackDiagnosticFailureReasonCode(error);
+        _recordDiagnosticStreamOpenResult(
+          attempt: diagnosticOpenAttempt,
+          succeeded: false,
+          reasonCode: failureReasonCode,
+        );
+        if (automaticDecoderFailureNeedsLibraryRecovery(
+              automatic: automatic,
+              hasLibrarySession: widget.libraryPlayback != null,
+              error: error,
+            ) &&
+            _handleLibraryStartupFailure(error)) {
+          return;
+        }
+        _recordDiagnosticOutcome(
+          PlaybackDiagnosticOutcome.failed,
+          reasonCode: failureReasonCode,
+        );
+        if (mounted) setState(() => _playbackError = error.toString());
+      } finally {
+        if (persistenceWasReady) _playbackPersistenceReady = true;
+        _changingDecoder = false;
+      }
+    }),
+  );
+
+  Future<void> _retryPlayback() => _trackPlayerMutation(
+    () => _serializeMediaOpen(() async {
+      final position = _effectiveHandoffPosition();
+      final wasPlaying = _player.state.playing;
       unawaited(
         _playbackDiagnostics.fallbackAttempted(
-          fallbackKind: PlaybackDiagnosticFallbackKind.decoder,
+          fallbackKind: PlaybackDiagnosticFallbackKind.retry,
           sourceKind: _diagnosticSourceKind,
-          decoder: switch (mode) {
-            PlaybackDecoderMode.hardwareSafe =>
-              PlaybackDiagnosticDecoder.hardwareAdaptive,
-            PlaybackDecoderMode.hardwareDirect =>
-              PlaybackDiagnosticDecoder.hardwareDirect,
-            PlaybackDecoderMode.software =>
-              PlaybackDiagnosticDecoder.softwareCompatibility,
-          },
+          decoder: _diagnosticDecoder,
           codec: _player.state.track.video.codec,
-          reasonCode: diagnosticReasonCode,
+          reasonCode: 'user_retry',
           attempt: ++_diagnosticFallbackAttempt,
         ),
       );
-    }
-    _changingDecoder = true;
-    _decoderMode = mode;
-    _recordDiagnosticDecoderSelected(
-      automatic: automatic,
-      reasonCode: diagnosticReasonCode,
-    );
-    _softwareFallbackUsed = mode == PlaybackDecoderMode.software;
-    _videoWatchdog?.cancel();
-    final position = _effectiveHandoffPosition();
-    final wasPlaying = _player.state.playing;
-    final diagnosticOpenAttempt = ++_diagnosticStreamOpenAttempt;
-    final persistenceWasReady = _playbackPersistenceReady;
-    _playbackPersistenceReady = false;
-    try {
-      _resetCompletionObservation(position);
-      final platform = _player.platform;
-      if (platform is NativePlayer) {
-        await platform.setProperty('hwdec', hwdecForPlaybackMode(mode));
-        await platform.setProperty('hwdec-software-fallback', '1');
-        await _configureNativeAudioPreference(platform);
-      }
-      _preferredAudioSelected = false;
-      _preferredSubtitleSelected = false;
-      _videoFrameSeen = false;
-      await _openCurrentMedia(play: automatic || wasPlaying);
-      _recordDiagnosticStreamOpenResult(
-        attempt: diagnosticOpenAttempt,
-        succeeded: true,
-      );
-      if (position > Duration.zero) await _restoreResumePosition(position);
-      await _applySubtitle();
-      await _applyPlayerTuning();
-      await _saveDecoderPreference();
-      _startVideoWatchdog();
-      _startPerformanceWatchdog();
-      if (mounted) {
-        setState(() => _playbackError = null);
-        _showTrackMessage(
-          automatic
-              ? reason ??
-                    'Video failed to start; software compatibility enabled'
-              : '${playbackDecoderLabel(mode)} enabled',
+      final diagnosticOpenAttempt = ++_diagnosticStreamOpenAttempt;
+      final persistenceWasReady = _playbackPersistenceReady;
+      _playbackPersistenceReady = false;
+      setState(() => _playbackError = null);
+      try {
+        _videoFrameSeen = false;
+        _resetCompletionObservation(position);
+        await _configureNativePlayback();
+        final expectedStream = _currentStream;
+        final mediaRevision = await _openCurrentMedia(
+          play: wasPlaying,
+          expectedStream: expectedStream,
+          expectedSource: _source,
+          expectedHeaders: Map<String, String>.of(_httpHeaders),
         );
+        if (mediaRevision == null) return;
+        _recordDiagnosticStreamOpenResult(
+          attempt: diagnosticOpenAttempt,
+          succeeded: true,
+        );
+        if (position > Duration.zero) await _restoreResumePosition(position);
+        if (!playerMediaOpenCanCommit(
+          expectedRevision: mediaRevision,
+          activeRevision: _mediaOpenRevision,
+          expectedStream: expectedStream,
+          activeStream: _currentStream,
+        )) {
+          return;
+        }
+        await _applySubtitle(
+          expectedMediaRevision: mediaRevision,
+          expectedStream: expectedStream,
+        );
+        await _applyPlayerTuning();
+        _startVideoWatchdog();
+        _startPerformanceWatchdog();
+        _showTrackMessage('Stream restarted');
+      } catch (error) {
+        final reasonCode = playbackDiagnosticFailureReasonCode(error);
+        _recordDiagnosticStreamOpenResult(
+          attempt: diagnosticOpenAttempt,
+          succeeded: false,
+          reasonCode: reasonCode,
+        );
+        _recordDiagnosticOutcome(
+          PlaybackDiagnosticOutcome.failed,
+          reasonCode: reasonCode,
+        );
+        if (mounted) setState(() => _playbackError = error.toString());
+      } finally {
+        if (persistenceWasReady) _playbackPersistenceReady = true;
       }
-    } catch (error) {
-      final failureReasonCode = playbackDiagnosticFailureReasonCode(error);
-      _recordDiagnosticStreamOpenResult(
-        attempt: diagnosticOpenAttempt,
-        succeeded: false,
-        reasonCode: failureReasonCode,
-      );
-      if (automaticDecoderFailureNeedsLibraryRecovery(
-            automatic: automatic,
-            hasLibrarySession: widget.libraryPlayback != null,
-            error: error,
-          ) &&
-          _handleLibraryStartupFailure(error)) {
-        return;
-      }
-      _recordDiagnosticOutcome(
-        PlaybackDiagnosticOutcome.failed,
-        reasonCode: failureReasonCode,
-      );
-      if (mounted) setState(() => _playbackError = error.toString());
-    } finally {
-      if (persistenceWasReady) _playbackPersistenceReady = true;
-      _changingDecoder = false;
-    }
-  });
-
-  Future<void> _retryPlayback() => _trackPlayerMutation(() async {
-    final position = _effectiveHandoffPosition();
-    final wasPlaying = _player.state.playing;
-    unawaited(
-      _playbackDiagnostics.fallbackAttempted(
-        fallbackKind: PlaybackDiagnosticFallbackKind.retry,
-        sourceKind: _diagnosticSourceKind,
-        decoder: _diagnosticDecoder,
-        codec: _player.state.track.video.codec,
-        reasonCode: 'user_retry',
-        attempt: ++_diagnosticFallbackAttempt,
-      ),
-    );
-    final diagnosticOpenAttempt = ++_diagnosticStreamOpenAttempt;
-    final persistenceWasReady = _playbackPersistenceReady;
-    _playbackPersistenceReady = false;
-    setState(() => _playbackError = null);
-    try {
-      _videoFrameSeen = false;
-      _resetCompletionObservation(position);
-      await _configureNativePlayback();
-      await _openCurrentMedia(play: wasPlaying);
-      _recordDiagnosticStreamOpenResult(
-        attempt: diagnosticOpenAttempt,
-        succeeded: true,
-      );
-      if (position > Duration.zero) await _restoreResumePosition(position);
-      await _applySubtitle();
-      await _applyPlayerTuning();
-      _startVideoWatchdog();
-      _startPerformanceWatchdog();
-      _showTrackMessage('Stream restarted');
-    } catch (error) {
-      final reasonCode = playbackDiagnosticFailureReasonCode(error);
-      _recordDiagnosticStreamOpenResult(
-        attempt: diagnosticOpenAttempt,
-        succeeded: false,
-        reasonCode: reasonCode,
-      );
-      _recordDiagnosticOutcome(
-        PlaybackDiagnosticOutcome.failed,
-        reasonCode: reasonCode,
-      );
-      if (mounted) setState(() => _playbackError = error.toString());
-    } finally {
-      if (persistenceWasReady) _playbackPersistenceReady = true;
-    }
-  });
+    }),
+  );
 
   Stream<WebStreamSearchProgress> _webSourceSearch({bool refresh = false}) =>
       ref
@@ -4482,6 +4889,7 @@ class _MpvTvPlayerScreenState extends ConsumerState<MpvTvPlayerScreen> {
           displayName: option.stream.displayName,
           headers: validated.headers,
           externalSubtitle: validated.subtitleUri,
+          externalSubtitleLanguage: option.stream.externalSubtitleLanguage,
           mediaContentType: validated.contentType,
           subtitleContentType: validated.subtitleContentType,
           externalSubtitleRejected: validated.subtitleRejected,
@@ -4544,8 +4952,15 @@ class _MpvTvPlayerScreenState extends ConsumerState<MpvTvPlayerScreen> {
       return;
     }
 
+    // Keep the current generation while validating the user's choice. If an
+    // automatic failover starts during this await, let it finish (or fail)
+    // before cancelling it; otherwise its unadopted candidate could be closed
+    // while it is still the only restorable stream.
+    final manualSelectionStartGeneration = _sourceSelectionGeneration;
     final option = await _preflightDirectStream(selected);
-    if (!mounted) {
+    if (!mounted ||
+        manualSelectionStartGeneration != _sourceSelectionGeneration ||
+        _failingOver) {
       await option?.stream.playbackLease?.close();
       return;
     }
@@ -4553,70 +4968,99 @@ class _MpvTvPlayerScreenState extends ConsumerState<MpvTvPlayerScreen> {
       _showControls();
       return;
     }
-    final resume = _effectiveHandoffPosition();
-    final previousSource = _source;
-    final previousStream = _currentStream;
-    final previousRelease = _currentRelease;
-    final previousPreferences = _seriesPreferences;
-    final previousDirectStreamOptions = _directStreamOptions;
-    final previousDecoderMode = _decoderMode;
-    final previousSoftwareFallbackUsed = _softwareFallbackUsed;
-    final previousVideoFrameSeen = _videoFrameSeen;
-    final selectedProvider = playbackStreamOptionProviderIdentity(option);
-    final previousProvider = playbackStreamOptionProviderIdentity(
-      PlaybackStreamOption(stream: previousStream, release: previousRelease),
-    );
-    _failedDirectStreamKeys.clear();
-    _currentStream = option.stream;
-    _source = option.stream.uri.toString();
-    _currentRelease = option.release;
-    _applyAutomaticSubtitleDefaultForRelease(option.release);
-    _directStreamOptions = mergePlaybackStreamOptions(
-      [option],
-      _directStreamOptions.where((candidate) {
-        final provider = playbackStreamOptionProviderIdentity(candidate);
-        if (provider == selectedProvider &&
-            (candidate.stream.uri == selected.stream.uri ||
-                candidate.stream.uri == option.stream.uri)) {
-          return false;
-        }
-        if (provider == previousProvider &&
-            candidate.stream.uri == previousStream.uri) {
-          return false;
-        }
-        return true;
-      }),
-    );
-    _preferredAudioSelected = false;
-    _preferredSubtitleSelected = false;
-    _softwareFallbackUsed = false;
-    _decoderMode = releaseRequiresSoftwareDecoder(option.release)
-        ? PlaybackDecoderMode.software
-        : PlaybackDecoderMode.hardwareSafe;
-    _softwareFallbackUsed = _decoderMode == PlaybackDecoderMode.software;
-    _videoFrameSeen = false;
-    unawaited(
-      _playbackDiagnostics.fallbackAttempted(
-        fallbackKind: PlaybackDiagnosticFallbackKind.source,
-        sourceKind: _diagnosticSourceKind,
-        decoder: _diagnosticDecoder,
-        codec: _player.state.track.video.codec,
-        reasonCode: 'manual_source_change',
-        attempt: ++_diagnosticFallbackAttempt,
-      ),
-    );
-    _recordDiagnosticSourceSelected(automatic: false);
-    _recordDiagnosticDecoderSelected(
-      automatic: true,
-      reasonCode: 'manual_source_change',
-    );
-    if (mounted) setState(() => _playbackError = null);
+    // A deliberate source choice is authoritative. Invalidate automatic
+    // failover only after preflight succeeds and no failover is in flight.
+    _manualSourceSelectionInProgress = true;
+    late final Duration resume;
+    late final String previousSource;
+    late final StreamReady previousStream;
+    late final ReleaseCandidate previousRelease;
+    late final SeriesPlaybackPreferences previousPreferences;
+    late final List<PlaybackStreamOption> previousDirectStreamOptions;
+    late final PlaybackDecoderMode previousDecoderMode;
+    late final bool previousSoftwareFallbackUsed;
+    late final bool previousVideoFrameSeen;
     try {
-      await _openMedia(
+      final manualSourceGeneration = ++_sourceSelectionGeneration;
+      resume = _effectiveHandoffPosition();
+      previousSource = _source;
+      previousStream = _currentStream;
+      previousRelease = _currentRelease;
+      previousPreferences = _seriesPreferences;
+      previousDirectStreamOptions = _directStreamOptions;
+      previousDecoderMode = _decoderMode;
+      previousSoftwareFallbackUsed = _softwareFallbackUsed;
+      previousVideoFrameSeen = _videoFrameSeen;
+      final selectedProvider = playbackStreamOptionProviderIdentity(option);
+      final previousProvider = playbackStreamOptionProviderIdentity(
+        PlaybackStreamOption(stream: previousStream, release: previousRelease),
+      );
+      _failedDirectStreamKeys.clear();
+      _currentStream = option.stream;
+      _source = option.stream.uri.toString();
+      _currentRelease = option.release;
+      _applyCaptionDefaultForRelease(option.release);
+      _directStreamOptions = mergePlaybackStreamOptions(
+        [option],
+        _directStreamOptions.where((candidate) {
+          final provider = playbackStreamOptionProviderIdentity(candidate);
+          if (provider == selectedProvider &&
+              (candidate.stream.uri == selected.stream.uri ||
+                  candidate.stream.uri == option.stream.uri)) {
+            return false;
+          }
+          if (provider == previousProvider &&
+              candidate.stream.uri == previousStream.uri) {
+            return false;
+          }
+          return true;
+        }),
+      );
+      _preferredAudioSelected = false;
+      _preferredSubtitleSelected = false;
+      _softwareFallbackUsed = false;
+      _decoderMode = releaseRequiresSoftwareDecoder(option.release)
+          ? PlaybackDecoderMode.software
+          : PlaybackDecoderMode.hardwareSafe;
+      _softwareFallbackUsed = _decoderMode == PlaybackDecoderMode.software;
+      _videoFrameSeen = false;
+      unawaited(
+        _playbackDiagnostics.fallbackAttempted(
+          fallbackKind: PlaybackDiagnosticFallbackKind.source,
+          sourceKind: _diagnosticSourceKind,
+          decoder: _diagnosticDecoder,
+          codec: _player.state.track.video.codec,
+          reasonCode: 'manual_source_change',
+          attempt: ++_diagnosticFallbackAttempt,
+        ),
+      );
+      _recordDiagnosticSourceSelected(automatic: false);
+      _recordDiagnosticDecoderSelected(
+        automatic: true,
+        reasonCode: 'manual_source_change',
+      );
+      if (mounted) setState(() => _playbackError = null);
+      final opened = await _openMedia(
         resume: resume,
         propagateFailure: true,
         requireDecodedVideo: true,
       );
+      if (!opened || !identical(_currentStream, option.stream)) {
+        await option.stream.playbackLease?.close();
+        if (mounted &&
+            manualSourceGeneration == _sourceSelectionGeneration &&
+            identical(_currentStream, option.stream)) {
+          _source = previousSource;
+          _currentStream = previousStream;
+          _currentRelease = previousRelease;
+          _seriesPreferences = previousPreferences;
+          _directStreamOptions = previousDirectStreamOptions;
+          _decoderMode = previousDecoderMode;
+          _softwareFallbackUsed = previousSoftwareFallbackUsed;
+          _videoFrameSeen = previousVideoFrameSeen;
+        }
+        return;
+      }
       if (!mounted || _engineHandoffInProgress) {
         await option.stream.playbackLease?.close();
         return;
@@ -4624,7 +5068,18 @@ class _MpvTvPlayerScreenState extends ConsumerState<MpvTvPlayerScreen> {
       await widget.onStreamAdopted(option.stream, option.release);
       _invalidateNextEpisodePreparation();
       _resetSkipSegmentsForSourceChange();
+      if (option.stream.externalSubtitleRejected) {
+        _showTrackMessage(
+          'Playing without the unsafe or unsupported external subtitles.',
+        );
+      }
+      _showTrackMessage('Playing ${playbackStreamOptionLabel(option)}');
+      _showControls();
     } catch (_) {
+      if (!identical(_currentStream, option.stream)) {
+        await option.stream.playbackLease?.close();
+        return;
+      }
       await option.stream.playbackLease?.close();
       _source = previousSource;
       _currentStream = previousStream;
@@ -4635,20 +5090,17 @@ class _MpvTvPlayerScreenState extends ConsumerState<MpvTvPlayerScreen> {
       _softwareFallbackUsed = previousSoftwareFallbackUsed;
       _videoFrameSeen = previousVideoFrameSeen;
       if (mounted && !_engineHandoffInProgress) {
-        await _openMedia(resume: resume);
-        _showTrackMessage(
-          'That source could not start. Restored the previous stream.',
-        );
+        final restored = await _openMedia(resume: resume);
+        if (restored) {
+          _showTrackMessage(
+            'That source could not start. Restored the previous stream.',
+          );
+        }
       }
       return;
+    } finally {
+      _manualSourceSelectionInProgress = false;
     }
-    if (option.stream.externalSubtitleRejected) {
-      _showTrackMessage(
-        'Playing without the unsafe or unsupported external subtitles.',
-      );
-    }
-    _showTrackMessage('Playing ${playbackStreamOptionLabel(option)}');
-    _showControls();
   }
 
   // TODO: Remove after older persisted player-route labels are migrated.
@@ -5180,6 +5632,7 @@ class _MpvTvPlayerScreenState extends ConsumerState<MpvTvPlayerScreen> {
 
   Future<void> _openAudioTrackPicker() async {
     if (_blockGuestLocalControl()) return;
+    final mediaRevision = _mediaOpenRevision;
     _controlsTimer?.cancel();
     final expectsMultipleAudio = releaseAdvertisesMultipleAudio(
       _currentRelease.releaseName,
@@ -5206,7 +5659,11 @@ class _MpvTvPlayerScreenState extends ConsumerState<MpvTvPlayerScreen> {
             : const Duration(seconds: 2),
       ),
     );
-    if (!mounted || _engineHandoffInProgress) return;
+    if (!mounted ||
+        _engineHandoffInProgress ||
+        mediaRevision != _mediaOpenRevision) {
+      return;
+    }
     if (_blockGuestLocalControl()) {
       _showControls(focusControls: true);
       return;
@@ -5249,40 +5706,60 @@ class _MpvTvPlayerScreenState extends ConsumerState<MpvTvPlayerScreen> {
       return;
     }
     final selected = tracks.firstWhere((track) => track.id == selectedId);
-    final previousAudioLanguage = _seriesPreferences.audioLanguage;
-    final previousAudioPreferenceSet = _seriesPreferences.audioPreferenceSet;
-    _preferredAudioSelected = true;
-    await _player.setAudioTrack(selected);
-    final selectedLanguage = persistedPlayerAudioLanguage(
-      storedLanguage: _seriesPreferences.audioLanguage,
-      audioPreferenceSet: _seriesPreferences.audioPreferenceSet,
-      observedLanguage: selected.language,
-      observedTitle: selected.title,
-      manualSelection: true,
+    var applied = false;
+    await _trackPlayerMutation(
+      () => _serializeMediaOpen(() async {
+        if (!mounted ||
+            _engineHandoffInProgress ||
+            mediaRevision != _mediaOpenRevision ||
+            !_canApplyTrackSelection) {
+          return;
+        }
+        final previousAudioLanguage = _seriesPreferences.audioLanguage;
+        final previousAudioPreferenceSet =
+            _seriesPreferences.audioPreferenceSet;
+        await _player.setAudioTrack(selected);
+        if (!mounted ||
+            _engineHandoffInProgress ||
+            mediaRevision != _mediaOpenRevision ||
+            !_canApplyTrackSelection) {
+          return;
+        }
+        _preferredAudioSelected = true;
+        final selectedLanguage = persistedPlayerAudioLanguage(
+          storedLanguage: _seriesPreferences.audioLanguage,
+          audioPreferenceSet: _seriesPreferences.audioPreferenceSet,
+          observedLanguage: selected.language,
+          observedTitle: selected.title,
+          manualSelection: true,
+        );
+        _seriesPreferences = _seriesPreferences.copyWith(
+          audioLanguage: selectedLanguage,
+          audioPreferenceSet: true,
+        );
+        _watchPartyPlayback.updateRequestedAudio(_effectiveAudioPreference);
+        _publishWatchPartyPlayback();
+        await _saveSeriesPreferences();
+        _recordDiagnosticAudioTrackSelected(
+          track: selected,
+          tracks: tracks,
+          preferenceMatched: playerTrackMatchesAudioLanguage(
+            selected,
+            _seriesPreferences.audioLanguage,
+          ),
+        );
+        if (playerAudioIntentChanged(
+          previousLanguage: previousAudioLanguage,
+          previousPreferenceSet: previousAudioPreferenceSet,
+          nextLanguage: _seriesPreferences.audioLanguage,
+          nextPreferenceSet: _seriesPreferences.audioPreferenceSet,
+        )) {
+          _invalidateNextEpisodePreparation();
+        }
+        applied = true;
+      }),
     );
-    _seriesPreferences = _seriesPreferences.copyWith(
-      audioLanguage: selectedLanguage,
-      audioPreferenceSet: true,
-    );
-    _watchPartyPlayback.updateRequestedAudio(_effectiveAudioPreference);
-    _publishWatchPartyPlayback();
-    await _saveSeriesPreferences();
-    _recordDiagnosticAudioTrackSelected(
-      track: selected,
-      tracks: tracks,
-      preferenceMatched: playerTrackMatchesAudioLanguage(
-        selected,
-        _seriesPreferences.audioLanguage,
-      ),
-    );
-    if (playerAudioIntentChanged(
-      previousLanguage: previousAudioLanguage,
-      previousPreferenceSet: previousAudioPreferenceSet,
-      nextLanguage: _seriesPreferences.audioLanguage,
-      nextPreferenceSet: _seriesPreferences.audioPreferenceSet,
-    )) {
-      _invalidateNextEpisodePreparation();
-    }
+    if (!applied) return;
     _showTrackMessage(
       'Audio: ${selected.title ?? selected.language ?? 'Track ${selected.id}'}',
     );
@@ -5380,6 +5857,7 @@ class _MpvTvPlayerScreenState extends ConsumerState<MpvTvPlayerScreen> {
 
   Future<void> _openSubtitleTrackPicker() async {
     if (_blockGuestLocalControl()) return;
+    final mediaRevision = _mediaOpenRevision;
     _controlsTimer?.cancel();
     _showTrackMessage('Checking embedded and external captions…');
     final discovered = await _withHudAutoHideSuspended(
@@ -5394,13 +5872,16 @@ class _MpvTvPlayerScreenState extends ConsumerState<MpvTvPlayerScreen> {
         },
         signature: mediaKitSubtitleTrackSignature,
         hasTracks: (tracks) => tracks.isNotEmpty,
-        maximumWait:
-            _currentStream.externalSubtitle != null || widget.subtitle != null
+        maximumWait: _currentStream.externalSubtitle != null
             ? const Duration(seconds: 4)
             : const Duration(seconds: 3),
       ),
     );
-    if (!mounted || _engineHandoffInProgress) return;
+    if (!mounted ||
+        _engineHandoffInProgress ||
+        mediaRevision != _mediaOpenRevision) {
+      return;
+    }
     if (_blockGuestLocalControl()) {
       _showControls(focusControls: true);
       return;
@@ -5449,7 +5930,7 @@ class _MpvTvPlayerScreenState extends ConsumerState<MpvTvPlayerScreen> {
             .toList(growable: false),
       ),
     );
-    if (!mounted) return;
+    if (!mounted || mediaRevision != _mediaOpenRevision) return;
     if (_blockGuestLocalControl()) {
       _showControls(focusControls: true);
       return;
@@ -5459,20 +5940,61 @@ class _MpvTvPlayerScreenState extends ConsumerState<MpvTvPlayerScreen> {
       return;
     }
     final selected = tracks.firstWhere((track) => track.id == selectedId);
-    _preferredSubtitleSelected = true;
-    final selectedLanguage = canonicalPlayerTrackLanguage(
-      language: selected.language,
-      title: selected.title,
-    );
-    _seriesPreferences = _seriesPreferences.copyWith(
-      subtitleLanguage: selectedLanguage.isEmpty
-          ? _seriesPreferences.subtitleLanguage
-          : selectedLanguage,
-      subtitleEnabled: selected.id != 'no',
-      subtitlePreferenceSet: true,
-    );
-    await _player.setSubtitleTrack(selected);
-    await _saveSeriesPreferences();
+    if (_engineHandoffInProgress || !_canApplyTrackSelection) return;
+    var applied = false;
+    try {
+      await _trackPlayerMutation(
+        () => _serializeMediaOpen(() async {
+          if (!mounted ||
+              _engineHandoffInProgress ||
+              mediaRevision != _mediaOpenRevision ||
+              !_canApplyTrackSelection) {
+            return;
+          }
+          await _player.setSubtitleTrack(selected);
+          if (!mounted || _engineHandoffInProgress) return;
+          if (mediaRevision != _mediaOpenRevision || !_canApplyTrackSelection) {
+            return;
+          }
+          _preferredSubtitleSelected = true;
+          final selectedLanguage = canonicalPlayerTrackLanguage(
+            language: selected.language,
+            title: selected.title,
+          );
+          _seriesPreferences = _seriesPreferences.copyWith(
+            subtitleLanguage: selectedLanguage.isEmpty
+                ? _seriesPreferences.subtitleLanguage
+                : selectedLanguage,
+            subtitleEnabled: selected.id != 'no',
+            subtitlePreferenceSet: true,
+          );
+          if (_catalogAnilistMediaId == null || !_seriesPreferencesReady) {
+            await ref
+                .read(settingsPreferencesProvider.notifier)
+                .setPreferredCaptionSelection(
+                  mode: selected.id == 'no'
+                      ? PreferredCaptionMode.disabled
+                      : PreferredCaptionMode.enabled,
+                  language: selectedLanguage.isEmpty
+                      ? _seriesPreferences.subtitleLanguage
+                      : selectedLanguage,
+                );
+          } else {
+            await _saveSeriesPreferences();
+          }
+          _invalidateNextEpisodePreparation();
+          applied = true;
+        }),
+      );
+    } catch (error, stackTrace) {
+      if (mounted && !_engineHandoffInProgress) {
+        debugPrint('MPV caption preference failed: $error\n$stackTrace');
+        _showTrackMessage('Could not change captions. Please try again.');
+        _showControls();
+      }
+      return;
+    }
+    if (!applied) return;
     _showTrackMessage(
       selected.id == 'no'
           ? 'Subtitles: Off'

--- a/lib/features/settings/application/settings_preferences_controller.dart
+++ b/lib/features/settings/application/settings_preferences_controller.dart
@@ -45,6 +45,8 @@ const _clickSoundsKey = 'audio_click_sounds';
 const _defaultLandingPageKey = 'navigation_default_landing_page';
 const _preferredPlayerKey = 'player_preferred_engine';
 const _preferredAudioKey = 'player_preferred_audio';
+const _preferredCaptionsKey = 'player_preferred_captions';
+const _preferredCaptionLanguageKey = 'player_preferred_caption_language';
 const _anonymousCrashReportingKey = 'privacy_anonymous_crash_reporting';
 const _anonymousUsageCountKey = 'privacy_anonymous_usage_count';
 const _debridStreamSortKey = 'streaming_debrid_sort';
@@ -273,6 +275,42 @@ extension PreferredPlayerLabel on PreferredPlayer {
   };
 }
 
+/// Controls how captions are initialized when playback starts.
+///
+/// [automatic] leaves caption selection to the series preference and the
+/// player. [enabled] and [disabled] are explicit global defaults that apply
+/// when a series has no user-selected caption preference yet.
+enum PreferredCaptionMode { automatic, enabled, disabled }
+
+/// Selects the language used while a private media server prepares caption
+/// capabilities. A viewer's explicit per-series choice remains authoritative;
+/// otherwise only the global On mode carries its remembered language into
+/// preparation. Automatic and Off preserve the existing series/default value.
+String preferredCaptionLanguageForPreparation({
+  required String seriesLanguage,
+  required bool seriesPreferenceSet,
+  required PreferredCaptionMode globalMode,
+  required String globalLanguage,
+}) => !seriesPreferenceSet && globalMode == PreferredCaptionMode.enabled
+    ? globalLanguage
+    : seriesLanguage;
+
+extension PreferredCaptionModeLabel on PreferredCaptionMode {
+  String get displayName => switch (this) {
+    PreferredCaptionMode.automatic => 'Automatic',
+    PreferredCaptionMode.enabled => 'On',
+    PreferredCaptionMode.disabled => 'Off',
+  };
+
+  String get description => switch (this) {
+    PreferredCaptionMode.automatic =>
+      'Remember each show\'s caption choice when available.',
+    PreferredCaptionMode.enabled =>
+      'Start captions on when a matching track is available.',
+    PreferredCaptionMode.disabled => 'Start playback with captions off.',
+  };
+}
+
 /// Legacy single-value Auto Pick source constraint.
 ///
 /// New code should use [AutoPickSourcePriority] and
@@ -424,6 +462,8 @@ class SettingsPreferences {
     this.defaultLandingPage = LandingPage.home,
     this.preferredPlayer = PreferredPlayer.mpv,
     this.preferredAudio = PlaybackAudioPreference.dub,
+    this.preferredCaptionMode = PreferredCaptionMode.automatic,
+    this.preferredCaptionLanguage = 'eng',
     this.debridStreamSort = DebridStreamSort.bestQuality,
     this.streamSourcePriority = StreamSourcePriority.debridFirst,
     this.webStreamQuality = WebStreamQualityPreference.bestAvailable,
@@ -495,6 +535,8 @@ class SettingsPreferences {
   final LandingPage defaultLandingPage;
   final PreferredPlayer preferredPlayer;
   final PlaybackAudioPreference preferredAudio;
+  final PreferredCaptionMode preferredCaptionMode;
+  final String preferredCaptionLanguage;
   final DebridStreamSort debridStreamSort;
   final StreamSourcePriority streamSourcePriority;
   final WebStreamQualityPreference webStreamQuality;
@@ -576,6 +618,8 @@ class SettingsPreferences {
     LandingPage? defaultLandingPage,
     PreferredPlayer? preferredPlayer,
     PlaybackAudioPreference? preferredAudio,
+    PreferredCaptionMode? preferredCaptionMode,
+    String? preferredCaptionLanguage,
     DebridStreamSort? debridStreamSort,
     StreamSourcePriority? streamSourcePriority,
     WebStreamQualityPreference? webStreamQuality,
@@ -641,6 +685,10 @@ class SettingsPreferences {
     defaultLandingPage: defaultLandingPage ?? this.defaultLandingPage,
     preferredPlayer: preferredPlayer ?? this.preferredPlayer,
     preferredAudio: preferredAudio ?? this.preferredAudio,
+    preferredCaptionMode: preferredCaptionMode ?? this.preferredCaptionMode,
+    preferredCaptionLanguage: preferredCaptionLanguage == null
+        ? this.preferredCaptionLanguage
+        : _normalizePreferredCaptionLanguage(preferredCaptionLanguage),
     debridStreamSort: debridStreamSort ?? this.debridStreamSort,
     streamSourcePriority: streamSourcePriority ?? this.streamSourcePriority,
     webStreamQuality: webStreamQuality ?? this.webStreamQuality,
@@ -723,6 +771,8 @@ final _strictPreferencePersistenceZoneKey = Object();
 
 const _phoneSetupPreferenceKeys = [
   _preferredAudioKey,
+  _preferredCaptionsKey,
+  _preferredCaptionLanguageKey,
   _builtInKeyboardKey,
   _autoSkipIntrosKey,
   _autoSkipOutrosKey,
@@ -910,6 +960,12 @@ class SettingsPreferencesController extends StateNotifier<SettingsPreferences> {
       // The feature-wide offline-download switch is append-only. Missing
       // values intentionally migrate existing installs to enabled.
       _safeRead(_offlineDownloadsEnabledKey),
+      // Preferred captions is append-only so every earlier storage index
+      // remains migration-safe.
+      _safeRead(_preferredCaptionsKey),
+      // The hidden preferred caption language follows the caption mode and is
+      // append-only so older storage positions never shift.
+      _safeRead(_preferredCaptionLanguageKey),
     ]);
 
     bool canRestore(String key, int index) {
@@ -1264,6 +1320,22 @@ class SettingsPreferencesController extends StateNotifier<SettingsPreferences> {
     if (canRestore(_offlineDownloadsEnabledKey, 57)) {
       restored = restored.copyWith(
         offlineDownloadsEnabled: valueAt(57) != 'false',
+      );
+    }
+    if (canRestore(_preferredCaptionsKey, 58)) {
+      restored = restored.copyWith(
+        preferredCaptionMode: _enumByName(
+          PreferredCaptionMode.values,
+          valueAt(58),
+          PreferredCaptionMode.automatic,
+        ),
+      );
+    }
+    if (canRestore(_preferredCaptionLanguageKey, 59)) {
+      restored = restored.copyWith(
+        preferredCaptionLanguage: _normalizePreferredCaptionLanguage(
+          valueAt(59),
+        ),
       );
     }
     if (restored.preferredPlayer == PreferredPlayer.external &&
@@ -1626,6 +1698,33 @@ class SettingsPreferencesController extends StateNotifier<SettingsPreferences> {
     {_preferredAudioKey: value.name},
   );
 
+  Future<void> setPreferredCaptionMode(PreferredCaptionMode value) => _update(
+    state.copyWith(preferredCaptionMode: value),
+    {_preferredCaptionsKey: value.name},
+  );
+
+  /// Persists a manual player caption choice as one ordered state mutation.
+  ///
+  /// The language is intentionally hidden from Settings UI. It lets private
+  /// and non-catalog playback retain the viewer's most recent safe language
+  /// code while the visible Preferred CC control remains Automatic/On/Off.
+  Future<void> setPreferredCaptionSelection({
+    required PreferredCaptionMode mode,
+    required String language,
+  }) {
+    final normalizedLanguage = _normalizePreferredCaptionLanguage(language);
+    return _update(
+      state.copyWith(
+        preferredCaptionMode: mode,
+        preferredCaptionLanguage: normalizedLanguage,
+      ),
+      {
+        _preferredCaptionsKey: mode.name,
+        _preferredCaptionLanguageKey: normalizedLanguage,
+      },
+    );
+  }
+
   Future<void> setDebridStreamSort(DebridStreamSort value) => _update(
     state.copyWith(debridStreamSort: value),
     {_debridStreamSortKey: value.name},
@@ -1922,6 +2021,8 @@ class SettingsPreferencesController extends StateNotifier<SettingsPreferences> {
       _seekForwardSecondsKey,
       _preferredPlayerKey,
       _preferredAudioKey,
+      _preferredCaptionsKey,
+      _preferredCaptionLanguageKey,
       _showFillerIndicatorsKey,
       _externalPlayerEnabledKey,
       _externalPlayerPackageKey,
@@ -1941,6 +2042,8 @@ class SettingsPreferencesController extends StateNotifier<SettingsPreferences> {
       seekForwardSeconds: defaults.seekForwardSeconds,
       preferredPlayer: defaults.preferredPlayer,
       preferredAudio: defaults.preferredAudio,
+      preferredCaptionMode: defaults.preferredCaptionMode,
+      preferredCaptionLanguage: defaults.preferredCaptionLanguage,
       showFillerIndicators: defaults.showFillerIndicators,
       showTitleStyle: defaults.showTitleStyle,
       externalPlayerEnabled: defaults.externalPlayerEnabled,
@@ -2007,6 +2110,11 @@ int _seekValue(String? value) {
 
 T _enumByName<T extends Enum>(List<T> values, String? name, T fallback) =>
     values.where((value) => value.name == name).firstOrNull ?? fallback;
+
+String _normalizePreferredCaptionLanguage(String? value) {
+  final normalized = value?.trim().toLowerCase() ?? '';
+  return RegExp(r'^[a-z]{2,3}$').hasMatch(normalized) ? normalized : 'eng';
+}
 
 String _encodeEnumPriority<T extends Enum>(Iterable<T> values) =>
     values.map((value) => value.name).join(',');

--- a/lib/features/settings/presentation/accounts_screen.dart
+++ b/lib/features/settings/presentation/accounts_screen.dart
@@ -221,6 +221,10 @@ extension _SettingsSectionMetadata on _SettingsSection {
     _SettingsSection.closedCaptions => const [
       'Closed captions',
       'Subtitles',
+      'Preferred CC',
+      'Caption default',
+      'Captions on',
+      'Captions off',
       'Text color',
       'Caption background',
       'Text size',
@@ -533,6 +537,9 @@ class _AccountsScreenState extends ConsumerState<AccountsScreen> {
   );
   final _closedCaptionsSectionFocus = FocusNode(
     debugLabel: 'accounts.section.closed-captions',
+  );
+  final _preferredCaptionsFocus = FocusNode(
+    debugLabel: 'accounts.captions.preference',
   );
   final _captionTextColorFocus = FocusNode(
     debugLabel: 'accounts.captions.text-color',
@@ -847,7 +854,7 @@ class _AccountsScreenState extends ConsumerState<AccountsScreen> {
         _SettingsSection.inputFeedback => _inputFeedbackSectionFocus,
         _SettingsSection.homeShelves => _firstHomeShelfFocusNode,
         _SettingsSection.navigation => _navigationSizeFocus,
-        _SettingsSection.closedCaptions => _captionTextColorFocus,
+        _SettingsSection.closedCaptions => _preferredCaptionsFocus,
         _SettingsSection.playerControls => _playerControlsSectionFocus,
         _SettingsSection.debridStreaming => _debridProviderFocus,
         _SettingsSection.sourcesStreamOrder => _debridStreamsFocus,
@@ -1011,6 +1018,10 @@ class _AccountsScreenState extends ConsumerState<AccountsScreen> {
       'navigation size' => _navigationSizeFocus,
       'menu order' || 'settings placement' => _menuOrderFocus,
       'reset appearance and navigation' => _customizationResetFocus,
+      'preferred cc' ||
+      'caption default' ||
+      'captions on' ||
+      'captions off' => _preferredCaptionsFocus,
       'text color' => _captionTextColorFocus,
       'text size' => _captionTextSizeFocus,
       'default player' => _playerControlsSectionFocus,
@@ -1225,6 +1236,7 @@ class _AccountsScreenState extends ConsumerState<AccountsScreen> {
     _inputFeedbackSectionFocus.dispose();
     _clickSoundsFocus.dispose();
     _closedCaptionsSectionFocus.dispose();
+    _preferredCaptionsFocus.dispose();
     _captionTextColorFocus.dispose();
     _captionTextSizeFocus.dispose();
     _playerControlsSectionFocus.dispose();
@@ -1404,6 +1416,7 @@ class _AccountsScreenState extends ConsumerState<AccountsScreen> {
       _inputFeedbackSectionFocus,
       _clickSoundsFocus,
       _closedCaptionsSectionFocus,
+      _preferredCaptionsFocus,
       _captionTextColorFocus,
       _captionTextSizeFocus,
       _playerControlsSectionFocus,
@@ -1509,7 +1522,7 @@ class _AccountsScreenState extends ConsumerState<AccountsScreen> {
             ? activeSectionNodes.first
             : switch (_activeArea) {
                 _SettingsArea.appearance => _customizationFocus,
-                _SettingsArea.playback => _captionTextColorFocus,
+                _SettingsArea.playback => _preferredCaptionsFocus,
                 _SettingsArea.services => _debridProviderFocus,
                 _SettingsArea.accounts => _trackingProviderFocus,
                 _SettingsArea.system => _setupFocus,
@@ -1746,14 +1759,21 @@ class _AccountsScreenState extends ConsumerState<AccountsScreen> {
             _expandedCustomizationSections.contains(
               _CustomizationSection.closedCaptions,
             )
-            ? _captionTextColorFocus
+            ? _preferredCaptionsFocus
             : _playerControlsSectionFocus;
       }
-    } else if (current == _captionTextColorFocus) {
+    } else if (current == _preferredCaptionsFocus) {
       if (key == LogicalKeyboardKey.arrowUp) {
         target = _activeArea == _SettingsArea.playback
             ? _areaFocusNodes[_SettingsArea.playback]
             : _closedCaptionsSectionFocus;
+      }
+      if (key == LogicalKeyboardKey.arrowDown) {
+        target = _captionTextColorFocus;
+      }
+    } else if (current == _captionTextColorFocus) {
+      if (key == LogicalKeyboardKey.arrowUp) {
+        target = _preferredCaptionsFocus;
       }
     } else if (current == _captionTextSizeFocus) {
       if (key == LogicalKeyboardKey.arrowDown && tvListLayout) {
@@ -1767,7 +1787,7 @@ class _AccountsScreenState extends ConsumerState<AccountsScreen> {
           _CustomizationSection.closedCaptions,
         )) {
           target = _activeArea == _SettingsArea.playback
-              ? _captionTextColorFocus
+              ? _preferredCaptionsFocus
               : _closedCaptionsSectionFocus;
         }
       }
@@ -2463,6 +2483,7 @@ class _AccountsScreenState extends ConsumerState<AccountsScreen> {
       topNavigationRowFocusNodes: _topNavigationRowFocusNodes,
       inputFeedbackSectionFocusNode: _inputFeedbackSectionFocus,
       closedCaptionsSectionFocusNode: _closedCaptionsSectionFocus,
+      preferredCaptionsFocusNode: _preferredCaptionsFocus,
       captionTextColorFocusNode: _captionTextColorFocus,
       captionTextSizeFocusNode: _captionTextSizeFocus,
       playerControlsSectionFocusNode: _playerControlsSectionFocus,
@@ -5496,6 +5517,7 @@ class _CustomizationPanel extends StatelessWidget {
     required this.topNavigationRowFocusNodes,
     required this.inputFeedbackSectionFocusNode,
     required this.closedCaptionsSectionFocusNode,
+    required this.preferredCaptionsFocusNode,
     required this.captionTextColorFocusNode,
     required this.captionTextSizeFocusNode,
     required this.playerControlsSectionFocusNode,
@@ -5528,6 +5550,7 @@ class _CustomizationPanel extends StatelessWidget {
   final Map<TopNavigationDestination, FocusNode> topNavigationRowFocusNodes;
   final FocusNode inputFeedbackSectionFocusNode;
   final FocusNode closedCaptionsSectionFocusNode;
+  final FocusNode preferredCaptionsFocusNode;
   final FocusNode captionTextColorFocusNode;
   final FocusNode captionTextSizeFocusNode;
   final FocusNode playerControlsSectionFocusNode;
@@ -5832,7 +5855,7 @@ class _CustomizationPanel extends StatelessWidget {
                 ? 'CAPTION OPTIONS'
                 : 'CLOSED CAPTIONS',
             focusNode: closedCaptionsSectionFocusNode,
-            firstChildFocusNode: captionTextColorFocusNode,
+            firstChildFocusNode: preferredCaptionsFocusNode,
             expanded: expandedSections.contains(
               _CustomizationSection.closedCaptions,
             ),
@@ -5844,6 +5867,24 @@ class _CustomizationPanel extends StatelessWidget {
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
                 const SizedBox(height: 6),
+                _AppearanceSelectionRow<PreferredCaptionMode>(
+                  key: const ValueKey('settings-preferred-cc'),
+                  label: 'Preferred CC',
+                  icon: Icons.closed_caption_rounded,
+                  value: preferences.preferredCaptionMode,
+                  valueLabel: preferences.preferredCaptionMode.displayName,
+                  focusNode: preferredCaptionsFocusNode,
+                  options: [
+                    for (final mode in PreferredCaptionMode.values)
+                      _SettingsOption(
+                        value: mode,
+                        label: mode.displayName,
+                        detail: mode.description,
+                      ),
+                  ],
+                  showDivider: true,
+                  onSelected: controller.setPreferredCaptionMode,
+                ),
                 _AppearanceSelectionRow<int>(
                   label: 'Text color',
                   icon: Icons.format_color_text_rounded,

--- a/lib/features/streaming/application/next_episode_preparation_controller.dart
+++ b/lib/features/streaming/application/next_episode_preparation_controller.dart
@@ -1254,6 +1254,7 @@ class NextEpisodePreparationController {
           displayName: release.releaseName,
           headers: validated.headers,
           externalSubtitle: validated.subtitleUri,
+          externalSubtitleLanguage: candidate.subtitleLanguage,
           mediaContentType: validated.contentType,
           subtitleContentType: validated.subtitleContentType,
           externalSubtitleRejected: validated.subtitleRejected,
@@ -1453,6 +1454,12 @@ class _PreparationSlot {
           other.seriesPreferences.audioLanguage &&
       request.seriesPreferences.audioPreferenceSet ==
           other.seriesPreferences.audioPreferenceSet &&
+      request.seriesPreferences.subtitleLanguage ==
+          other.seriesPreferences.subtitleLanguage &&
+      request.seriesPreferences.subtitleEnabled ==
+          other.seriesPreferences.subtitleEnabled &&
+      request.seriesPreferences.subtitlePreferenceSet ==
+          other.seriesPreferences.subtitlePreferenceSet &&
       request.seriesPreferences.preferredStreamLanguage ==
           other.seriesPreferences.preferredStreamLanguage &&
       request.seriesPreferences.preferredQuality ==
@@ -1634,6 +1641,7 @@ PlaybackStreamOption _optionForWebStream(WebStreamResult result) {
       displayName: release.releaseName,
       headers: result.headers,
       externalSubtitle: result.subtitleUri,
+      externalSubtitleLanguage: result.subtitleLanguage,
       providerId: result.providerId,
       providerName: '${result.providerName} web stream',
       providerEpisodeIdentity: ProviderEpisodeIdentity.fromFields(

--- a/lib/features/streaming/domain/stream_resolver.dart
+++ b/lib/features/streaming/domain/stream_resolver.dart
@@ -173,6 +173,7 @@ class StreamReady extends StreamResolution {
     this.debridService,
     this.headers = const {},
     this.externalSubtitle,
+    this.externalSubtitleLanguage,
     this.mediaContentType,
     this.subtitleContentType,
     this.externalSubtitleRejected = false,
@@ -189,6 +190,7 @@ class StreamReady extends StreamResolution {
   final DebridService? debridService;
   final Map<String, String> headers;
   final Uri? externalSubtitle;
+  final String? externalSubtitleLanguage;
   final String? mediaContentType;
   final String? subtitleContentType;
   final bool externalSubtitleRejected;

--- a/lib/features/streaming/presentation/resolve_episode_screen.dart
+++ b/lib/features/streaming/presentation/resolve_episode_screen.dart
@@ -634,6 +634,16 @@ class _ResolveEpisodeScreenState extends ConsumerState<ResolveEpisodeScreen> {
   SettingsPreferences get _streamPreferences =>
       ref.read(settingsPreferencesProvider);
 
+  String get _preferredSubtitleLanguageForPreparation {
+    final settings = _streamPreferences;
+    return preferredCaptionLanguageForPreparation(
+      seriesLanguage: _seriesPreferences.subtitleLanguage,
+      seriesPreferenceSet: _seriesPreferences.subtitlePreferenceSet,
+      globalMode: settings.preferredCaptionMode,
+      globalLanguage: settings.preferredCaptionLanguage,
+    );
+  }
+
   bool get _autoPickActive =>
       _autoPickEnabledForOpen && !_autoPickManualFallback;
 
@@ -2314,6 +2324,7 @@ class _ResolveEpisodeScreenState extends ConsumerState<ResolveEpisodeScreen> {
       externalSubtitle: validatedUri == null
           ? stream.subtitleUri
           : validatedSubtitleUri,
+      externalSubtitleLanguage: stream.subtitleLanguage,
       mediaContentType: mediaContentType,
       subtitleContentType: subtitleContentType,
       externalSubtitleRejected: externalSubtitleRejected,
@@ -2823,7 +2834,7 @@ class _ResolveEpisodeScreenState extends ConsumerState<ResolveEpisodeScreen> {
       var request = await service.preparePlayback(
         source,
         watchPartyIdentity: _libraryWatchPartyIdentity,
-        preferredSubtitleLanguage: _seriesPreferences.subtitleLanguage,
+        preferredSubtitleLanguage: _preferredSubtitleLanguageForPreparation,
         requestedAudio: requestedAudio,
       );
       if (!mounted ||
@@ -2859,7 +2870,7 @@ class _ResolveEpisodeScreenState extends ConsumerState<ResolveEpisodeScreen> {
         request = await service.preparePlayback(
           source,
           watchPartyIdentity: _libraryWatchPartyIdentity,
-          preferredSubtitleLanguage: _seriesPreferences.subtitleLanguage,
+          preferredSubtitleLanguage: _preferredSubtitleLanguageForPreparation,
           requestedAudio: requestedAudio,
           forceCompatibility: true,
         );

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: 'none'
 # Public and Beta artifacts built from the same source use one monotonically
 # increasing Android versionCode. The project default carries the Beta display
 # version; the Public universal APK overrides the build name to the 1.x line.
-version: 2.0.52+410029
+version: 2.0.53+410030
 
 environment:
   sdk: ^3.12.2

--- a/test/accounts_focus_test.dart
+++ b/test/accounts_focus_test.dart
@@ -506,6 +506,25 @@ void main() {
         FocusManager.instance.primaryFocus?.debugLabel,
         'accounts.system.diagnostics',
       );
+
+      await tester.tap(editable);
+      await tester.pumpAndSettle();
+      await tester.enterText(editable, 'Preferred CC');
+      await tester.pumpAndSettle();
+      final captionResult = find.byKey(
+        const ValueKey('settings-search-result-closed-captions-preferred-cc'),
+      );
+      expect(captionResult, findsOneWidget);
+      await tester.tap(captionResult);
+      await tester.pumpAndSettle();
+      expect(
+        find.byKey(const ValueKey('settings-section-content-closed-captions')),
+        findsOneWidget,
+      );
+      expect(
+        FocusManager.instance.primaryFocus?.debugLabel,
+        'accounts.captions.preference',
+      );
       expect(tester.takeException(), isNull);
     },
   );
@@ -825,6 +844,78 @@ void main() {
     expect(find.text('Theme Studio'), findsOneWidget);
     expect(find.text('Title language'), findsOneWidget);
     expect(find.text('Show title style'), findsOneWidget);
+    await tester.tap(find.text('Playback'));
+    await tester.pumpAndSettle();
+    expect(find.byKey(const ValueKey('settings-preferred-cc')), findsOneWidget);
+    expect(find.text('Preferred CC'), findsOneWidget);
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('Preferred CC selector updates and restores the saved setting', (
+    tester,
+  ) async {
+    FlutterSecureStorage.setMockInitialValues({});
+    tester.view.physicalSize = const Size(390, 844);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    Widget buildSettings() => ProviderScope(
+      overrides: [isTelevisionProvider.overrideWithValue(false)],
+      child: const MaterialApp(home: AccountsScreen()),
+    );
+
+    await tester.pumpWidget(buildSettings());
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Playback'));
+    await tester.pumpAndSettle();
+
+    final preferredCc = find.byKey(const ValueKey('settings-preferred-cc'));
+    expect(
+      find.descendant(of: preferredCc, matching: find.text('Automatic')),
+      findsOneWidget,
+    );
+    await tester.tap(preferredCc);
+    await tester.pumpAndSettle();
+
+    final dialog = find.byType(Dialog);
+    expect(dialog, findsOneWidget);
+    await tester.tap(find.descendant(of: dialog, matching: find.text('On')));
+    await tester.pumpAndSettle();
+
+    var container = ProviderScope.containerOf(
+      tester.element(find.byType(AccountsScreen)),
+    );
+    expect(
+      container.read(settingsPreferencesProvider).preferredCaptionMode,
+      PreferredCaptionMode.enabled,
+    );
+    expect(
+      find.descendant(of: preferredCc, matching: find.text('On')),
+      findsOneWidget,
+    );
+
+    await tester.pumpWidget(const SizedBox.shrink());
+    await tester.pumpAndSettle();
+    await tester.pumpWidget(buildSettings());
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Playback'));
+    await tester.pumpAndSettle();
+
+    container = ProviderScope.containerOf(
+      tester.element(find.byType(AccountsScreen)),
+    );
+    expect(
+      container.read(settingsPreferencesProvider).preferredCaptionMode,
+      PreferredCaptionMode.enabled,
+    );
+    expect(
+      find.descendant(
+        of: find.byKey(const ValueKey('settings-preferred-cc')),
+        matching: find.text('On'),
+      ),
+      findsOneWidget,
+    );
     expect(tester.takeException(), isNull);
   });
 
@@ -1607,6 +1698,7 @@ void main() {
       findsOneWidget,
     );
     expect(find.text('Text color'), findsOneWidget);
+    expect(find.text('Preferred CC'), findsOneWidget);
     expect(find.text('Default player'), findsOneWidget);
 
     final playbackTab = tester.widget<TvFocusable>(
@@ -1625,9 +1717,21 @@ void main() {
     await tester.pumpAndSettle();
     expect(
       FocusManager.instance.primaryFocus?.debugLabel,
-      'accounts.captions.text-color',
+      'accounts.captions.preference',
     );
 
+    await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
+    await tester.pumpAndSettle();
+    expect(
+      FocusManager.instance.primaryFocus?.debugLabel,
+      'accounts.captions.text-color',
+    );
+    await tester.sendKeyEvent(LogicalKeyboardKey.arrowUp);
+    await tester.pumpAndSettle();
+    expect(
+      FocusManager.instance.primaryFocus?.debugLabel,
+      'accounts.captions.preference',
+    );
     await tester.sendKeyEvent(LogicalKeyboardKey.arrowUp);
     await tester.pumpAndSettle();
     expect(

--- a/test/local_media_tv_navigation_test.dart
+++ b/test/local_media_tv_navigation_test.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:anime_tv/core/platform/android_tv_bridge.dart';
+import 'package:anime_tv/core/preferences/playback_audio_preference.dart';
 import 'package:anime_tv/features/local_media/application/local_media_controller.dart';
 import 'package:anime_tv/features/local_media/application/plex_controller.dart';
 import 'package:anime_tv/features/local_media/application/unified_media_search_controller.dart';
@@ -9,6 +10,7 @@ import 'package:anime_tv/features/local_media/data/plex_client.dart';
 import 'package:anime_tv/features/local_media/domain/jellyfin_models.dart';
 import 'package:anime_tv/features/local_media/domain/plex_models.dart';
 import 'package:anime_tv/features/local_media/presentation/local_media_screen.dart';
+import 'package:anime_tv/features/player/domain/library_playback_request.dart';
 import 'package:anime_tv/features/settings/application/settings_preferences_controller.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
@@ -289,6 +291,39 @@ void main() {
     );
     expect(tester.takeException(), isNull);
   });
+
+  testWidgets(
+    'direct Jellyfin browse prepares the globally remembered On language',
+    (tester) async {
+      LibraryPlaybackRequest? openedRequest;
+      final harness = await _pumpMedia(
+        tester,
+        mode: InterfaceMode.television,
+        localState: _connectedJellyfinState(itemCount: 1),
+        settings: const SettingsPreferences(
+          loaded: true,
+          interfaceMode: InterfaceMode.television,
+          preferredCaptionMode: PreferredCaptionMode.enabled,
+          preferredCaptionLanguage: 'spa',
+        ),
+        openLibraryPlayer: (request) async {
+          openedRequest = request;
+        },
+      );
+
+      await tester.scrollUntilVisible(
+        find.byKey(const ValueKey('jellyfin-item-item-0')),
+        250,
+        scrollable: find.byType(Scrollable).first,
+      );
+      await tester.pumpAndSettle();
+      await tester.tap(find.byKey(const ValueKey('jellyfin-item-item-0')));
+      await tester.pumpAndSettle();
+
+      expect(harness.local.preferredSubtitleLanguage, 'spa');
+      expect(openedRequest, isNotNull);
+    },
+  );
 }
 
 Future<
@@ -305,6 +340,8 @@ _pumpMedia(
   PlexState plexState = const PlexState(loaded: true),
   UnifiedMediaSearchState searchState = const UnifiedMediaSearchState(),
   List<UnifiedMediaSearchItem> nextSearchResults = const [],
+  SettingsPreferences? settings,
+  Future<void> Function(LibraryPlaybackRequest request)? openLibraryPlayer,
 }) async {
   tester.view.physicalSize = const Size(960, 540);
   tester.view.devicePixelRatio = 1;
@@ -327,10 +364,15 @@ _pumpMedia(
         plexControllerProvider.overrideWith((_) => plex),
         unifiedMediaSearchControllerProvider.overrideWith((_) => search),
         settingsPreferencesProvider.overrideWith(
-          (_) => _NavigationSettingsController(storage, mode),
+          (_) => _NavigationSettingsController(
+            storage,
+            settings ?? SettingsPreferences(loaded: true, interfaceMode: mode),
+          ),
         ),
       ],
-      child: const MaterialApp(home: LocalMediaScreen()),
+      child: MaterialApp(
+        home: LocalMediaScreen(openLibraryPlayer: openLibraryPlayer),
+      ),
     ),
   );
   await tester.pumpAndSettle();
@@ -436,11 +478,29 @@ class _NavigationLocalMediaController extends LocalMediaController {
     state = initialState;
   }
 
+  String? preferredSubtitleLanguage;
+
   @override
   Future<void> load() async {}
 
   @override
   Uri? imageUri(JellyfinMediaItem item) => null;
+
+  @override
+  JellyfinPlaybackPlan playbackPlan(
+    JellyfinMediaItem item, {
+    required String playSessionId,
+    String preferredSubtitleLanguage = 'eng',
+    PlaybackAudioPreference? requestedAudio,
+  }) {
+    this.preferredSubtitleLanguage = preferredSubtitleLanguage;
+    return JellyfinPlaybackPlan(
+      uri: Uri.parse('https://jellyfin.example.com/video/${item.id}'),
+      headers: const {},
+      method: JellyfinPlayMethod.directPlay,
+      playSessionId: playSessionId,
+    );
+  }
 
   void replace(LocalMediaState value) => state = value;
 
@@ -530,8 +590,11 @@ class _NavigationSearchController extends UnifiedMediaSearchController {
 }
 
 class _NavigationSettingsController extends SettingsPreferencesController {
-  _NavigationSettingsController(super.storage, InterfaceMode mode) {
-    state = SettingsPreferences(loaded: true, interfaceMode: mode);
+  _NavigationSettingsController(
+    super.storage,
+    SettingsPreferences preferences,
+  ) {
+    state = preferences;
   }
 
   @override

--- a/test/next_episode_preparation_controller_test.dart
+++ b/test/next_episode_preparation_controller_test.dart
@@ -1495,6 +1495,74 @@ void main() {
     await controller.dispose();
   });
 
+  for (final subtitleChange
+      in <
+        ({
+          String label,
+          NextEpisodePreparationRequest preparedRequest,
+          NextEpisodePreparationRequest currentRequest,
+        })
+      >[
+        (
+          label: 'subtitle language',
+          preparedRequest: _request(
+            subtitleLanguage: 'eng',
+            subtitlePreferenceSet: true,
+          ),
+          currentRequest: _request(
+            subtitleLanguage: 'jpn',
+            subtitlePreferenceSet: true,
+          ),
+        ),
+        (
+          label: 'subtitle enabled state',
+          preparedRequest: _request(
+            subtitleEnabled: true,
+            subtitlePreferenceSet: true,
+          ),
+          currentRequest: _request(
+            subtitleEnabled: false,
+            subtitlePreferenceSet: true,
+          ),
+        ),
+        (
+          label: 'subtitle preference-set state',
+          preparedRequest: _request(subtitlePreferenceSet: false),
+          currentRequest: _request(subtitlePreferenceSet: true),
+        ),
+      ]) {
+    test(
+      'changed ${subtitleChange.label} rejects and closes a prepared lease',
+      () async {
+        final lease = _FakeLease();
+        final controller = _controller(
+          releases: [_release(hash: 'subtitle-preference-next')],
+          resolver: (_) => Stream.value(
+            StreamReady(
+              uri: Uri.parse(
+                'https://cdn.example/subtitle-preference-next.mkv',
+              ),
+              displayName: 'Subtitle preference next',
+              debridService: DebridService.realDebrid,
+              playbackLease: lease,
+            ),
+          ),
+        );
+        await controller.warm(subtitleChange.preparedRequest);
+
+        final taken = await controller.take(
+          7,
+          1,
+          currentRequest: subtitleChange.currentRequest,
+        );
+
+        expect(taken, isNull);
+        expect(lease.closeCount, 1);
+        await controller.dispose();
+      },
+    );
+  }
+
   test('replacement waits for old resolver cancellation cleanup', () async {
     final listened = Completer<void>();
     final cleanupGate = Completer<void>();
@@ -1795,6 +1863,9 @@ NextEpisodePreparationRequest _request({
   String currentUri = 'https://cdn.example/episode-1.mkv',
   String? currentWebProviderId,
   String audioLanguage = 'eng',
+  String subtitleLanguage = 'eng',
+  bool subtitleEnabled = true,
+  bool subtitlePreferenceSet = false,
   String? currentProvider = 'Same source',
   String currentSourceId = 'stable-source',
   String currentReleaseName = '[Group] Show - 01 Dual Audio',
@@ -1836,6 +1907,9 @@ NextEpisodePreparationRequest _request({
     seriesPreferences: SeriesPlaybackPreferences(
       audioLanguage: audioLanguage,
       audioPreferenceSet: true,
+      subtitleLanguage: subtitleLanguage,
+      subtitleEnabled: subtitleEnabled,
+      subtitlePreferenceSet: subtitlePreferenceSet,
       skipFillerEpisodes: skipFillerEpisodes,
       preferredQuality: preferredQuality,
       preferredCodec: preferredCodec,

--- a/test/player_lifecycle_safety_test.dart
+++ b/test/player_lifecycle_safety_test.dart
@@ -1,6 +1,7 @@
 import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
+import 'package:anime_tv/features/player/presentation/player_failover_coordinator.dart';
 
 void main() {
   final source = File(
@@ -374,7 +375,7 @@ void main() {
 
       final tracking = method(
         'Future<void> _syncProgress',
-        'Future<void> _openMedia',
+        'Future<bool> _openMedia',
       );
       expect(tracking, contains('if (!_animeFeaturesEnabled'));
 
@@ -472,17 +473,352 @@ void main() {
     expect(privateSafePrefix, isNot(contains('preferredReleaseGroup:')));
   });
 
-  test(
-    'automatic subtitle selection becomes final only after MPV accepts it',
-    () {
-      final selection = method(
-        'Future<void> _selectPreferredTracks',
-        'void _applyAutomaticSubtitleDefaultForRelease',
+  test('generic preference saves preserve explicit caption intent', () {
+    final savePreferences = method(
+      'Future<void> _saveSeriesPreferences()',
+      'Future<void> _saveDecoderPreference()',
+    );
+
+    expect(savePreferences, isNot(contains('_player.state.track.subtitle')));
+    expect(savePreferences, isNot(contains('subtitleLanguage:')));
+    expect(savePreferences, isNot(contains('subtitleEnabled:')));
+    expect(savePreferences, isNot(contains('subtitlePreferenceSet:')));
+    expect(savePreferences, contains('subtitleSize: _subtitleSize'));
+    expect(savePreferences, contains('subtitlePosition: _subtitlePosition'));
+    expect(savePreferences, contains('subtitleDelayMs: _subtitleDelayMs'));
+    expect(
+      savePreferences,
+      contains('_database.saveSeriesPreferences(mediaId, _seriesPreferences)'),
+    );
+  });
+
+  test('every settled media open safely reapplies the caption preference', () {
+    final openCurrentMedia = method(
+      'Future<int?> _openCurrentMedia',
+      'Future<bool> _openMedia',
+    );
+    expectInOrder(openCurrentMedia, [
+      '_preferredAudioSelected = false',
+      '_preferredSubtitleSelected = false',
+      'await _tracksSubscription?.cancel()',
+      'await _player.open(',
+      '_mediaOpenInProgress = false',
+      '_player.stream.tracks.listen(',
+      'await _selectPreferredTracks(_player.state.tracks)',
+    ]);
+
+    final changedTracks = method(
+      'void _onTracksChanged',
+      'Future<void> _applyPreferredAudio',
+    );
+    expect(changedTracks, contains('_player.state.tracks'));
+    expect(changedTracks, isNot(contains('Tracks tracks')));
+    expect(
+      changedTracks,
+      contains('mediaRevision != _mediaOpenRevision'),
+      reason: 'queued events from an old episode cannot select its track IDs',
+    );
+
+    final subtitleSelection = method(
+      'Future<void> _applyPreferredSubtitle',
+      'Future<void> _selectPreferredTracks',
+    );
+    expect(subtitleSelection, contains('_mediaOpenInProgress'));
+    expect(
+      subtitleSelection,
+      contains(
+        'final mediaRevision = expectedMediaRevision ?? _mediaOpenRevision',
+      ),
+    );
+    expect(
+      subtitleSelection,
+      contains('if (!_seriesPreferences.subtitleEnabled)'),
+    );
+    expect(subtitleSelection, contains('SubtitleTrack.no()'));
+    expect(
+      subtitleSelection,
+      contains("_player.state.track.subtitle.id == 'no'"),
+      reason:
+          'a wrong-language default is disabled without locking out a late matching track',
+    );
+    expectInOrder(subtitleSelection, [
+      'if (mediaRevision != _mediaOpenRevision || _mediaOpenInProgress)',
+      'await _player.setSubtitleTrack(',
+      'if (mediaRevision != _mediaOpenRevision',
+      '_preferredSubtitleSelected = true',
+    ]);
+
+    final externalSubtitleRegistration = method(
+      'Future<void> _applySubtitle({',
+      'Future<void> _persistPlayback',
+    );
+    expect(
+      externalSubtitleRegistration,
+      contains('expectedMediaRevision: expectedMediaRevision'),
+      reason:
+          'external captions are published after Player.open, so preference '
+          'selection must be retried after registration',
+    );
+    expect(
+      externalSubtitleRegistration,
+      contains('bool revisionIsActive()'),
+      reason: 'a superseded media open cannot attach its sidecar to the next',
+    );
+    expect(
+      externalSubtitleRegistration,
+      contains('expectedStream.externalSubtitleLanguage'),
+    );
+    expect(
+      externalSubtitleRegistration,
+      isNot(contains('language: _seriesPreferences.subtitleLanguage')),
+      reason:
+          'unknown sidecars must not be relabeled as the requested language',
+    );
+    expect(
+      externalSubtitleRegistration,
+      isNot(contains('widget.subtitle')),
+      reason:
+          'a failover stream without a sidecar must not inherit the initial '
+          'route subtitle',
+    );
+    expect(
+      externalSubtitleRegistration,
+      contains('shouldKeepRegisteredExternalCaption('),
+      reason:
+          'explicit and globally remembered languages cannot be replaced by '
+          'a mismatched sidecar',
+    );
+    expect(
+      externalSubtitleRegistration,
+      contains('.preferredCaptionMode'),
+      reason: 'only Automatic may retain an unknown provider sidecar',
+    );
+  });
+
+  test('superseded opens cannot adopt or publish an obsolete source', () {
+    final openMedia = method(
+      'Future<bool> _openMedia',
+      'Future<void> _trackPlayerMutation',
+    );
+    expect(openMedia, contains('_serializeMediaOpen('));
+    expect(openMedia, contains('final expectedStream = _currentStream'));
+    expect(openMedia, contains('final expectedSource = _source'));
+    expect(openMedia, contains('playerMediaOpenCanCommit('));
+    expectInOrder(openMedia, [
+      'if (!attemptIsActive()) return',
+      '_recordDiagnosticStreamOpenResult(',
+      'opened = true',
+      'return opened',
+    ]);
+
+    for (final adoption in <String>[
+      'await widget.onStreamAdopted(ready, candidate)',
+      'await widget.onStreamAdopted(option.stream, option.release)',
+    ]) {
+      final adoptionOffset = source.indexOf(adoption);
+      expect(adoptionOffset, greaterThanOrEqualTo(0));
+      final beforeAdoption = source.substring(0, adoptionOffset);
+      final gateOffset = beforeAdoption.lastIndexOf('if (!opened ||');
+      expect(
+        gateOffset,
+        greaterThanOrEqualTo(0),
+        reason: '$adoption must be guarded by the active open result',
       );
-      expectInOrder(selection, [
-        'await _player.setSubtitleTrack(preferred)',
-        '_preferredSubtitleSelected = true',
-      ]);
+      final gate = source.substring(gateOffset, adoptionOffset);
+      expect(gate, contains('!failoverIsActive()'));
+      expect(gate, contains('identical(_currentStream,'));
+      expect(adoptionOffset - gateOffset, lessThan(1500));
+    }
+  });
+
+  test('manual source selection cancels an in-flight automatic failover', () {
+    expect(source, contains('int _sourceSelectionGeneration = 0'));
+    expect(source, contains('bool _manualSourceSelectionInProgress = false'));
+    final automatic = method(
+      'Future<void> _tryNextStream',
+      'Future<bool> _switchToNextDirectStream',
+    );
+    expectInOrder(automatic, [
+      'final failoverGeneration = ++_sourceSelectionGeneration',
+      'bool failoverIsActive()',
+      'playerFailoverGenerationIsActive(',
+      'expectedSourceGeneration: failoverGeneration',
+    ]);
+    expect(automatic, contains('_manualSourceSelectionInProgress'));
+
+    final directFailover = method(
+      'Future<bool> _switchToNextDirectStream',
+      'Future<void> _waitForInFlightDirectDiscovery',
+    );
+    expectInOrder(directFailover, [
+      'required int expectedSourceGeneration',
+      'activeGeneration: _sourceSelectionGeneration',
+      'isActive: failoverIsActive',
+    ]);
+
+    final manual = method(
+      'Future<void> _openStreamSourcePicker()',
+      'Future<void> _openPlaybackMenu()',
+    );
+    expectInOrder(manual, [
+      'final manualSelectionStartGeneration = _sourceSelectionGeneration',
+      'await _preflightDirectStream(selected)',
+      'manualSelectionStartGeneration != _sourceSelectionGeneration',
+      '_failingOver',
+      '_manualSourceSelectionInProgress = true',
+      'final manualSourceGeneration = ++_sourceSelectionGeneration',
+      '_currentStream = option.stream',
+      '_manualSourceSelectionInProgress = false',
+    ]);
+
+    expect(
+      playerFailoverGenerationIsActive(
+        expectedGeneration: 3,
+        activeGeneration: 3,
+        manualSourceSelectionInProgress: false,
+      ),
+      isTrue,
+    );
+    expect(
+      playerFailoverGenerationIsActive(
+        expectedGeneration: 3,
+        activeGeneration: 3,
+        manualSourceSelectionInProgress: true,
+      ),
+      isFalse,
+    );
+    expect(
+      playerFailoverGenerationIsActive(
+        expectedGeneration: 3,
+        activeGeneration: 4,
+        manualSourceSelectionInProgress: false,
+      ),
+      isFalse,
+    );
+  });
+
+  test('every unadopted source candidate closes its playback lease', () {
+    final automatic = method(
+      'Future<void> _tryNextStream',
+      'Future<bool> _switchToNextDirectStream',
+    );
+    expectInOrder(automatic, [
+      'if (!opened ||',
+      'await ready.playbackLease?.close()',
+      'resolvedStream = null',
+    ]);
+
+    final directFailover = method(
+      'Future<bool> _switchToNextDirectStream',
+      'Future<void> _waitForInFlightDirectDiscovery',
+    );
+    expectInOrder(directFailover, [
+      'if (!opened ||',
+      'await option.stream.playbackLease?.close()',
+      'preparedOption = null',
+    ]);
+
+    final manual = method(
+      'Future<void> _openStreamSourcePicker()',
+      'Future<void> _openPlaybackMenu()',
+    );
+    expectInOrder(manual, [
+      'if (!opened || !identical(_currentStream, option.stream))',
+      'await option.stream.playbackLease?.close()',
+    ]);
+  });
+
+  test('manual caption choices persist only after MPV accepts them', () {
+    final picker = method(
+      'Future<void> _openSubtitleTrackPicker()',
+      'void _showTrackMessage',
+    );
+    expectInOrder(picker, [
+      'await _trackPlayerMutation(',
+      '_serializeMediaOpen(',
+      'await _player.setSubtitleTrack(selected)',
+      'if (!mounted || _engineHandoffInProgress)',
+      '_preferredSubtitleSelected = true',
+      'final selectedLanguage = canonicalPlayerTrackLanguage(',
+      '_seriesPreferences = _seriesPreferences.copyWith(',
+      'subtitleEnabled: selected.id != \'no\'',
+      'subtitlePreferenceSet: true',
+      'if (_catalogAnilistMediaId == null || !_seriesPreferencesReady)',
+      '.setPreferredCaptionSelection(',
+      'await _saveSeriesPreferences()',
+      '_invalidateNextEpisodePreparation()',
+    ]);
+  });
+
+  test('all automatic and manual track changes share the media-open queue', () {
+    final automatic = method(
+      'Future<void> _runTrackedTrackSelection',
+      'Future<void> _applyPreferredAudio',
+    );
+    expect(automatic, contains('_serializeMediaOpen('));
+    expect(automatic, contains('mediaRevision != _mediaOpenRevision'));
+
+    final audioPicker = method(
+      'Future<void> _openAudioTrackPicker()',
+      'Future<void> _skipCurrentSegment()',
+    );
+    expectInOrder(audioPicker, [
+      'final mediaRevision = _mediaOpenRevision',
+      '_serializeMediaOpen(',
+      'mediaRevision != _mediaOpenRevision',
+      'await _player.setAudioTrack(selected)',
+      'mediaRevision != _mediaOpenRevision',
+      '_preferredAudioSelected = true',
+    ]);
+
+    final captionPicker = method(
+      'Future<void> _openSubtitleTrackPicker()',
+      'void _showTrackMessage',
+    );
+    expectInOrder(captionPicker, [
+      'final mediaRevision = _mediaOpenRevision',
+      '_serializeMediaOpen(',
+      'mediaRevision != _mediaOpenRevision',
+      'await _player.setSubtitleTrack(selected)',
+      'mediaRevision != _mediaOpenRevision',
+      '_preferredSubtitleSelected = true',
+    ]);
+  });
+
+  test('global Preferred CC applies only without a per-series choice', () {
+    final defaults = method(
+      'void _applyCaptionDefaultForRelease',
+      'void _onPosition',
+    );
+    expectInOrder(defaults, [
+      'if (_seriesPreferences.subtitlePreferenceSet) return',
+      'final preferences = ref.read(settingsPreferencesProvider)',
+      'switch (preferences.preferredCaptionMode)',
+      'case PreferredCaptionMode.automatic:',
+      '_applyAutomaticSubtitleDefaultForRelease(release)',
+      'case PreferredCaptionMode.enabled:',
+      'subtitleLanguage: preferences.preferredCaptionLanguage',
+      'subtitleEnabled: true',
+      'case PreferredCaptionMode.disabled:',
+      'subtitleEnabled: false',
+    ]);
+    expect(
+      defaults,
+      isNot(contains('subtitlePreferenceSet: true')),
+      reason: 'a global default must never masquerade as a per-series choice',
+    );
+    expect(
+      RegExp(r'_applyCaptionDefaultForRelease\(').allMatches(source).length,
+      greaterThanOrEqualTo(5),
+      reason:
+          'bootstrap, fallback resolution, direct fallback, and manual source '
+          'selection must all preserve Preferred CC On/Off',
+    );
+  });
+
+  test(
+    'automatic subtitle defaults cannot replace an explicit caption choice',
+    () {
       final defaults = method(
         'void _applyAutomaticSubtitleDefaultForRelease',
         'void _onPosition',

--- a/test/player_preferences_test.dart
+++ b/test/player_preferences_test.dart
@@ -2,14 +2,113 @@ import 'package:anime_tv/features/player/application/audio_track_selector.dart';
 import 'package:anime_tv/core/preferences/playback_audio_preference.dart';
 import 'package:anime_tv/features/player/presentation/player_control_overlay.dart';
 import 'package:anime_tv/features/player/presentation/tv_player_screen.dart';
+import 'package:anime_tv/features/settings/application/settings_preferences_controller.dart';
 import 'package:anime_tv/features/streaming/domain/debrid_service.dart';
 import 'package:anime_tv/features/streaming/domain/release_audio_preference.dart';
 import 'package:anime_tv/features/streaming/domain/stream_resolver.dart';
 import 'package:flutter/services.dart';
+import 'dart:async';
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:media_kit/media_kit.dart';
 
 void main() {
+  test('superseded media open cannot publish success', () async {
+    final firstStream = Object();
+    final secondStream = Object();
+    var activeRevision = 1;
+    Object activeStream = firstStream;
+    final finishFirst = Completer<void>();
+
+    final firstResult = () async {
+      await finishFirst.future;
+      return playerMediaOpenCanCommit(
+        expectedRevision: 1,
+        activeRevision: activeRevision,
+        expectedStream: firstStream,
+        activeStream: activeStream,
+      );
+    }();
+
+    activeRevision = 2;
+    activeStream = secondStream;
+    finishFirst.complete();
+
+    expect(await firstResult, isFalse);
+    expect(
+      playerMediaOpenCanCommit(
+        expectedRevision: 2,
+        activeRevision: activeRevision,
+        expectedStream: secondStream,
+        activeStream: activeStream,
+      ),
+      isTrue,
+    );
+  });
+
+  group('registered external caption selection', () {
+    test('Automatic may keep a provider sidecar with unknown language', () {
+      expect(
+        shouldKeepRegisteredExternalCaption(
+          subtitlesEnabled: true,
+          hasPerSeriesPreference: false,
+          globalMode: PreferredCaptionMode.automatic,
+          externalLanguage: null,
+          requestedLanguage: 'eng',
+        ),
+        isTrue,
+      );
+    });
+
+    test('global On only keeps a sidecar matching the remembered language', () {
+      for (final externalLanguage in <String?>[null, 'jpn']) {
+        expect(
+          shouldKeepRegisteredExternalCaption(
+            subtitlesEnabled: true,
+            hasPerSeriesPreference: false,
+            globalMode: PreferredCaptionMode.enabled,
+            externalLanguage: externalLanguage,
+            requestedLanguage: 'spa',
+          ),
+          isFalse,
+        );
+      }
+      expect(
+        shouldKeepRegisteredExternalCaption(
+          subtitlesEnabled: true,
+          hasPerSeriesPreference: false,
+          globalMode: PreferredCaptionMode.enabled,
+          externalLanguage: 'spa',
+          requestedLanguage: 'spa',
+        ),
+        isTrue,
+      );
+    });
+
+    test('Off and explicit language choices remain authoritative', () {
+      expect(
+        shouldKeepRegisteredExternalCaption(
+          subtitlesEnabled: false,
+          hasPerSeriesPreference: false,
+          globalMode: PreferredCaptionMode.disabled,
+          externalLanguage: 'eng',
+          requestedLanguage: 'eng',
+        ),
+        isFalse,
+      );
+      expect(
+        shouldKeepRegisteredExternalCaption(
+          subtitlesEnabled: true,
+          hasPerSeriesPreference: true,
+          globalMode: PreferredCaptionMode.automatic,
+          externalLanguage: 'jpn',
+          requestedLanguage: 'eng',
+        ),
+        isFalse,
+      );
+    });
+  });
+
   test('opens every supported stream class with MPV', () {
     final web = StreamReady(
       uri: Uri.parse('https://cdn.example.test/episode.m3u8'),

--- a/test/player_stream_source_picker_test.dart
+++ b/test/player_stream_source_picker_test.dart
@@ -44,6 +44,25 @@ void main() {
     expect(unlabeled.release.audioIntent, ReleaseAudioIntent.unknown);
   });
 
+  test('web playback launch preserves external subtitle language metadata', () {
+    final option = playbackOptionForWebStream(
+      WebStreamResult(
+        providerId: 'provider',
+        providerName: 'Provider',
+        title: '1080p',
+        uri: Uri.parse('https://video.example/episode.m3u8'),
+        subtitleUri: Uri.parse('https://video.example/subtitles/es.vtt'),
+        subtitleLanguage: 'Spanish',
+      ),
+    );
+
+    expect(
+      option.stream.externalSubtitle,
+      Uri.parse('https://video.example/subtitles/es.vtt'),
+    );
+    expect(option.stream.externalSubtitleLanguage, 'Spanish');
+  });
+
   test(
     'web playback option preserves structured provider episode identity',
     () {

--- a/test/resolve_episode_screen_test.dart
+++ b/test/resolve_episode_screen_test.dart
@@ -5094,6 +5094,8 @@ void main() {
           webStreamsEnabled: false,
           autoPickSourceEnabled: true,
           autoPickAudio: AutoPickAudio.dubOnly,
+          preferredCaptionMode: PreferredCaptionMode.enabled,
+          preferredCaptionLanguage: 'spa',
         ),
         releases: const [],
         libraryService: libraryService,
@@ -5111,7 +5113,42 @@ void main() {
         libraryService.preparedSources.single.stableKey,
         'jellyfin:local-fallback',
       );
+      expect(libraryService.chosenSubtitleLanguage, 'spa');
       expect(find.text('DEBRID STREAMS'), findsNothing);
+    },
+  );
+
+  testWidgets(
+    'Your Media preparation keeps an explicit series caption language',
+    (tester) async {
+      final libraryService = _FixedLibraryEpisodeSourceService([
+        _autoPickLibrarySource('series-caption'),
+      ]);
+      await _pumpAutoPickScenario(
+        tester,
+        mediaId: 99112,
+        settings: const SettingsPreferences(
+          loaded: true,
+          debridStreamsEnabled: false,
+          webStreamsEnabled: false,
+          autoPickSourceEnabled: true,
+          preferredCaptionMode: PreferredCaptionMode.enabled,
+          preferredCaptionLanguage: 'spa',
+        ),
+        seriesPreferences: const SeriesPlaybackPreferences(
+          subtitleLanguage: 'jpn',
+          subtitlePreferenceSet: true,
+        ),
+        releases: const [],
+        libraryService: libraryService,
+      );
+
+      await _pumpUntilCondition(
+        tester,
+        () => libraryService.preparedSources.isNotEmpty,
+      );
+
+      expect(libraryService.chosenSubtitleLanguage, 'jpn');
     },
   );
 
@@ -6266,6 +6303,7 @@ class _FixedLibraryEpisodeSourceService implements LibraryEpisodeSourceService {
   LibraryWatchPartyIdentity? chosenIdentity;
   final List<LibraryEpisodeSource> preparedSources = [];
   int compatibilityPrepareCount = 0;
+  String? chosenSubtitleLanguage;
 
   @override
   bool get hasConnectedServer => connected;
@@ -6288,6 +6326,7 @@ class _FixedLibraryEpisodeSourceService implements LibraryEpisodeSourceService {
     preparedSources.add(source);
     if (forceCompatibility) compatibilityPrepareCount++;
     chosenIdentity = watchPartyIdentity;
+    chosenSubtitleLanguage = preferredSubtitleLanguage;
     final callback = onPreparePlayback;
     if (callback != null) return callback(source);
     return Completer<LibraryPlaybackRequest>().future;
@@ -6362,6 +6401,8 @@ Future<_AutoPickProbe> _pumpAutoPickScenario(
   String episodeTitle = 'Auto Pick test',
   int? episodeYear,
   required SettingsPreferences settings,
+  SeriesPlaybackPreferences seriesPreferences =
+      const SeriesPlaybackPreferences(),
   required List<ReleaseCandidate> releases,
   List<WebStreamResult> webStreams = const [],
   WebStreamAggregator? webAggregator,
@@ -6414,7 +6455,7 @@ Future<_AutoPickProbe> _pumpAutoPickScenario(
         ),
         addonStoreProvider.overrideWithValue(_NoopAddonStore()),
         seriesPreferencesReaderProvider.overrideWithValue(
-          (_) async => const SeriesPlaybackPreferences(),
+          (_) async => seriesPreferences,
         ),
         seriesPreferencesWriterProvider.overrideWithValue((_, _) async {}),
         resolveDeviceProfileReaderProvider.overrideWithValue(

--- a/test/seamless_next_episode_player_test.dart
+++ b/test/seamless_next_episode_player_test.dart
@@ -638,9 +638,9 @@ void main() {
     _expectInOrder(failover, const [
       'final tokenService = ref.read(debridTokenServiceProvider)',
       'await AndroidTvBridge.instance.getDeviceProfile()',
-      'if (!mounted || _engineHandoffInProgress) return',
+      'if (!failoverIsActive()) return',
       'await _recordStreamFailureBestEffort(',
-      'if (!mounted || _engineHandoffInProgress) return',
+      'if (!failoverIsActive()) return',
       'await _switchToNextDirectStream(',
     ]);
 
@@ -915,7 +915,8 @@ void main() {
       'await widget.onStreamAdopted(option.stream, option.release)',
       'preparedOption = null',
       '} catch (error)',
-      'await preparedOption?.stream.playbackLease?.close()',
+      'final attemptStream = preparedOption?.stream',
+      'await attemptStream?.playbackLease?.close()',
     ]);
   });
 
@@ -928,7 +929,8 @@ void main() {
       'await _openMedia(',
       'await widget.onStreamAdopted(ready, candidate)',
       '} catch (error)',
-      'await resolvedStream?.playbackLease?.close()',
+      'final attemptStream = resolvedStream',
+      'await attemptStream.playbackLease?.close()',
       '_currentStream = previousStream',
     ]);
     expect(
@@ -960,18 +962,21 @@ void main() {
       'if (_videoFrameSeen) _recordDiagnosticWorkingOutcome()',
     ]);
 
-    final openMedia = _member(source, 'Future<void> _openMedia(');
+    final openMedia = _member(source, 'Future<bool> _openMedia(');
     _expectInOrder(openMedia, const [
+      '_serializeMediaOpen(',
       '_videoWatchdog?.cancel()',
       '_performanceWatchdog?.cancel()',
       'if (requireDecodedVideo)',
       '_videoFrameSeen = false',
       'await _configureNativePlayback()',
+      'mediaRevision = await _openCurrentMedia(',
       'await waitForPlayerMediaReadiness(',
       'throw const PlayerMediaReadinessException()',
       '_recordDiagnosticStreamOpenResult(',
       'succeeded: true',
       '_startVideoWatchdog()',
+      'opened = true',
     ]);
 
     final bootstrap = _member(source, 'Future<void> _bootstrapPlayback()');

--- a/test/settings_preferences_controller_test.dart
+++ b/test/settings_preferences_controller_test.dart
@@ -260,6 +260,167 @@ void main() {
     },
   );
 
+  test('preferred captions default to Automatic with clear labels', () async {
+    FlutterSecureStorage.setMockInitialValues({});
+    final controller = SettingsPreferencesController(
+      const FlutterSecureStorage(),
+    );
+
+    await controller.load();
+
+    expect(
+      controller.state.preferredCaptionMode,
+      PreferredCaptionMode.automatic,
+    );
+    expect(controller.state.preferredCaptionLanguage, 'eng');
+    expect(PreferredCaptionMode.automatic.displayName, 'Automatic');
+    expect(PreferredCaptionMode.enabled.displayName, 'On');
+    expect(PreferredCaptionMode.disabled.displayName, 'Off');
+    for (final mode in PreferredCaptionMode.values) {
+      expect(mode.description, isNotEmpty);
+    }
+  });
+
+  test(
+    'private caption preparation respects series intent and global On only',
+    () {
+      expect(
+        preferredCaptionLanguageForPreparation(
+          seriesLanguage: 'jpn',
+          seriesPreferenceSet: true,
+          globalMode: PreferredCaptionMode.enabled,
+          globalLanguage: 'spa',
+        ),
+        'jpn',
+      );
+      expect(
+        preferredCaptionLanguageForPreparation(
+          seriesLanguage: 'eng',
+          seriesPreferenceSet: false,
+          globalMode: PreferredCaptionMode.enabled,
+          globalLanguage: 'spa',
+        ),
+        'spa',
+      );
+      for (final mode in [
+        PreferredCaptionMode.automatic,
+        PreferredCaptionMode.disabled,
+      ]) {
+        expect(
+          preferredCaptionLanguageForPreparation(
+            seriesLanguage: 'eng',
+            seriesPreferenceSet: false,
+            globalMode: mode,
+            globalLanguage: 'spa',
+          ),
+          'eng',
+          reason: '${mode.name} must preserve the prior preparation default',
+        );
+      }
+    },
+  );
+
+  test('preferred caption mode persists explicit on and off choices', () async {
+    FlutterSecureStorage.setMockInitialValues({});
+    const storage = FlutterSecureStorage();
+    final controller = SettingsPreferencesController(storage);
+
+    await controller.setPreferredCaptionMode(PreferredCaptionMode.enabled);
+    final enabled = SettingsPreferencesController(storage);
+    await enabled.load();
+    expect(enabled.state.preferredCaptionMode, PreferredCaptionMode.enabled);
+
+    await enabled.setPreferredCaptionMode(PreferredCaptionMode.disabled);
+    final disabled = SettingsPreferencesController(storage);
+    await disabled.load();
+    expect(disabled.state.preferredCaptionMode, PreferredCaptionMode.disabled);
+  });
+
+  test(
+    'manual caption selection atomically persists mode and safe language',
+    () async {
+      FlutterSecureStorage.setMockInitialValues({});
+      const storage = FlutterSecureStorage();
+      final controller = SettingsPreferencesController(storage);
+
+      await controller.setPreferredCaptionSelection(
+        mode: PreferredCaptionMode.enabled,
+        language: ' JA ',
+      );
+
+      expect(
+        controller.state.preferredCaptionMode,
+        PreferredCaptionMode.enabled,
+      );
+      expect(controller.state.preferredCaptionLanguage, 'ja');
+      final restored = SettingsPreferencesController(storage);
+      await restored.load();
+      expect(restored.state.preferredCaptionMode, PreferredCaptionMode.enabled);
+      expect(restored.state.preferredCaptionLanguage, 'ja');
+    },
+  );
+
+  test(
+    'preferred caption language normalizes storage and unsafe values',
+    () async {
+      for (final testCase in const [
+        (' PT ', 'pt'),
+        ('FRA', 'fra'),
+        ('en-US', 'eng'),
+        ('english', 'eng'),
+        ('e1', 'eng'),
+        ('', 'eng'),
+      ]) {
+        FlutterSecureStorage.setMockInitialValues({
+          'player_preferred_caption_language': testCase.$1,
+        });
+        final controller = SettingsPreferencesController(
+          const FlutterSecureStorage(),
+        );
+
+        await controller.load();
+
+        expect(
+          controller.state.preferredCaptionLanguage,
+          testCase.$2,
+          reason: 'stored ${testCase.$1}',
+        );
+      }
+
+      FlutterSecureStorage.setMockInitialValues({});
+      final controller = SettingsPreferencesController(
+        const FlutterSecureStorage(),
+      );
+      await controller.setPreferredCaptionSelection(
+        mode: PreferredCaptionMode.disabled,
+        language: '../eng',
+      );
+      expect(controller.state.preferredCaptionLanguage, 'eng');
+      expect(
+        const SettingsPreferences()
+            .copyWith(preferredCaptionLanguage: ' DE ')
+            .preferredCaptionLanguage,
+        'de',
+      );
+    },
+  );
+
+  test('invalid preferred caption storage falls back to Automatic', () async {
+    FlutterSecureStorage.setMockInitialValues({
+      'player_preferred_captions': 'not-a-caption-mode',
+    });
+    final controller = SettingsPreferencesController(
+      const FlutterSecureStorage(),
+    );
+
+    await controller.load();
+
+    expect(
+      controller.state.preferredCaptionMode,
+      PreferredCaptionMode.automatic,
+    );
+  });
+
   test('Direct torrent is opt-in and persists explicit changes', () async {
     FlutterSecureStorage.setMockInitialValues({});
     const storage = FlutterSecureStorage();
@@ -666,6 +827,10 @@ void main() {
       await controller.setCaptionTextColor(0xFF00FF00);
       await controller.setSeekBackSeconds(30);
       await controller.setPreferredAudio(PlaybackAudioPreference.sub);
+      await controller.setPreferredCaptionSelection(
+        mode: PreferredCaptionMode.enabled,
+        language: 'jpn',
+      );
 
       await controller.resetAppearanceAndNavigation();
 
@@ -676,6 +841,11 @@ void main() {
       expect(controller.state.captionTextColor, 0xFF00FF00);
       expect(controller.state.seekBackSeconds, 30);
       expect(controller.state.preferredAudio, PlaybackAudioPreference.sub);
+      expect(
+        controller.state.preferredCaptionMode,
+        PreferredCaptionMode.enabled,
+      );
+      expect(controller.state.preferredCaptionLanguage, 'jpn');
 
       final restored = SettingsPreferencesController(storage);
       await restored.load();
@@ -684,8 +854,59 @@ void main() {
       expect(restored.state.captionTextColor, 0xFF00FF00);
       expect(restored.state.seekBackSeconds, 30);
       expect(restored.state.preferredAudio, PlaybackAudioPreference.sub);
+      expect(restored.state.preferredCaptionMode, PreferredCaptionMode.enabled);
+      expect(restored.state.preferredCaptionLanguage, 'jpn');
     },
   );
+
+  test('reset appearance restores preferred captions to Automatic', () async {
+    FlutterSecureStorage.setMockInitialValues({});
+    const storage = FlutterSecureStorage();
+    final controller = SettingsPreferencesController(storage);
+
+    await controller.setPreferredCaptionSelection(
+      mode: PreferredCaptionMode.disabled,
+      language: 'spa',
+    );
+    await controller.resetAppearance();
+
+    expect(
+      controller.state.preferredCaptionMode,
+      PreferredCaptionMode.automatic,
+    );
+    expect(controller.state.preferredCaptionLanguage, 'eng');
+    final restored = SettingsPreferencesController(storage);
+    await restored.load();
+    expect(restored.state.preferredCaptionMode, PreferredCaptionMode.automatic);
+    expect(restored.state.preferredCaptionLanguage, 'eng');
+  });
+
+  test('import snapshot restores preferred caption mode', () async {
+    FlutterSecureStorage.setMockInitialValues({});
+    const storage = FlutterSecureStorage();
+    final controller = SettingsPreferencesController(storage);
+
+    await controller.setPreferredCaptionSelection(
+      mode: PreferredCaptionMode.disabled,
+      language: 'jpn',
+    );
+    final snapshot = await controller.snapshotForImport();
+    await controller.setPreferredCaptionSelection(
+      mode: PreferredCaptionMode.enabled,
+      language: 'spa',
+    );
+    await controller.restoreImportSnapshot(snapshot);
+
+    expect(
+      controller.state.preferredCaptionMode,
+      PreferredCaptionMode.disabled,
+    );
+    expect(controller.state.preferredCaptionLanguage, 'jpn');
+    final restored = SettingsPreferencesController(storage);
+    await restored.load();
+    expect(restored.state.preferredCaptionMode, PreferredCaptionMode.disabled);
+    expect(restored.state.preferredCaptionLanguage, 'jpn');
+  });
 
   test('explicit built-in keyboard choice is preserved', () async {
     FlutterSecureStorage.setMockInitialValues({
@@ -958,11 +1179,44 @@ void main() {
       gate.complete();
       await Future.wait([firstLoad, duplicateLoad]);
 
-      expect(reads, 58, reason: 'duplicate startup loads must be coalesced');
+      expect(reads, 60, reason: 'duplicate startup loads must be coalesced');
       expect(controller.state.webStreamsEnabled, isTrue);
       expect(controller.state.navigationSounds, isFalse);
     },
   );
+
+  test('startup load preserves an early preferred caption mutation', () async {
+    FlutterSecureStorage.setMockInitialValues({});
+    final gate = Completer<void>();
+    final values = <String, String>{
+      'player_preferred_captions': PreferredCaptionMode.disabled.name,
+      'player_preferred_caption_language': 'jpn',
+    };
+    final controller = SettingsPreferencesController(
+      const FlutterSecureStorage(),
+      readValue: (key) async {
+        await gate.future;
+        return values[key];
+      },
+      writeValue: (key, value) async => values[key] = value,
+    );
+
+    final load = controller.load();
+    await controller.setPreferredCaptionSelection(
+      mode: PreferredCaptionMode.enabled,
+      language: 'spa',
+    );
+    gate.complete();
+    await load;
+
+    expect(controller.state.preferredCaptionMode, PreferredCaptionMode.enabled);
+    expect(controller.state.preferredCaptionLanguage, 'spa');
+    expect(
+      values['player_preferred_captions'],
+      PreferredCaptionMode.enabled.name,
+    );
+    expect(values['player_preferred_caption_language'], 'spa');
+  });
 
   test(
     'serializes rapid writes so the newest preference persists last',

--- a/test/tetotv_database_test.dart
+++ b/test/tetotv_database_test.dart
@@ -34,10 +34,14 @@ void main() {
       preferredReleaseGroup: 'subsplease',
     );
 
-    final restored = SeriesPlaybackPreferences.fromJson(preferences.toJson());
+    final encoded = preferences.toJson();
+    final restored = SeriesPlaybackPreferences.fromJson(encoded);
 
     expect(restored.audioLanguage, 'jpn');
     expect(restored.audioPreferenceSet, isTrue);
+    expect(encoded['subtitlePreferenceExplicit'], isTrue);
+    expect(restored.subtitleLanguage, 'eng');
+    expect(restored.subtitleEnabled, isTrue);
     expect(restored.subtitlePreferenceSet, isTrue);
     expect(restored.subtitleSize, 42);
     expect(restored.skipFillerEpisodes, isTrue);
@@ -50,6 +54,46 @@ void main() {
     expect(restored.preferredReleaseProvider, 'User source');
     expect(restored.preferredReleaseGroup, 'subsplease');
   });
+
+  test('explicit subtitle off preference retains its language in JSON', () {
+    const preferences = SeriesPlaybackPreferences(
+      subtitleLanguage: 'jpn',
+      subtitleEnabled: false,
+      subtitlePreferenceSet: true,
+    );
+
+    final encoded = preferences.toJson();
+    final restored = SeriesPlaybackPreferences.fromJson(encoded);
+
+    expect(encoded['subtitleLanguage'], 'jpn');
+    expect(encoded['subtitleEnabled'], isFalse);
+    expect(encoded['subtitlePreferenceSet'], isTrue);
+    expect(encoded['subtitlePreferenceExplicit'], isTrue);
+    expect(restored.subtitleLanguage, 'jpn');
+    expect(restored.subtitleEnabled, isFalse);
+    expect(restored.subtitlePreferenceSet, isTrue);
+  });
+
+  test(
+    'legacy subtitle intent without the explicit marker is non-explicit',
+    () {
+      for (final enabled in [true, false]) {
+        final restored = SeriesPlaybackPreferences.fromJson({
+          'subtitleLanguage': 'jpn',
+          'subtitleEnabled': enabled,
+          'subtitlePreferenceSet': true,
+        });
+
+        expect(restored.subtitleLanguage, 'eng');
+        expect(restored.subtitleEnabled, isTrue);
+        expect(
+          restored.subtitlePreferenceSet,
+          isFalse,
+          reason: 'legacy ${enabled ? 'On' : 'Off'} must allow global default',
+        );
+      }
+    },
+  );
 
   test('skip filler remains off for existing per-series preferences', () {
     final restored = SeriesPlaybackPreferences.fromJson(const {

--- a/tool/release/native_playback_manifest.json
+++ b/tool/release/native_playback_manifest.json
@@ -376,9 +376,9 @@
       "path": "lib/arm64-v8a/libapp.so",
       "size": 12321680,
       "sha256": "37a1b15a85c9244776ec27a140023bcf3e5a44c55d493f814a6c6471f0ef1f1e",
-      "origin": "TetoTV Flutter application AOT 2.0.52",
+      "origin": "TetoTV Flutter application AOT 2.0.53",
       "license": "MIT",
-      "sourceLocator": "Git tag v2.0.52",
+      "sourceLocator": "Git tag v2.0.53",
       "noticeLocator": "LICENSE"
     },
     {
@@ -423,7 +423,7 @@
       "sha256": "dc05f53278b2733094f12aeaed54c080329309762ce49e6de4118e4bfb0fff55",
       "origin": "TetoTV source build of media-kit Android helper at 42054e5d479f39ccbb0ae604862e2bcaf59b74c2",
       "license": "MIT",
-      "sourceLocator": "TetoTV-v2.0.52-native-playback-sources.zip: sources/media-kit-android-helper-42054e5d479f39ccbb0ae604862e2bcaf59b74c2.zip",
+      "sourceLocator": "TetoTV-v2.0.53-native-playback-sources.zip: sources/media-kit-android-helper-42054e5d479f39ccbb0ae604862e2bcaf59b74c2.zip",
       "noticeLocator": "assets/legal/native/MEDIA_KIT_ANDROID_HELPER_LICENSE.txt; assets/legal/native/NATIVE_PLAYBACK_NOTICE.txt"
     },
     {
@@ -432,7 +432,7 @@
       "sha256": "a7399d0be70844e5ee94cc5b1acc1516571113c50561fe0a5d05b49101c53ef2",
       "origin": "TetoTV source build of the pinned mpv and FFmpeg native playback stack",
       "license": "LGPL-3.0-or-later (conservative combined classification) plus component terms",
-      "sourceLocator": "TetoTV-v2.0.52-native-playback-sources.zip and tool/native/build_native_playback.sh",
+      "sourceLocator": "TetoTV-v2.0.53-native-playback-sources.zip and tool/native/build_native_playback.sh",
       "noticeLocator": "assets/legal/native/NATIVE_PLAYBACK_NOTICE.txt and its referenced exact license assets"
     },
     {
@@ -450,16 +450,16 @@
       "sha256": "263ba714570fb3acfc308cce52776b00506ec8809d225617e52352336144cfa2",
       "origin": "TetoTV source build of the pinned libtorrent4j and libtorrent-rasterbar stack",
       "license": "Mixed MIT, BSD, Boost-1.0, Apache-2.0, and MPL-2.0 component terms",
-      "sourceLocator": "TetoTV-v2.0.52-native-playback-sources.zip and tool/native/build_native_playback.sh",
+      "sourceLocator": "TetoTV-v2.0.53-native-playback-sources.zip and tool/native/build_native_playback.sh",
       "noticeLocator": "assets/legal/native/DIRECT_TORRENT_NATIVE_NOTICE.txt and its referenced exact license assets"
     },
     {
       "path": "lib/armeabi-v7a/libapp.so",
       "size": 13484620,
       "sha256": "00212563aa8f04e25cbebf72b2348c31d4b78f5d3c6efd20aaf2712ae0c10c40",
-      "origin": "TetoTV Flutter application AOT 2.0.52",
+      "origin": "TetoTV Flutter application AOT 2.0.53",
       "license": "MIT",
-      "sourceLocator": "Git tag v2.0.52",
+      "sourceLocator": "Git tag v2.0.53",
       "noticeLocator": "LICENSE"
     },
     {
@@ -504,7 +504,7 @@
       "sha256": "8820a12e07bb3dc45f5b4286acf6918827fba4c265767e7f1cc8f07215c84b6a",
       "origin": "TetoTV source build of media-kit Android helper at 42054e5d479f39ccbb0ae604862e2bcaf59b74c2",
       "license": "MIT",
-      "sourceLocator": "TetoTV-v2.0.52-native-playback-sources.zip: sources/media-kit-android-helper-42054e5d479f39ccbb0ae604862e2bcaf59b74c2.zip",
+      "sourceLocator": "TetoTV-v2.0.53-native-playback-sources.zip: sources/media-kit-android-helper-42054e5d479f39ccbb0ae604862e2bcaf59b74c2.zip",
       "noticeLocator": "assets/legal/native/MEDIA_KIT_ANDROID_HELPER_LICENSE.txt; assets/legal/native/NATIVE_PLAYBACK_NOTICE.txt"
     },
     {
@@ -513,7 +513,7 @@
       "sha256": "d5a220fdf41edde10f161f86addc846ae9cb18137ea48e4db541cd703fec5092",
       "origin": "TetoTV source build of the pinned mpv and FFmpeg native playback stack",
       "license": "LGPL-3.0-or-later (conservative combined classification) plus component terms",
-      "sourceLocator": "TetoTV-v2.0.52-native-playback-sources.zip and tool/native/build_native_playback.sh",
+      "sourceLocator": "TetoTV-v2.0.53-native-playback-sources.zip and tool/native/build_native_playback.sh",
       "noticeLocator": "assets/legal/native/NATIVE_PLAYBACK_NOTICE.txt and its referenced exact license assets"
     },
     {
@@ -531,7 +531,7 @@
       "sha256": "ba0a19d2730969b8e6107db1847888ea8d3b8cafd14a535a3259dd04f8b28d60",
       "origin": "TetoTV source build of the pinned libtorrent4j and libtorrent-rasterbar stack",
       "license": "Mixed MIT, BSD, Boost-1.0, Apache-2.0, and MPL-2.0 component terms",
-      "sourceLocator": "TetoTV-v2.0.52-native-playback-sources.zip and tool/native/build_native_playback.sh",
+      "sourceLocator": "TetoTV-v2.0.53-native-playback-sources.zip and tool/native/build_native_playback.sh",
       "noticeLocator": "assets/legal/native/DIRECT_TORRENT_NATIVE_NOTICE.txt and its referenced exact license assets"
     }
   ],


### PR DESCRIPTION
## Summary
- add a persistent Preferred CC setting under Playback (Automatic, On, Off)
- preserve explicit caption language/intent across episode changes, source fallback, redirects, and private-library playback
- bind media-open, subtitle, and failover work to the active episode/source to prevent stale events and wrong-episode playback
- safely migrate legacy transient caption rows and update Beta 2.0.53 release documentation

## Validation
- `flutter analyze`
- `flutter test --reporter compact` (1,952 passed, 17 skipped)
- focused caption/lifecycle/settings suite (366 passed)
- Android Gradle checks: `:app:test :app:lintRelease :app:compileReleaseKotlin`

This PR prepares the Beta-only v2.0.53 source. The APK and release assets will be built and hash-recorded after merge. No Public release is included.
