### PR TITLE
Stabilize TV Settings focus and publish Beta 2.0.54

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 
 <p align="center">
   <a href="https://github.com/LindersOSX/TetoTV-Beta/releases/latest"><strong>Download Beta</strong></a>
-  · <a href="docs/RELEASE_NOTES_2.0.53.md">What's new</a>
+  · <a href="docs/RELEASE_NOTES_2.0.54.md">What's new</a>
   · <a href="https://github.com/LindersOSX/TetoTV-Beta/issues/new">Report an issue</a>
   · <a href="https://discord.gg/juC6k7d4WY">Discord</a>
   · <a href="https://www.youtube.com/@TetoTVApp">YouTube</a>
@@ -85,10 +85,10 @@ TetoTV runs directly on the Android device with no companion server required for
 | Channel | Version | Best for |
 | --- | --- | --- |
 | Public | Not published | Source and release-readiness documents are available, but no Public APK is currently offered |
-| Beta | [2.0.53](docs/RELEASE_NOTES_2.0.53.md) | Testing persistent caption choices and a Preferred CC playback setting across episode changes, source fallback, and private-library playback |
+| Beta | [2.0.54](docs/RELEASE_NOTES_2.0.54.md) | Testing TV Settings focus stability, responsive mobile Settings, and smoother D-pad navigation |
 
 > [!WARNING]
-> Beta 2.0.53 uses the repository's explicit unreviewed-Beta exception. Its native-library and corresponding-source material did not receive independent license review, and automated integrity checks are not a legal compliance determination. Read the [complete Beta disclosure](docs/RELEASE_NOTES_2.0.53.md). This exception does not apply to a future Public release.
+> Beta 2.0.54 uses the repository's explicit unreviewed-Beta exception. Its native-library and corresponding-source material did not receive independent license review, and automated integrity checks are not a legal compliance determination. Read the [complete Beta disclosure](docs/RELEASE_NOTES_2.0.54.md). This exception does not apply to a future Public release.
 
 The Public updater repository intentionally has no release while the Public build is held for review. Existing Beta installations continue to update from the Beta repository. Android never permits an in-place install of an APK with a lower build code; Developer Mode does not bypass that platform rule.
 

--- a/docs/BUILD_WINDOWS.md
+++ b/docs/BUILD_WINDOWS.md
@@ -220,39 +220,39 @@ APK containing both supported application ABIs.
 Public and Beta updates use anonymous GitHub requests. No Beta key, GitHub
 token, update-proxy URL, or update-specific Dart define is required. Every
 published APK uses the production signing identity. No Public APK is currently
-published. Beta 2.0.53 uses Android build code `410030`. Flutter reuses
+published. Beta 2.0.54 uses Android build code `410031`. Flutter reuses
 `app-release.apk`, so copy and rename the Beta artifact immediately after the
 build:
 
 ```powershell
-New-Item -ItemType Directory -Force .\build\fire-tv\v2.0.53 | Out-Null
+New-Item -ItemType Directory -Force .\build\fire-tv\v2.0.54 | Out-Null
 
-# Beta 2.0.53
+# Beta 2.0.54
 flutter build apk --release --target-platform android-arm,android-arm64 `
-  --build-name 2.0.53 --build-number 410030 --no-tree-shake-icons
+  --build-name 2.0.54 --build-number 410031 --no-tree-shake-icons
 Copy-Item .\build\app\outputs\flutter-apk\app-release.apk `
-  .\build\fire-tv\v2.0.53\TetoTV-v2.0.53-universal.apk
+  .\build\fire-tv\v2.0.54\TetoTV-v2.0.54-universal.apk
 
 .\tool\release\verify_release_apk.ps1 `
   -Channel Beta `
-  -ApkPath .\build\fire-tv\v2.0.53\TetoTV-v2.0.53-universal.apk
+  -ApkPath .\build\fire-tv\v2.0.54\TetoTV-v2.0.54-universal.apk
 
 .\tool\release\verify_native_redistribution.ps1 `
   -RequireResolvedBinaries `
   -ResolvedBinaryDirectory .\build\native-playback\outputs `
-  -StageBundle -ReleaseTag v2.0.53
+  -StageBundle -ReleaseTag v2.0.54
 
 .\tool\release\new_release_checksums.ps1 `
-  -ApkPath .\build\fire-tv\v2.0.53\TetoTV-v2.0.53-universal.apk `
-  -NativeSourcePath .\build\release-compliance\v2.0.53\TetoTV-v2.0.53-native-playback-sources.zip `
-  -OutputPath .\build\fire-tv\v2.0.53\SHA256SUMS
+  -ApkPath .\build\fire-tv\v2.0.54\TetoTV-v2.0.54-universal.apk `
+  -NativeSourcePath .\build\release-compliance\v2.0.54\TetoTV-v2.0.54-native-playback-sources.zip `
+  -OutputPath .\build\fire-tv\v2.0.54\SHA256SUMS
 
 .\tool\release\verify_release_payloads.ps1 `
   -Channel Beta `
-  -ApkPath .\build\fire-tv\v2.0.53\TetoTV-v2.0.53-universal.apk `
-  -NativeSourcePath .\build\release-compliance\v2.0.53\TetoTV-v2.0.53-native-playback-sources.zip `
-  -ChecksumsPath .\build\fire-tv\v2.0.53\SHA256SUMS `
-  -ReleaseNotesPath .\docs\RELEASE_NOTES_2.0.53.md
+  -ApkPath .\build\fire-tv\v2.0.54\TetoTV-v2.0.54-universal.apk `
+  -NativeSourcePath .\build\release-compliance\v2.0.54\TetoTV-v2.0.54-native-playback-sources.zip `
+  -ChecksumsPath .\build\fire-tv\v2.0.54\SHA256SUMS `
+  -ReleaseNotesPath .\docs\RELEASE_NOTES_2.0.54.md
 ```
 
 The final payload check requires all five exact, source-built native JARs

--- a/docs/RELEASE_NOTES_2.0.54.md
+++ b/docs/RELEASE_NOTES_2.0.54.md
@@ -1,0 +1,32 @@
+# TetoTV 2.0.54 Beta
+
+> [!WARNING]
+> No independent native-license review: This Beta has not received independent native-library licensing review. Automated checks verify the APK, native-source bundle, notices, pinned inputs, and checksums, but do not establish legal compliance or reproducible builds.
+
+This Beta tightens Settings focus behavior on TV while preserving the responsive Settings presentation on phones and tablets.
+
+## What's changed
+
+- TV Settings keeps D-pad focus inside its single vertical content list when a row has no explicit directional mapping, preventing accidental jumps to the navigation rail while moving up and down.
+- Settings scroll reveals are now cancelled and generation-checked when a new D-pad event arrives, so stale animations cannot move the viewport after focus has changed.
+- Leaving Settings with LEFT now waits for the normal focus traversal result before restoring the active Settings rail item; horizontal controls and phone/tablet navigation are not intercepted.
+- Activating the already-selected Settings item in the rail restores the visible Settings content instead of opening a duplicate Settings route. This also handles the fixed TV search field being temporarily removed while the list is scrolled.
+- Rail, profile, and content focus recovery ignores detached or non-focusable nodes, reducing intermittent “right does nothing” states after a route or layout change.
+- Repeated D-pad focus callbacks no longer restart the Home hero restore animation, reducing visible choppiness during rapid TV navigation.
+- Phone and tablet Settings retain their existing responsive layout and direct controls; the TV-only single-list focus graph does not change their presentation.
+- The new diagnostic report from a Samsung phone showed no crashes or stream failures. Its retained frame samples indicate occasional startup/rendering spikes, but no evidence of a mobile Settings layout or focus failure; diagnostic-capacity drops are reported transparently.
+- AI-assisted development disclosure: AI tools assisted with implementation, design iteration, documentation, tests, and review. The project owner directed the work, validated the changes, and remains responsible for this release.
+
+## Release assets
+
+- `TetoTV-v2.0.54-universal.apk`
+- `TetoTV-v2.0.54-native-playback-sources.zip`
+- `SHA256SUMS`
+
+## Beta notes
+
+- This is a Beta-channel build with Android build code `410031`.
+- No Public APK is being published with this release.
+- Android does not permit an in-place install over an APK with a higher build code. A future Public counterpart must use build code `410031` or newer for data-preserving channel switching.
+
+<!-- tetotv-android-version-code: 410031 -->

--- a/docs/UPDATE_CHANNELS.md
+++ b/docs/UPDATE_CHANNELS.md
@@ -35,11 +35,11 @@ Beta reads completed 2.x releases from:
 https://api.github.com/repos/LindersOSX/TetoTV-Beta/releases/latest
 ```
 
-The current Beta source build is `v2.0.53` with Android build code `410030`.
+The current Beta source build is `v2.0.54` with Android build code `410031`.
 Its release title is:
 
 ```text
-TetoTV 2.0.53 Beta - Android TV / Google TV / Fire TV
+TetoTV 2.0.54 Beta - Android TV / Google TV / Fire TV
 ```
 
 Publish it as a normal, non-draft, non-prerelease GitHub release so
@@ -72,7 +72,7 @@ proxy.
 Release notes must include the exact asset names and this build-code marker:
 
 ```html
-<!-- tetotv-android-version-code: 410030 -->
+<!-- tetotv-android-version-code: 410031 -->
 ```
 
 When build-code metadata is present, the updater rejects a known lower build
@@ -94,10 +94,10 @@ These rules apply equally on phones, Android TV, Google TV, and Fire TV.
 
 ## Switching and rollback
 
-The current Beta uses build code `410030`. No Public counterpart is available.
+The current Beta uses build code `410031`. No Public counterpart is available.
 An older Public install can move to this Beta when Android accepts the higher
 build code, but it cannot move back in place until a future Public build uses
-code `410030` or higher. Uninstalling first permits an older APK but deletes
+code `410031` or higher. Uninstalling first permits an older APK but deletes
 local application data. Developer Mode and in-app settings cannot override
 this Android rule.
 

--- a/lib/core/widgets/teto_top_level_shell.dart
+++ b/lib/core/widgets/teto_top_level_shell.dart
@@ -108,9 +108,11 @@ class _TetoTopLevelShellState extends ConsumerState<TetoTopLevelShell> {
   }
 
   void _focusRail() {
-    if (_railFocusNode.context != null) {
+    if (_railFocusNode.context?.mounted == true &&
+        _railFocusNode.canRequestFocus) {
       _railFocusNode.requestFocus();
-    } else if (_profileFocusNode.context != null) {
+    } else if (_profileFocusNode.context?.mounted == true &&
+        _profileFocusNode.canRequestFocus) {
       // Settings may live under the profile menu while every optional rail
       // destination is disabled. The profile remains a deterministic escape
       // target instead of leaving LEFT trapped in Settings content.
@@ -119,9 +121,11 @@ class _TetoTopLevelShellState extends ConsumerState<TetoTopLevelShell> {
   }
 
   void _focusContent() {
-    if (widget.firstContentFocusNode.context != null) {
+    if (widget.firstContentFocusNode.context?.mounted == true &&
+        widget.firstContentFocusNode.canRequestFocus) {
       requestTvFocusAndReveal(widget.firstContentFocusNode);
-    } else if (widget.fallbackContentFocusNode?.context != null) {
+    } else if (widget.fallbackContentFocusNode?.context?.mounted == true &&
+        widget.fallbackContentFocusNode!.canRequestFocus) {
       requestTvFocusAndReveal(widget.fallbackContentFocusNode!);
     }
   }
@@ -144,7 +148,8 @@ class _TetoTopLevelShellState extends ConsumerState<TetoTopLevelShell> {
     );
     if (!_profileShouldBeVisibleAtTop &&
         (_profileFocusNode.hasFocus || hiddenHeaderOwnsFocus)) {
-      if (_railFocusNode.context != null) {
+      if (_railFocusNode.context?.mounted == true &&
+          _railFocusNode.canRequestFocus) {
         _railFocusNode.requestFocus();
       } else {
         _focusContent();

--- a/lib/features/home/presentation/home_screen.dart
+++ b/lib/features/home/presentation/home_screen.dart
@@ -72,6 +72,7 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
   bool _homeRefreshInProgress = false;
   bool _headerVisibleAtTop = true;
   bool _suppressNextNavigationHeroRestore = false;
+  bool _sponsoredHeroRestoreInFlight = false;
   bool? _lastUseSideNavigation;
   bool _lastContentWasHero = true;
   HomeShelf? _lastFocusedShelf;
@@ -304,14 +305,24 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
     if (!mounted ||
         !ref.read(settingsPreferencesProvider).showHero ||
         !_scrollController.hasClients ||
-        _scrollController.offset <= .5) {
+        _scrollController.offset <= .5 ||
+        _sponsoredHeroRestoreInFlight) {
       return;
     }
-    await _scrollController.animateTo(
-      0,
-      duration: const Duration(milliseconds: 170),
-      curve: Curves.easeOutCubic,
-    );
+    // Rail, search, and profile focus callbacks can fire several times while
+    // a held D-pad key is moving. Coalesce those callbacks so each visit to
+    // the rail drives one scroll animation instead of restarting it every
+    // frame.
+    _sponsoredHeroRestoreInFlight = true;
+    try {
+      await _scrollController.animateTo(
+        0,
+        duration: const Duration(milliseconds: 170),
+        curve: Curves.easeOutCubic,
+      );
+    } finally {
+      _sponsoredHeroRestoreInFlight = false;
+    }
   }
 
   void _rememberShelfFocus(HomeShelf shelf, int column) {

--- a/lib/features/home/presentation/main_navigation_bar.dart
+++ b/lib/features/home/presentation/main_navigation_bar.dart
@@ -201,7 +201,11 @@ class _HomeSideNavigationState extends ConsumerState<HomeSideNavigation> {
       _focusRecoveryScheduled = false;
       if (!mounted || !widget.autofocusActive) return;
       final primary = FocusManager.instance.primaryFocus;
-      if (primary != null && primary.context != null) return;
+      if (primary != null &&
+          primary.context?.mounted == true &&
+          primary.canRequestFocus) {
+        return;
+      }
       final destination = _activeFocusDestination;
       if (destination == null) {
         widget.onExitRight();

--- a/lib/features/settings/presentation/accounts_screen.dart
+++ b/lib/features/settings/presentation/accounts_screen.dart
@@ -646,6 +646,18 @@ class _AccountsScreenState extends ConsumerState<AccountsScreen> {
     repeatInterval: const Duration(milliseconds: 92),
   );
   final _settingsScrollController = ScrollController();
+  // Incremented for every accepted D-pad event so delayed reveals from an
+  // earlier move cannot scroll the list after focus has already moved on.
+  int _settingsRevealGeneration = 0;
+  // TV settings are rendered as one vertical list. Keep that list in its own
+  // focus scope so Flutter's fallback traversal cannot escape into the app
+  // rail when a row does not have an explicit directional mapping.
+  final _settingsListFocusScope = FocusScopeNode(
+    debugLabel: 'accounts.settings-list',
+    skipTraversal: true,
+    traversalEdgeBehavior: TraversalEdgeBehavior.stop,
+    directionalTraversalEdgeBehavior: TraversalEdgeBehavior.stop,
+  );
   final Set<_CustomizationSection> _expandedCustomizationSections = {};
   final Set<_AutoPickPrioritySection> _expandedAutoPickPrioritySections = {
     _AutoPickPrioritySection.source,
@@ -1185,7 +1197,9 @@ class _AccountsScreenState extends ConsumerState<AccountsScreen> {
   @override
   void dispose() {
     _directionalRepeatGate.reset();
+    _settingsRevealGeneration++;
     _settingsScrollController.dispose();
+    _settingsListFocusScope.dispose();
     _torBoxTokenController.dispose();
     _allDebridTokenController.dispose();
     _premiumizeTokenController.dispose();
@@ -1325,6 +1339,19 @@ class _AccountsScreenState extends ConsumerState<AccountsScreen> {
     }
     final current = FocusManager.instance.primaryFocus;
     final tvListLayout = layout?.usesTvRail == true;
+    // Stop a previous TV-list reveal before handling this packet. Without
+    // this, a held D-pad can leave an old ensureVisible animation driving the
+    // viewport toward a stale target. The generation invalidates callbacks
+    // already queued for that target as well.
+    final revealGeneration = ++_settingsRevealGeneration;
+    if (tvListLayout && _settingsScrollController.hasClients) {
+      final position = _settingsScrollController.position;
+      if (position.isScrollingNotifier.value) {
+        // jumpTo cancels Driven/Ballistic activities through the public
+        // ScrollPosition API while preserving the current offset.
+        position.jumpTo(position.pixels);
+      }
+    }
     bool focusNodeIsMounted(FocusNode node) => node.context?.mounted ?? false;
     final preferences = ref.read(settingsPreferencesProvider);
     final selectedDebridAction = switch (preferences.debridProvider) {
@@ -2273,6 +2300,25 @@ class _AccountsScreenState extends ConsumerState<AccountsScreen> {
     }
 
     if (target == null || !focusNodeIsMounted(target)) {
+      if (tvListLayout &&
+          current != null &&
+          (key == LogicalKeyboardKey.arrowUp ||
+              key == LogicalKeyboardKey.arrowDown)) {
+        // Anonymous rows (for example the secondary display options) do not
+        // have an explicit node in the screen's directional graph. Traverse
+        // them through the TV list scope instead of allowing the global
+        // reading-order policy to jump to the navigation rail. The scope's
+        // `stop` edge behavior keeps an edge press in place; named rows above
+        // already provide the intentional cross-section transitions.
+        if (identical(current.nearestScope, _settingsListFocusScope)) {
+          if (key == LogicalKeyboardKey.arrowUp) {
+            _settingsListFocusScope.previousFocus();
+          } else {
+            _settingsListFocusScope.nextFocus();
+          }
+          return KeyEventResult.handled;
+        }
+      }
       // Some Settings rows intentionally let Flutter traverse between their
       // anonymous option nodes (for example Small -> Medium -> Large). When
       // LEFT leaves the final option, the default directional policy chooses
@@ -2282,19 +2328,28 @@ class _AccountsScreenState extends ConsumerState<AccountsScreen> {
       if (key == LogicalKeyboardKey.arrowLeft &&
           layout?.usesSideNavigation == true) {
         final origin = current;
-        WidgetsBinding.instance.addPostFrameCallback((_) {
-          if (!mounted) return;
+        final activeLayout = layout;
+        scheduleMicrotask(() {
+          if (!mounted || activeLayout == null) return;
           final primary = FocusManager.instance.primaryFocus;
-          final leftSettingsContent = !_contentFocus.hasFocus;
+          // Check the list scope itself instead of the broader content
+          // ancestor. This preserves horizontal child controls when Flutter
+          // successfully moved within the list, while normalizing a genuine
+          // content-to-rail exit to the active Settings action.
+          final stayedInSettingsList =
+              primary != null &&
+              (identical(primary, _settingsListFocusScope) ||
+                  primary.ancestors.contains(_settingsListFocusScope));
           final wasTrappedAtLeftEdge = identical(primary, origin);
-          if (leftSettingsContent || wasTrappedAtLeftEdge) {
-            layout!.focusRail();
+          if (!stayedInSettingsList || wasTrappedAtLeftEdge) {
+            activeLayout.focusRail();
           }
         });
       }
       return KeyEventResult.ignored;
     }
-    target.requestFocus();
+    final targetToReveal = target;
+    targetToReveal.requestFocus();
     // Settings intentionally uses a screen-local focus graph for a few
     // cross-column transitions, so reveal that explicit target exactly once.
     // Normal app-wide D-pad traversal is revealed by Flutter's policy.
@@ -2303,11 +2358,17 @@ class _AccountsScreenState extends ConsumerState<AccountsScreen> {
         ? ScrollPositionAlignmentPolicy.keepVisibleAtStart
         : ScrollPositionAlignmentPolicy.keepVisibleAtEnd;
     WidgetsBinding.instance.addPostFrameCallback((_) {
-      final targetContext = target?.context;
-      if (mounted && targetContext != null && targetContext.mounted) {
+      final targetContext = targetToReveal.context;
+      if (mounted &&
+          revealGeneration == _settingsRevealGeneration &&
+          targetToReveal.hasFocus &&
+          targetContext != null &&
+          targetContext.mounted) {
         Scrollable.ensureVisible(
           targetContext,
-          duration: const Duration(milliseconds: 120),
+          duration: tvListLayout
+              ? Duration.zero
+              : const Duration(milliseconds: 120),
           curve: Curves.easeOutCubic,
           alignmentPolicy: alignmentPolicy,
         );
@@ -2764,6 +2825,28 @@ class _AccountsScreenState extends ConsumerState<AccountsScreen> {
           : _areaFocusNodes[_activeArea]!,
       fallbackContentFocusNode: _areaFocusNodes[_activeArea],
       autofocusRail: widget.autofocusNavigation,
+      // Settings is itself the active rail destination.  Pressing the
+      // already-selected rail item must return focus to this screen's content
+      // instead of pushing a second `/settings/accounts` route.  A duplicate
+      // route leaves two independent focus graphs mounted and is the source
+      // of the intermittent "right does nothing" behavior after exiting to
+      // the rail.
+      onActiveDestinationPressed: () {
+        final preferredTarget = collapsibleSettings
+            ? _settingsSearchFocus
+            : _activeArea == _SettingsArea.appearance
+            ? _customizationFocus
+            : _areaFocusNodes[_activeArea]!;
+        // The fixed search header is removed while the settings list is
+        // scrolled. Its FocusNode can retain a non-null context briefly after
+        // removal, so do not hand that detached node back to the shell.
+        final target =
+            preferredTarget.context?.mounted == true &&
+                preferredTarget.canRequestFocus
+            ? preferredTarget
+            : _areaFocusNodes[_activeArea]!;
+        requestTvFocusAndReveal(target);
+      },
       tvHeaderFocusNodes: [
         _settingsSearchFocus,
         _settingsToggleAllFocus,
@@ -2852,748 +2935,806 @@ class _AccountsScreenState extends ConsumerState<AccountsScreen> {
                   : (_activeArea == _SettingsArea.appearance ? 16 : 12),
             ),
             Expanded(
-              child: ListView(
-                key: const ValueKey('settings-content-list'),
-                controller: _settingsScrollController,
-                scrollCacheExtent: const ScrollCacheExtent.pixels(5000),
-                keyboardDismissBehavior:
-                    ScrollViewKeyboardDismissBehavior.onDrag,
-                padding: EdgeInsets.only(
-                  bottom:
-                      MediaQuery.viewInsetsOf(context).bottom +
-                      (layout.usesTvRail ? 16 : 24),
-                ),
-                children: [
-                  if (_activeArea == _SettingsArea.appearance) ...[
-                    if (!layout.usesTvRail) ...[
-                      const _SectionHeader(
-                        icon: Icons.palette_rounded,
-                        title: 'APPEARANCE',
-                        subtitle:
-                            'Personalize TetoTV, the Home screen, navigation, and feedback.',
-                      ),
-                      const SizedBox(height: 8),
-                    ],
-                    _AppearanceSettingsLayout(
-                      usesTvListLayout: layout.usesTvRail,
-                      preferences: preferences,
-                      titlePreference: titlePreference,
-                      homeShelves: homeShelves,
-                      homeShelfOrder: homeShelfOrder,
-                      controller: ref.read(
-                        settingsPreferencesProvider.notifier,
-                      ),
-                      themeStudioFocusNode: _customizationFocus,
-                      titleLanguageFocusNode: _titleLanguageFocus,
-                      showTitleStyleFocusNode: _showTitleStyleFocus,
-                      navigationSizeFocusNode: _navigationSizeFocus,
-                      menuOrderFocusNode: _menuOrderFocus,
-                      resetFocusNode: _customizationResetFocus,
-                      featuredFocusNode: _featuredHomeContentFocus,
-                      posterMetadataFocusNode: _posterMetadataFocus,
-                      continueWatchingFocusNode: _continueWatchingFocus,
-                      displayOptionsFirstFocusNode: _displaySectionFocus,
-                      cardDetailsFocusNode: _cardDetailsFocus,
-                      inputFeedbackFirstFocusNode: _inputFeedbackSectionFocus,
-                      clickSoundsFocusNode: _clickSoundsFocus,
-                      shelfFocusNodes: _shelfFocusNodes,
-                      expandedSections: _expandedSettingsSections,
-                      sectionFocusNodes: _settingsSectionFocusNodes,
-                      onSectionExpandedChanged: _setSettingsSectionExpanded,
-                      onOpenThemeStudio: () =>
-                          context.push(ThemeStudioScreen.routePath),
-                      onOpenMenuOrder: _openMenuOrderDialog,
-                      onTitleLanguageChanged: (preference) => ref
-                          .read(titleLanguagePreferenceProvider.notifier)
-                          .setPreference(preference),
-                      onReset: resetAppearance,
-                      onShelfToggle: (shelf) => ref
-                          .read(homeShelfPreferencesProvider.notifier)
-                          .toggle(shelf),
-                      onShelfMove: (shelf, offset) => ref
-                          .read(homeShelfOrderProvider.notifier)
-                          .move(shelf, offset),
+              child: FocusScope(
+                node: _settingsListFocusScope,
+                skipTraversal: true,
+                child: FocusTraversalGroup(
+                  policy: WidgetOrderTraversalPolicy(),
+                  child: ListView(
+                    key: const ValueKey('settings-content-list'),
+                    controller: _settingsScrollController,
+                    scrollCacheExtent: const ScrollCacheExtent.pixels(5000),
+                    keyboardDismissBehavior:
+                        ScrollViewKeyboardDismissBehavior.onDrag,
+                    padding: EdgeInsets.only(
+                      bottom:
+                          MediaQuery.viewInsetsOf(context).bottom +
+                          (layout.usesTvRail ? 16 : 24),
                     ),
-                    SizedBox(height: layout.usesTvRail ? 5 : 10),
-                  ],
-                  if (_activeArea == _SettingsArea.playback) ...[
-                    if (!layout.usesTvRail) ...[
-                      const _SectionHeader(
-                        icon: Icons.play_circle_rounded,
-                        title: 'PLAYBACK',
-                        subtitle:
-                            'Tune captions, player behavior, audio, skipping, and seeking.',
-                      ),
-                      const SizedBox(height: 8),
-                    ],
-                    _SettingsResponsiveColumns(
-                      forceSingleColumn: layout.usesTvRail,
-                      left: settingsSectionCard(
-                        key: const ValueKey('settings-card-playback-captions'),
-                        section: _SettingsSection.closedCaptions,
-                        subtitle:
-                            'Style subtitles for comfortable viewing on every screen.',
-                        child: customizationPanel(const {
-                          _CustomizationSection.closedCaptions,
-                        }, showReset: false),
-                      ),
-                      right: settingsSectionCard(
-                        key: const ValueKey('settings-card-playback-player'),
-                        section: _SettingsSection.playerControls,
-                        subtitle:
-                            'Choose audio, skipping, seeking, and playback behavior.',
-                        child: customizationPanel(const {
-                          _CustomizationSection.playerControls,
-                        }, showReset: false),
-                      ),
-                    ),
-                    SizedBox(height: layout.usesTvRail ? 5 : 10),
-                  ],
-                  if (_activeArea == _SettingsArea.services) ...[
-                    if (!layout.usesTvRail) ...[
-                      const _SectionHeader(
-                        icon: Icons.hub_rounded,
-                        title: 'SERVICES',
-                        subtitle:
-                            'Connect providers and choose how episode sources are found.',
-                      ),
-                      const SizedBox(height: 8),
-                    ],
-                    _SettingsResponsiveColumns(
-                      forceSingleColumn: layout.usesTvRail,
-                      left: _SettingsCardLane(
-                        children: [
-                          settingsSectionCard(
-                            key: const ValueKey(
-                              'settings-card-services-debrid',
-                            ),
-                            section: _SettingsSection.debridStreaming,
+                    children: [
+                      if (_activeArea == _SettingsArea.appearance) ...[
+                        if (!layout.usesTvRail) ...[
+                          const _SectionHeader(
+                            icon: Icons.palette_rounded,
+                            title: 'APPEARANCE',
                             subtitle:
-                                'Choose and securely connect the provider used to resolve streams.',
-                            child: Column(
-                              crossAxisAlignment: CrossAxisAlignment.stretch,
-                              children: [
-                                _SettingsSelection<DebridService>(
-                                  focusNode: _debridProviderFocus,
-                                  label: 'Debrid provider',
-                                  value: preferences.debridProvider,
-                                  options: [
-                                    for (final service in DebridService.values)
-                                      _SettingsOption(
-                                        value: service,
-                                        label: service.displayName,
-                                        detail:
-                                            switch (service) {
-                                              DebridService.realDebrid =>
-                                                debrid.hasSavedToken,
-                                              DebridService.torBox =>
-                                                torBox.hasSavedToken,
-                                              DebridService.allDebrid =>
-                                                allDebrid.hasSavedToken,
-                                              DebridService.premiumize =>
-                                                premiumize.hasSavedToken,
-                                            }
-                                            ? 'Connected'
-                                            : 'Not connected',
-                                      ),
-                                  ],
-                                  onSelected: ref
-                                      .read(
-                                        settingsPreferencesProvider.notifier,
-                                      )
-                                      .setDebridProvider,
-                                  showDivider: true,
-                                ),
-                                switch (preferences.debridProvider) {
-                                  DebridService.realDebrid => _RealDebridPanel(
-                                    state: debrid,
-                                    onDisconnect: () => ref
-                                        .read(
-                                          realDebridSettingsControllerProvider
-                                              .notifier,
-                                        )
-                                        .disconnect(),
-                                    onDeviceConnect: () =>
-                                        context.push('/pair/realdebrid'),
-                                    connectFocusNode: _debridConnectFocus,
-                                  ),
-                                  DebridService.torBox => _TorBoxPanel(
-                                    state: torBox,
-                                    tokenController: _torBoxTokenController,
-                                    onSave: () async {
-                                      final saved = await ref
-                                          .read(
-                                            torBoxSettingsControllerProvider
-                                                .notifier,
-                                          )
-                                          .saveAndValidate(
-                                            _torBoxTokenController.text,
-                                          );
-                                      if (saved) _torBoxTokenController.clear();
-                                    },
-                                    onDisconnect: () => ref
-                                        .read(
-                                          torBoxSettingsControllerProvider
-                                              .notifier,
-                                        )
-                                        .disconnect(),
-                                    onDeviceConnect: () async {
-                                      await context.push('/pair/torbox');
-                                      await ref
-                                          .read(
-                                            torBoxSettingsControllerProvider
-                                                .notifier,
-                                          )
-                                          .load();
-                                    },
-                                    actionFocusNode: _torBoxActionFocus,
-                                    tokenFocusNode: _torBoxTokenFocus,
-                                    saveFocusNode: _torBoxSaveFocus,
-                                  ),
-                                  DebridService.allDebrid => _ApiKeyDebridPanel(
-                                    title: 'AllDebrid',
-                                    icon: Icons.cloud_sync_rounded,
-                                    gradient: [
-                                      context.appPalette.accent,
-                                      context.appPalette.secondaryAccent,
-                                    ],
-                                    connected: allDebrid.account != null,
-                                    hasSavedToken: allDebrid.hasSavedToken,
-                                    connectedLabel: 'PREMIUM',
-                                    description: allDebrid.account == null
-                                        ? 'Authorize with AllDebrid PIN, or enter a personal API key.'
-                                        : 'Connected as ${allDebrid.account!.username}. '
-                                              'Torrent files resolve through AllDebrid only.',
-                                    errorMessage: allDebrid.errorMessage,
-                                    isLoading: allDebrid.isLoading,
-                                    tokenController: _allDebridTokenController,
-                                    tokenTitle: 'AllDebrid API key',
-                                    keyboardTitle: 'Enter AllDebrid API key',
-                                    connectLabel: 'Connect by PIN',
-                                    connectIcon: Icons.qr_code_rounded,
-                                    onSave: () async {
-                                      final saved = await ref
-                                          .read(
-                                            allDebridSettingsControllerProvider
-                                                .notifier,
-                                          )
-                                          .saveAndValidate(
-                                            _allDebridTokenController.text,
-                                          );
-                                      if (saved) {
-                                        _allDebridTokenController.clear();
-                                      }
-                                    },
-                                    onDisconnect: () => ref
-                                        .read(
-                                          allDebridSettingsControllerProvider
-                                              .notifier,
-                                        )
-                                        .disconnect(),
-                                    onConnect: () async {
-                                      await context.push('/pair/alldebrid');
-                                      await ref
-                                          .read(
-                                            allDebridSettingsControllerProvider
-                                                .notifier,
-                                          )
-                                          .load();
-                                    },
-                                    actionFocusNode: _allDebridActionFocus,
-                                    tokenFocusNode: _allDebridTokenFocus,
-                                    saveFocusNode: _allDebridSaveFocus,
-                                  ),
-                                  DebridService.premiumize => _ApiKeyDebridPanel(
-                                    title: 'Premiumize',
-                                    icon: Icons.cloud_queue_rounded,
-                                    gradient: [
-                                      context.appPalette.secondaryAccent,
-                                      context.appPalette.accentBright,
-                                    ],
-                                    connected: premiumize.account != null,
-                                    hasSavedToken: premiumize.hasSavedToken,
-                                    connectedLabel: 'PREMIUM',
-                                    description: premiumize.account == null
-                                        ? 'Enter the API key from your Premiumize account page.'
-                                        : 'Connected as customer '
-                                              '${premiumize.account!.customerId}. '
-                                              'Torrent files resolve through Premiumize only.',
-                                    errorMessage: premiumize.errorMessage,
-                                    isLoading: premiumize.isLoading,
-                                    tokenController: _premiumizeTokenController,
-                                    tokenTitle: 'Premiumize API key',
-                                    keyboardTitle: 'Enter Premiumize API key',
-                                    connectLabel: 'Connection help',
-                                    connectIcon: Icons.key_rounded,
-                                    onSave: () async {
-                                      final saved = await ref
-                                          .read(
-                                            premiumizeSettingsControllerProvider
-                                                .notifier,
-                                          )
-                                          .saveAndValidate(
-                                            _premiumizeTokenController.text,
-                                          );
-                                      if (saved) {
-                                        _premiumizeTokenController.clear();
-                                      }
-                                    },
-                                    onDisconnect: () => ref
-                                        .read(
-                                          premiumizeSettingsControllerProvider
-                                              .notifier,
-                                        )
-                                        .disconnect(),
-                                    onConnect: () async {
-                                      await context.push('/pair/premiumize');
-                                      await ref
-                                          .read(
-                                            premiumizeSettingsControllerProvider
-                                                .notifier,
-                                          )
-                                          .load();
-                                    },
-                                    actionFocusNode: _premiumizeActionFocus,
-                                    tokenFocusNode: _premiumizeTokenFocus,
-                                    saveFocusNode: _premiumizeSaveFocus,
-                                  ),
-                                },
-                              ],
-                            ),
+                                'Personalize TetoTV, the Home screen, navigation, and feedback.',
                           ),
+                          const SizedBox(height: 8),
                         ],
-                      ),
-                      right: _SettingsCardLane(
-                        children: [
-                          settingsSectionCard(
-                            key: const ValueKey(
-                              'settings-card-services-sources',
-                            ),
-                            section: _SettingsSection.sourcesStreamOrder,
-                            subtitle:
-                                'Choose which source types are searched and how results are ranked.',
-                            child: Column(
-                              crossAxisAlignment: CrossAxisAlignment.stretch,
-                              children: [
-                                _StreamingSourcesPanel(
-                                  preferences: preferences,
-                                  debridFocusNode: _debridStreamsFocus,
-                                  webFocusNode: _webStreamsFocus,
-                                  directTorrentFocusNode: _directTorrentFocus,
-                                  marketplaceFocusNode: _marketplaceFocus,
-                                  onDebridChanged: ref
-                                      .read(
-                                        settingsPreferencesProvider.notifier,
-                                      )
-                                      .setDebridStreamsEnabled,
-                                  onWebChanged: ref
-                                      .read(
-                                        settingsPreferencesProvider.notifier,
-                                      )
-                                      .setWebStreamsEnabled,
-                                  onDirectTorrentChanged:
-                                      _setDirectTorrentEnabled,
-                                  onMarketplace: () =>
-                                      context.push('/settings/marketplace'),
-                                ),
-                                const SizedBox(height: 8),
-                                _StreamRankingPanel(
-                                  preferences: preferences,
-                                  debridSortFocusNode: _debridSortFocus,
-                                  sourcePriorityFocusNode: _sourcePriorityFocus,
-                                  webQualityFocusNode: _webQualityFocus,
-                                  onDebridSortSelected: ref
-                                      .read(
-                                        settingsPreferencesProvider.notifier,
-                                      )
-                                      .setDebridStreamSort,
-                                  onSourcePrioritySelected: ref
-                                      .read(
-                                        settingsPreferencesProvider.notifier,
-                                      )
-                                      .setStreamSourcePriority,
-                                  onWebQualitySelected: ref
-                                      .read(
-                                        settingsPreferencesProvider.notifier,
-                                      )
-                                      .setWebStreamQuality,
-                                ),
-                              ],
-                            ),
+                        _AppearanceSettingsLayout(
+                          usesTvListLayout: layout.usesTvRail,
+                          preferences: preferences,
+                          titlePreference: titlePreference,
+                          homeShelves: homeShelves,
+                          homeShelfOrder: homeShelfOrder,
+                          controller: ref.read(
+                            settingsPreferencesProvider.notifier,
                           ),
-                          if (layout.usesTvRail) automaticSourceSelectionCard(),
-                          if (layout.usesTvRail) librariesAndFeaturesCard(),
-                          if (layout.usesTvRail) streamingPrivacyCard(),
-                        ],
-                      ),
-                    ),
-                    if (!layout.usesTvRail) ...[
-                      const SizedBox(height: 8),
-                      automaticSourceSelectionCard(),
-                      const SizedBox(height: 10),
-                    ],
-                  ],
-                  if (_activeArea == _SettingsArea.services &&
-                      !layout.usesTvRail) ...[
-                    _SettingsResponsiveColumns(
-                      left: librariesAndFeaturesCard(),
-                      right: streamingPrivacyCard(),
-                    ),
-                    const SizedBox(height: 10),
-                  ],
-                  if (_activeArea == _SettingsArea.accounts) ...[
-                    if (!layout.usesTvRail) ...[
-                      const _SectionHeader(
-                        icon: Icons.sync_alt_rounded,
-                        title: 'ACCOUNTS',
-                        subtitle:
-                            'Profiles, anime tracking, notifications, and linked services.',
-                      ),
-                      const SizedBox(height: 8),
-                    ],
-                    _SettingsResponsiveColumns(
-                      forceSingleColumn: layout.usesTvRail,
-                      left: _SettingsCardLane(
-                        children: [
-                          settingsSectionCard(
-                            key: const ValueKey(
-                              'settings-card-accounts-tracking',
-                            ),
-                            section: _SettingsSection.animeTracking,
+                          themeStudioFocusNode: _customizationFocus,
+                          titleLanguageFocusNode: _titleLanguageFocus,
+                          showTitleStyleFocusNode: _showTitleStyleFocus,
+                          navigationSizeFocusNode: _navigationSizeFocus,
+                          menuOrderFocusNode: _menuOrderFocus,
+                          resetFocusNode: _customizationResetFocus,
+                          featuredFocusNode: _featuredHomeContentFocus,
+                          posterMetadataFocusNode: _posterMetadataFocus,
+                          continueWatchingFocusNode: _continueWatchingFocus,
+                          displayOptionsFirstFocusNode: _displaySectionFocus,
+                          cardDetailsFocusNode: _cardDetailsFocus,
+                          inputFeedbackFirstFocusNode:
+                              _inputFeedbackSectionFocus,
+                          clickSoundsFocusNode: _clickSoundsFocus,
+                          shelfFocusNodes: _shelfFocusNodes,
+                          expandedSections: _expandedSettingsSections,
+                          sectionFocusNodes: _settingsSectionFocusNodes,
+                          onSectionExpandedChanged: _setSettingsSectionExpanded,
+                          onOpenThemeStudio: () =>
+                              context.push(ThemeStudioScreen.routePath),
+                          onOpenMenuOrder: _openMenuOrderDialog,
+                          onTitleLanguageChanged: (preference) => ref
+                              .read(titleLanguagePreferenceProvider.notifier)
+                              .setPreference(preference),
+                          onReset: resetAppearance,
+                          onShelfToggle: (shelf) => ref
+                              .read(homeShelfPreferencesProvider.notifier)
+                              .toggle(shelf),
+                          onShelfMove: (shelf, offset) => ref
+                              .read(homeShelfOrderProvider.notifier)
+                              .move(shelf, offset),
+                        ),
+                        SizedBox(height: layout.usesTvRail ? 5 : 10),
+                      ],
+                      if (_activeArea == _SettingsArea.playback) ...[
+                        if (!layout.usesTvRail) ...[
+                          const _SectionHeader(
+                            icon: Icons.play_circle_rounded,
+                            title: 'PLAYBACK',
                             subtitle:
-                                'Connect a list provider and keep episode progress synchronized.',
-                            child: Column(
-                              crossAxisAlignment: CrossAxisAlignment.stretch,
-                              children: [
-                                _SettingsSelection<TrackingProvider>(
-                                  focusNode: _trackingProviderFocus,
-                                  label: 'Anime-list provider',
-                                  value: preferences.trackingProvider,
-                                  options: [
-                                    for (final provider
-                                        in TrackingProvider.values)
-                                      _SettingsOption(
-                                        value: provider,
-                                        label: provider.displayName,
-                                        detail: tracking.isConnected(provider)
-                                            ? 'Connected as ${tracking.usernames[provider]}'
-                                            : 'Not connected',
-                                      ),
-                                  ],
-                                  onSelected: ref
-                                      .read(
-                                        settingsPreferencesProvider.notifier,
-                                      )
-                                      .setTrackingProvider,
-                                  showDivider: true,
+                                'Tune captions, player behavior, audio, skipping, and seeking.',
+                          ),
+                          const SizedBox(height: 8),
+                        ],
+                        _SettingsResponsiveColumns(
+                          forceSingleColumn: layout.usesTvRail,
+                          left: settingsSectionCard(
+                            key: const ValueKey(
+                              'settings-card-playback-captions',
+                            ),
+                            section: _SettingsSection.closedCaptions,
+                            subtitle:
+                                'Style subtitles for comfortable viewing on every screen.',
+                            child: customizationPanel(const {
+                              _CustomizationSection.closedCaptions,
+                            }, showReset: false),
+                          ),
+                          right: settingsSectionCard(
+                            key: const ValueKey(
+                              'settings-card-playback-player',
+                            ),
+                            section: _SettingsSection.playerControls,
+                            subtitle:
+                                'Choose audio, skipping, seeking, and playback behavior.',
+                            child: customizationPanel(const {
+                              _CustomizationSection.playerControls,
+                            }, showReset: false),
+                          ),
+                        ),
+                        SizedBox(height: layout.usesTvRail ? 5 : 10),
+                      ],
+                      if (_activeArea == _SettingsArea.services) ...[
+                        if (!layout.usesTvRail) ...[
+                          const _SectionHeader(
+                            icon: Icons.hub_rounded,
+                            title: 'SERVICES',
+                            subtitle:
+                                'Connect providers and choose how episode sources are found.',
+                          ),
+                          const SizedBox(height: 8),
+                        ],
+                        _SettingsResponsiveColumns(
+                          forceSingleColumn: layout.usesTvRail,
+                          left: _SettingsCardLane(
+                            children: [
+                              settingsSectionCard(
+                                key: const ValueKey(
+                                  'settings-card-services-debrid',
                                 ),
-                                _TrackingPanel(
-                                  provider: preferences.trackingProvider,
-                                  color:
-                                      preferences.trackingProvider ==
-                                          TrackingProvider.anilist
-                                      ? context.appPalette.accentBright
-                                      : const Color(0xFFB41F3D),
-                                  description:
-                                      preferences.trackingProvider ==
-                                          TrackingProvider.anilist
-                                      ? 'Seasonal discovery, lists, and automatic episode progress.'
-                                      : 'Sync watch progress and MAL statuses automatically.',
-                                  username: tracking
-                                      .usernames[preferences.trackingProvider],
-                                  error: tracking
-                                      .errors[preferences.trackingProvider],
-                                  isLoading: tracking.isLoading,
-                                  onConnect: () async {
-                                    await context.push(
-                                      preferences.trackingProvider ==
+                                section: _SettingsSection.debridStreaming,
+                                subtitle:
+                                    'Choose and securely connect the provider used to resolve streams.',
+                                child: Column(
+                                  crossAxisAlignment:
+                                      CrossAxisAlignment.stretch,
+                                  children: [
+                                    _SettingsSelection<DebridService>(
+                                      focusNode: _debridProviderFocus,
+                                      label: 'Debrid provider',
+                                      value: preferences.debridProvider,
+                                      options: [
+                                        for (final service
+                                            in DebridService.values)
+                                          _SettingsOption(
+                                            value: service,
+                                            label: service.displayName,
+                                            detail:
+                                                switch (service) {
+                                                  DebridService.realDebrid =>
+                                                    debrid.hasSavedToken,
+                                                  DebridService.torBox =>
+                                                    torBox.hasSavedToken,
+                                                  DebridService.allDebrid =>
+                                                    allDebrid.hasSavedToken,
+                                                  DebridService.premiumize =>
+                                                    premiumize.hasSavedToken,
+                                                }
+                                                ? 'Connected'
+                                                : 'Not connected',
+                                          ),
+                                      ],
+                                      onSelected: ref
+                                          .read(
+                                            settingsPreferencesProvider
+                                                .notifier,
+                                          )
+                                          .setDebridProvider,
+                                      showDivider: true,
+                                    ),
+                                    switch (preferences.debridProvider) {
+                                      DebridService.realDebrid =>
+                                        _RealDebridPanel(
+                                          state: debrid,
+                                          onDisconnect: () => ref
+                                              .read(
+                                                realDebridSettingsControllerProvider
+                                                    .notifier,
+                                              )
+                                              .disconnect(),
+                                          onDeviceConnect: () =>
+                                              context.push('/pair/realdebrid'),
+                                          connectFocusNode: _debridConnectFocus,
+                                        ),
+                                      DebridService.torBox => _TorBoxPanel(
+                                        state: torBox,
+                                        tokenController: _torBoxTokenController,
+                                        onSave: () async {
+                                          final saved = await ref
+                                              .read(
+                                                torBoxSettingsControllerProvider
+                                                    .notifier,
+                                              )
+                                              .saveAndValidate(
+                                                _torBoxTokenController.text,
+                                              );
+                                          if (saved) {
+                                            _torBoxTokenController.clear();
+                                          }
+                                        },
+                                        onDisconnect: () => ref
+                                            .read(
+                                              torBoxSettingsControllerProvider
+                                                  .notifier,
+                                            )
+                                            .disconnect(),
+                                        onDeviceConnect: () async {
+                                          await context.push('/pair/torbox');
+                                          await ref
+                                              .read(
+                                                torBoxSettingsControllerProvider
+                                                    .notifier,
+                                              )
+                                              .load();
+                                        },
+                                        actionFocusNode: _torBoxActionFocus,
+                                        tokenFocusNode: _torBoxTokenFocus,
+                                        saveFocusNode: _torBoxSaveFocus,
+                                      ),
+                                      DebridService.allDebrid => _ApiKeyDebridPanel(
+                                        title: 'AllDebrid',
+                                        icon: Icons.cloud_sync_rounded,
+                                        gradient: [
+                                          context.appPalette.accent,
+                                          context.appPalette.secondaryAccent,
+                                        ],
+                                        connected: allDebrid.account != null,
+                                        hasSavedToken: allDebrid.hasSavedToken,
+                                        connectedLabel: 'PREMIUM',
+                                        description: allDebrid.account == null
+                                            ? 'Authorize with AllDebrid PIN, or enter a personal API key.'
+                                            : 'Connected as ${allDebrid.account!.username}. '
+                                                  'Torrent files resolve through AllDebrid only.',
+                                        errorMessage: allDebrid.errorMessage,
+                                        isLoading: allDebrid.isLoading,
+                                        tokenController:
+                                            _allDebridTokenController,
+                                        tokenTitle: 'AllDebrid API key',
+                                        keyboardTitle:
+                                            'Enter AllDebrid API key',
+                                        connectLabel: 'Connect by PIN',
+                                        connectIcon: Icons.qr_code_rounded,
+                                        onSave: () async {
+                                          final saved = await ref
+                                              .read(
+                                                allDebridSettingsControllerProvider
+                                                    .notifier,
+                                              )
+                                              .saveAndValidate(
+                                                _allDebridTokenController.text,
+                                              );
+                                          if (saved) {
+                                            _allDebridTokenController.clear();
+                                          }
+                                        },
+                                        onDisconnect: () => ref
+                                            .read(
+                                              allDebridSettingsControllerProvider
+                                                  .notifier,
+                                            )
+                                            .disconnect(),
+                                        onConnect: () async {
+                                          await context.push('/pair/alldebrid');
+                                          await ref
+                                              .read(
+                                                allDebridSettingsControllerProvider
+                                                    .notifier,
+                                              )
+                                              .load();
+                                        },
+                                        actionFocusNode: _allDebridActionFocus,
+                                        tokenFocusNode: _allDebridTokenFocus,
+                                        saveFocusNode: _allDebridSaveFocus,
+                                      ),
+                                      DebridService.premiumize => _ApiKeyDebridPanel(
+                                        title: 'Premiumize',
+                                        icon: Icons.cloud_queue_rounded,
+                                        gradient: [
+                                          context.appPalette.secondaryAccent,
+                                          context.appPalette.accentBright,
+                                        ],
+                                        connected: premiumize.account != null,
+                                        hasSavedToken: premiumize.hasSavedToken,
+                                        connectedLabel: 'PREMIUM',
+                                        description: premiumize.account == null
+                                            ? 'Enter the API key from your Premiumize account page.'
+                                            : 'Connected as customer '
+                                                  '${premiumize.account!.customerId}. '
+                                                  'Torrent files resolve through Premiumize only.',
+                                        errorMessage: premiumize.errorMessage,
+                                        isLoading: premiumize.isLoading,
+                                        tokenController:
+                                            _premiumizeTokenController,
+                                        tokenTitle: 'Premiumize API key',
+                                        keyboardTitle:
+                                            'Enter Premiumize API key',
+                                        connectLabel: 'Connection help',
+                                        connectIcon: Icons.key_rounded,
+                                        onSave: () async {
+                                          final saved = await ref
+                                              .read(
+                                                premiumizeSettingsControllerProvider
+                                                    .notifier,
+                                              )
+                                              .saveAndValidate(
+                                                _premiumizeTokenController.text,
+                                              );
+                                          if (saved) {
+                                            _premiumizeTokenController.clear();
+                                          }
+                                        },
+                                        onDisconnect: () => ref
+                                            .read(
+                                              premiumizeSettingsControllerProvider
+                                                  .notifier,
+                                            )
+                                            .disconnect(),
+                                        onConnect: () async {
+                                          await context.push(
+                                            '/pair/premiumize',
+                                          );
+                                          await ref
+                                              .read(
+                                                premiumizeSettingsControllerProvider
+                                                    .notifier,
+                                              )
+                                              .load();
+                                        },
+                                        actionFocusNode: _premiumizeActionFocus,
+                                        tokenFocusNode: _premiumizeTokenFocus,
+                                        saveFocusNode: _premiumizeSaveFocus,
+                                      ),
+                                    },
+                                  ],
+                                ),
+                              ),
+                            ],
+                          ),
+                          right: _SettingsCardLane(
+                            children: [
+                              settingsSectionCard(
+                                key: const ValueKey(
+                                  'settings-card-services-sources',
+                                ),
+                                section: _SettingsSection.sourcesStreamOrder,
+                                subtitle:
+                                    'Choose which source types are searched and how results are ranked.',
+                                child: Column(
+                                  crossAxisAlignment:
+                                      CrossAxisAlignment.stretch,
+                                  children: [
+                                    _StreamingSourcesPanel(
+                                      preferences: preferences,
+                                      debridFocusNode: _debridStreamsFocus,
+                                      webFocusNode: _webStreamsFocus,
+                                      directTorrentFocusNode:
+                                          _directTorrentFocus,
+                                      marketplaceFocusNode: _marketplaceFocus,
+                                      onDebridChanged: ref
+                                          .read(
+                                            settingsPreferencesProvider
+                                                .notifier,
+                                          )
+                                          .setDebridStreamsEnabled,
+                                      onWebChanged: ref
+                                          .read(
+                                            settingsPreferencesProvider
+                                                .notifier,
+                                          )
+                                          .setWebStreamsEnabled,
+                                      onDirectTorrentChanged:
+                                          _setDirectTorrentEnabled,
+                                      onMarketplace: () =>
+                                          context.push('/settings/marketplace'),
+                                    ),
+                                    const SizedBox(height: 8),
+                                    _StreamRankingPanel(
+                                      preferences: preferences,
+                                      debridSortFocusNode: _debridSortFocus,
+                                      sourcePriorityFocusNode:
+                                          _sourcePriorityFocus,
+                                      webQualityFocusNode: _webQualityFocus,
+                                      onDebridSortSelected: ref
+                                          .read(
+                                            settingsPreferencesProvider
+                                                .notifier,
+                                          )
+                                          .setDebridStreamSort,
+                                      onSourcePrioritySelected: ref
+                                          .read(
+                                            settingsPreferencesProvider
+                                                .notifier,
+                                          )
+                                          .setStreamSourcePriority,
+                                      onWebQualitySelected: ref
+                                          .read(
+                                            settingsPreferencesProvider
+                                                .notifier,
+                                          )
+                                          .setWebStreamQuality,
+                                    ),
+                                  ],
+                                ),
+                              ),
+                              if (layout.usesTvRail)
+                                automaticSourceSelectionCard(),
+                              if (layout.usesTvRail) librariesAndFeaturesCard(),
+                              if (layout.usesTvRail) streamingPrivacyCard(),
+                            ],
+                          ),
+                        ),
+                        if (!layout.usesTvRail) ...[
+                          const SizedBox(height: 8),
+                          automaticSourceSelectionCard(),
+                          const SizedBox(height: 10),
+                        ],
+                      ],
+                      if (_activeArea == _SettingsArea.services &&
+                          !layout.usesTvRail) ...[
+                        _SettingsResponsiveColumns(
+                          left: librariesAndFeaturesCard(),
+                          right: streamingPrivacyCard(),
+                        ),
+                        const SizedBox(height: 10),
+                      ],
+                      if (_activeArea == _SettingsArea.accounts) ...[
+                        if (!layout.usesTvRail) ...[
+                          const _SectionHeader(
+                            icon: Icons.sync_alt_rounded,
+                            title: 'ACCOUNTS',
+                            subtitle:
+                                'Profiles, anime tracking, notifications, and linked services.',
+                          ),
+                          const SizedBox(height: 8),
+                        ],
+                        _SettingsResponsiveColumns(
+                          forceSingleColumn: layout.usesTvRail,
+                          left: _SettingsCardLane(
+                            children: [
+                              settingsSectionCard(
+                                key: const ValueKey(
+                                  'settings-card-accounts-tracking',
+                                ),
+                                section: _SettingsSection.animeTracking,
+                                subtitle:
+                                    'Connect a list provider and keep episode progress synchronized.',
+                                child: Column(
+                                  crossAxisAlignment:
+                                      CrossAxisAlignment.stretch,
+                                  children: [
+                                    _SettingsSelection<TrackingProvider>(
+                                      focusNode: _trackingProviderFocus,
+                                      label: 'Anime-list provider',
+                                      value: preferences.trackingProvider,
+                                      options: [
+                                        for (final provider
+                                            in TrackingProvider.values)
+                                          _SettingsOption(
+                                            value: provider,
+                                            label: provider.displayName,
+                                            detail:
+                                                tracking.isConnected(provider)
+                                                ? 'Connected as ${tracking.usernames[provider]}'
+                                                : 'Not connected',
+                                          ),
+                                      ],
+                                      onSelected: ref
+                                          .read(
+                                            settingsPreferencesProvider
+                                                .notifier,
+                                          )
+                                          .setTrackingProvider,
+                                      showDivider: true,
+                                    ),
+                                    _TrackingPanel(
+                                      provider: preferences.trackingProvider,
+                                      color:
+                                          preferences.trackingProvider ==
                                               TrackingProvider.anilist
-                                          ? '/pair/anilist'
-                                          : '/pair/myanimelist',
-                                    );
-                                    await ref
-                                        .read(
-                                          trackingAccountsControllerProvider
-                                              .notifier,
-                                        )
-                                        .load();
-                                  },
-                                  onDisconnect: () => ref
-                                      .read(
-                                        trackingAccountsControllerProvider
-                                            .notifier,
-                                      )
-                                      .disconnect(preferences.trackingProvider),
-                                  onSaveToken: (token) => ref
-                                      .read(
-                                        trackingAccountsControllerProvider
-                                            .notifier,
-                                      )
-                                      .save(
-                                        preferences.trackingProvider,
-                                        token,
-                                      ),
-                                  focusNode:
-                                      preferences.trackingProvider ==
-                                          TrackingProvider.anilist
-                                      ? _anilistFocus
-                                      : _malFocus,
-                                  tokenFocusNode:
-                                      preferences.trackingProvider ==
-                                          TrackingProvider.anilist
-                                      ? _anilistTokenFocus
-                                      : _malTokenFocus,
-                                  saveFocusNode:
-                                      preferences.trackingProvider ==
-                                          TrackingProvider.anilist
-                                      ? _anilistSaveFocus
-                                      : _malSaveFocus,
-                                  disconnectFocusNode: _trackingDisconnectFocus,
-                                ),
-                              ],
-                            ),
-                          ),
-                          settingsSectionCard(
-                            key: const ValueKey(
-                              'settings-card-accounts-profiles',
-                            ),
-                            section: _SettingsSection.profiles,
-                            subtitle:
-                                'Manage local viewers and their separate preferences.',
-                            child: _LocalProfilesPanel(
-                              state: localProfiles,
-                              focusNode: _localProfilesFocus,
-                            ),
-                          ),
-                        ],
-                      ),
-                      right: _SettingsCardLane(
-                        children: [
-                          settingsSectionCard(
-                            key: const ValueKey(
-                              'settings-card-accounts-behavior',
-                            ),
-                            section: _SettingsSection.progressNotifications,
-                            subtitle:
-                                'Choose when progress syncs and which episode alerts appear.',
-                            child: Column(
-                              crossAxisAlignment: CrossAxisAlignment.stretch,
-                              children: [
-                                _SettingsSelection<TrackerUpdateThreshold>(
-                                  key: const ValueKey(
-                                    'settings-tracking-update-threshold',
-                                  ),
-                                  focusNode: _trackingThresholdFocus,
-                                  label: 'When to update episode progress',
-                                  value: preferences.trackerUpdateThreshold,
-                                  options: [
-                                    for (final threshold
-                                        in TrackerUpdateThreshold.values)
-                                      _SettingsOption(
-                                        value: threshold,
-                                        label: threshold.displayName,
-                                        detail: threshold.description,
-                                      ),
+                                          ? context.appPalette.accentBright
+                                          : const Color(0xFFB41F3D),
+                                      description:
+                                          preferences.trackingProvider ==
+                                              TrackingProvider.anilist
+                                          ? 'Seasonal discovery, lists, and automatic episode progress.'
+                                          : 'Sync watch progress and MAL statuses automatically.',
+                                      username:
+                                          tracking.usernames[preferences
+                                              .trackingProvider],
+                                      error: tracking
+                                          .errors[preferences.trackingProvider],
+                                      isLoading: tracking.isLoading,
+                                      onConnect: () async {
+                                        await context.push(
+                                          preferences.trackingProvider ==
+                                                  TrackingProvider.anilist
+                                              ? '/pair/anilist'
+                                              : '/pair/myanimelist',
+                                        );
+                                        await ref
+                                            .read(
+                                              trackingAccountsControllerProvider
+                                                  .notifier,
+                                            )
+                                            .load();
+                                      },
+                                      onDisconnect: () => ref
+                                          .read(
+                                            trackingAccountsControllerProvider
+                                                .notifier,
+                                          )
+                                          .disconnect(
+                                            preferences.trackingProvider,
+                                          ),
+                                      onSaveToken: (token) => ref
+                                          .read(
+                                            trackingAccountsControllerProvider
+                                                .notifier,
+                                          )
+                                          .save(
+                                            preferences.trackingProvider,
+                                            token,
+                                          ),
+                                      focusNode:
+                                          preferences.trackingProvider ==
+                                              TrackingProvider.anilist
+                                          ? _anilistFocus
+                                          : _malFocus,
+                                      tokenFocusNode:
+                                          preferences.trackingProvider ==
+                                              TrackingProvider.anilist
+                                          ? _anilistTokenFocus
+                                          : _malTokenFocus,
+                                      saveFocusNode:
+                                          preferences.trackingProvider ==
+                                              TrackingProvider.anilist
+                                          ? _anilistSaveFocus
+                                          : _malSaveFocus,
+                                      disconnectFocusNode:
+                                          _trackingDisconnectFocus,
+                                    ),
                                   ],
-                                  onSelected: ref
-                                      .read(
-                                        settingsPreferencesProvider.notifier,
-                                      )
-                                      .setTrackerUpdateThreshold,
-                                  showDivider: true,
                                 ),
-                                const _SettingsSupportingText(
-                                  'Trackers store whole completed episodes, so the '
-                                  'selected percentage marks the current episode watched.',
+                              ),
+                              settingsSectionCard(
+                                key: const ValueKey(
+                                  'settings-card-accounts-profiles',
                                 ),
-                                _AppearanceToggleRow(
-                                  key: const ValueKey(
-                                    'settings-sub-episode-notifications',
-                                  ),
-                                  label: 'Sub & simulcast alerts',
-                                  subtitle:
-                                      'Notify when a subtitled or simulcast episode reaches its normal airtime.',
-                                  icon: Icons.subtitles_outlined,
-                                  value: preferences
-                                      .subEpisodeNotificationsEnabled,
-                                  focusNode: _subEpisodeNotificationsFocus,
-                                  showDivider: true,
-                                  onChanged: ref
-                                      .read(
-                                        settingsPreferencesProvider.notifier,
-                                      )
-                                      .setSubEpisodeNotificationsEnabled,
+                                section: _SettingsSection.profiles,
+                                subtitle:
+                                    'Manage local viewers and their separate preferences.',
+                                child: _LocalProfilesPanel(
+                                  state: localProfiles,
+                                  focusNode: _localProfilesFocus,
                                 ),
-                                _AppearanceToggleRow(
-                                  key: const ValueKey(
-                                    'settings-dub-episode-notifications',
-                                  ),
-                                  label: 'Verified dub alerts',
-                                  subtitle:
-                                      'Notify only when a dubbed episode has a verified release schedule.',
-                                  icon: Icons.record_voice_over_outlined,
-                                  value: preferences
-                                      .dubEpisodeNotificationsEnabled,
-                                  focusNode: _dubEpisodeNotificationsFocus,
-                                  onChanged: ref
-                                      .read(
-                                        settingsPreferencesProvider.notifier,
-                                      )
-                                      .setDubEpisodeNotificationsEnabled,
-                                ),
-                              ],
-                            ),
+                              ),
+                            ],
                           ),
-                          if (layout.usesTvRail) discordPresenceCard(),
-                        ],
-                      ),
-                    ),
-                    if (!layout.usesTvRail) const SizedBox(height: 10),
-                  ],
-                  if (_activeArea == _SettingsArea.system) ...[
-                    if (!layout.usesTvRail) ...[
-                      const _SectionHeader(
-                        icon: Icons.settings_rounded,
-                        title: 'SYSTEM',
-                        subtitle:
-                            'Manage this device, updates, diagnostics, privacy, storage, and legal information.',
-                      ),
-                      const SizedBox(height: 8),
-                    ],
-                    _SettingsResponsiveColumns(
-                      forceSingleColumn: layout.usesTvRail,
-                      left: _SettingsCardLane(
-                        children: [
-                          settingsSectionCard(
-                            key: const ValueKey('settings-card-system-support'),
-                            section: _SettingsSection.deviceSupport,
-                            subtitle:
-                                'Setup, device compatibility, calibration, and diagnostics.',
-                            child: Column(
-                              children: [
-                                _AppearanceActionRow(
-                                  label: 'Run setup again',
-                                  subtitle:
-                                      'Change setup method or reconnect your services.',
-                                  icon: Icons.auto_awesome_rounded,
-                                  focusNode: _setupFocus,
-                                  showDivider: true,
-                                  onPressed: () => context.push('/setup/start'),
+                          right: _SettingsCardLane(
+                            children: [
+                              settingsSectionCard(
+                                key: const ValueKey(
+                                  'settings-card-accounts-behavior',
                                 ),
-                                _AppearanceActionRow(
-                                  label: 'Device calibration',
-                                  subtitle:
-                                      'Adjust display fit, input, and playback compatibility.',
-                                  icon: Icons.tune_rounded,
-                                  focusNode: _calibrationFocus,
-                                  showDivider: true,
-                                  onPressed: () =>
-                                      context.push('/settings/device-setup'),
-                                ),
-                                _AppearanceActionRow(
-                                  label: 'Diagnostics',
-                                  subtitle:
-                                      'Review system health and export troubleshooting details.',
-                                  icon: Icons.monitor_heart_rounded,
-                                  focusNode: _diagnosticsFocus,
-                                  onPressed: () =>
-                                      context.push('/settings/diagnostics'),
-                                ),
-                              ],
-                            ),
-                          ),
-                        ],
-                      ),
-                      right: _SettingsCardLane(
-                        children: [
-                          settingsSectionCard(
-                            key: const ValueKey('settings-card-system-updates'),
-                            section: _SettingsSection.appUpdates,
-                            subtitle:
-                                'Stable public releases download directly to this device.',
-                            child: Column(
-                              crossAxisAlignment: CrossAxisAlignment.stretch,
-                              children: [
-                                _AppUpdatePanel(
-                                  forceSingleColumn: isTelevision,
-                                  state: appUpdate,
-                                  automaticFocusNode: _automaticUpdatesFocus,
-                                  checkFocusNode: _checkUpdatesFocus,
-                                  onToggleAutomatic: () => ref
-                                      .read(
-                                        appUpdateControllerProvider.notifier,
-                                      )
-                                      .setAutomaticUpdates(
-                                        !appUpdate.automaticUpdates,
+                                section: _SettingsSection.progressNotifications,
+                                subtitle:
+                                    'Choose when progress syncs and which episode alerts appear.',
+                                child: Column(
+                                  crossAxisAlignment:
+                                      CrossAxisAlignment.stretch,
+                                  children: [
+                                    _SettingsSelection<TrackerUpdateThreshold>(
+                                      key: const ValueKey(
+                                        'settings-tracking-update-threshold',
                                       ),
-                                  onCheckOrInstall: () {
-                                    final controller = ref.read(
-                                      appUpdateControllerProvider.notifier,
-                                    );
-                                    if (appUpdate.downloadedPath != null) {
-                                      controller.installDownloadedUpdate();
-                                    } else {
-                                      controller.checkForUpdates(
-                                        launchInstaller: true,
-                                      );
-                                    }
-                                  },
+                                      focusNode: _trackingThresholdFocus,
+                                      label: 'When to update episode progress',
+                                      value: preferences.trackerUpdateThreshold,
+                                      options: [
+                                        for (final threshold
+                                            in TrackerUpdateThreshold.values)
+                                          _SettingsOption(
+                                            value: threshold,
+                                            label: threshold.displayName,
+                                            detail: threshold.description,
+                                          ),
+                                      ],
+                                      onSelected: ref
+                                          .read(
+                                            settingsPreferencesProvider
+                                                .notifier,
+                                          )
+                                          .setTrackerUpdateThreshold,
+                                      showDivider: true,
+                                    ),
+                                    const _SettingsSupportingText(
+                                      'Trackers store whole completed episodes, so the '
+                                      'selected percentage marks the current episode watched.',
+                                    ),
+                                    _AppearanceToggleRow(
+                                      key: const ValueKey(
+                                        'settings-sub-episode-notifications',
+                                      ),
+                                      label: 'Sub & simulcast alerts',
+                                      subtitle:
+                                          'Notify when a subtitled or simulcast episode reaches its normal airtime.',
+                                      icon: Icons.subtitles_outlined,
+                                      value: preferences
+                                          .subEpisodeNotificationsEnabled,
+                                      focusNode: _subEpisodeNotificationsFocus,
+                                      showDivider: true,
+                                      onChanged: ref
+                                          .read(
+                                            settingsPreferencesProvider
+                                                .notifier,
+                                          )
+                                          .setSubEpisodeNotificationsEnabled,
+                                    ),
+                                    _AppearanceToggleRow(
+                                      key: const ValueKey(
+                                        'settings-dub-episode-notifications',
+                                      ),
+                                      label: 'Verified dub alerts',
+                                      subtitle:
+                                          'Notify only when a dubbed episode has a verified release schedule.',
+                                      icon: Icons.record_voice_over_outlined,
+                                      value: preferences
+                                          .dubEpisodeNotificationsEnabled,
+                                      focusNode: _dubEpisodeNotificationsFocus,
+                                      onChanged: ref
+                                          .read(
+                                            settingsPreferencesProvider
+                                                .notifier,
+                                          )
+                                          .setDubEpisodeNotificationsEnabled,
+                                    ),
+                                  ],
                                 ),
-                                const SizedBox(height: 8),
-                                _DeveloperUpdatePanel(
-                                  state: appUpdate,
-                                  channelFocusNode: _updateChannelFocus,
-                                  releaseHistoryFocusNode: _releaseHistoryFocus,
-                                  onChannelSelected: ref
-                                      .read(
-                                        appUpdateControllerProvider.notifier,
-                                      )
-                                      .setUpdateChannel,
-                                  onRefreshHistory: ref
-                                      .read(
-                                        appUpdateControllerProvider.notifier,
-                                      )
-                                      .refreshReleaseHistory,
-                                  onReleaseSelected: ref
-                                      .read(
-                                        appUpdateControllerProvider.notifier,
-                                      )
-                                      .installReleaseFromHistory,
-                                ),
-                              ],
-                            ),
+                              ),
+                              if (layout.usesTvRail) discordPresenceCard(),
+                            ],
                           ),
-                          if (layout.usesTvRail) communityCard(),
-                          if (layout.usesTvRail) storageAndResetCard(),
-                          if (layout.usesTvRail) legalNoticesCard(),
-                          if (layout.usesTvRail) privacyAndDiagnosticsCard(),
+                        ),
+                        if (!layout.usesTvRail) const SizedBox(height: 10),
+                      ],
+                      if (_activeArea == _SettingsArea.system) ...[
+                        if (!layout.usesTvRail) ...[
+                          const _SectionHeader(
+                            icon: Icons.settings_rounded,
+                            title: 'SYSTEM',
+                            subtitle:
+                                'Manage this device, updates, diagnostics, privacy, storage, and legal information.',
+                          ),
+                          const SizedBox(height: 8),
                         ],
-                      ),
-                    ),
-                    if (!layout.usesTvRail) const SizedBox(height: 12),
-                  ],
-                  if (_activeArea == _SettingsArea.accounts &&
-                      !layout.usesTvRail) ...[
-                    discordPresenceCard(),
-                    const SizedBox(height: 12),
-                  ],
-                  if (_activeArea == _SettingsArea.system &&
-                      !layout.usesTvRail) ...[
-                    _SettingsResponsiveColumns(
-                      left: communityCard(),
-                      right: Column(
-                        crossAxisAlignment: CrossAxisAlignment.stretch,
-                        children: [
-                          storageAndResetCard(),
-                          const SizedBox(height: 12),
-                          legalNoticesCard(),
-                          const SizedBox(height: 12),
-                          privacyAndDiagnosticsCard(),
-                        ],
-                      ),
-                    ),
-                  ],
-                ],
+                        _SettingsResponsiveColumns(
+                          forceSingleColumn: layout.usesTvRail,
+                          left: _SettingsCardLane(
+                            children: [
+                              settingsSectionCard(
+                                key: const ValueKey(
+                                  'settings-card-system-support',
+                                ),
+                                section: _SettingsSection.deviceSupport,
+                                subtitle:
+                                    'Setup, device compatibility, calibration, and diagnostics.',
+                                child: Column(
+                                  children: [
+                                    _AppearanceActionRow(
+                                      label: 'Run setup again',
+                                      subtitle:
+                                          'Change setup method or reconnect your services.',
+                                      icon: Icons.auto_awesome_rounded,
+                                      focusNode: _setupFocus,
+                                      showDivider: true,
+                                      onPressed: () =>
+                                          context.push('/setup/start'),
+                                    ),
+                                    _AppearanceActionRow(
+                                      label: 'Device calibration',
+                                      subtitle:
+                                          'Adjust display fit, input, and playback compatibility.',
+                                      icon: Icons.tune_rounded,
+                                      focusNode: _calibrationFocus,
+                                      showDivider: true,
+                                      onPressed: () => context.push(
+                                        '/settings/device-setup',
+                                      ),
+                                    ),
+                                    _AppearanceActionRow(
+                                      label: 'Diagnostics',
+                                      subtitle:
+                                          'Review system health and export troubleshooting details.',
+                                      icon: Icons.monitor_heart_rounded,
+                                      focusNode: _diagnosticsFocus,
+                                      onPressed: () =>
+                                          context.push('/settings/diagnostics'),
+                                    ),
+                                  ],
+                                ),
+                              ),
+                            ],
+                          ),
+                          right: _SettingsCardLane(
+                            children: [
+                              settingsSectionCard(
+                                key: const ValueKey(
+                                  'settings-card-system-updates',
+                                ),
+                                section: _SettingsSection.appUpdates,
+                                subtitle:
+                                    'Stable public releases download directly to this device.',
+                                child: Column(
+                                  crossAxisAlignment:
+                                      CrossAxisAlignment.stretch,
+                                  children: [
+                                    _AppUpdatePanel(
+                                      forceSingleColumn: isTelevision,
+                                      state: appUpdate,
+                                      automaticFocusNode:
+                                          _automaticUpdatesFocus,
+                                      checkFocusNode: _checkUpdatesFocus,
+                                      onToggleAutomatic: () => ref
+                                          .read(
+                                            appUpdateControllerProvider
+                                                .notifier,
+                                          )
+                                          .setAutomaticUpdates(
+                                            !appUpdate.automaticUpdates,
+                                          ),
+                                      onCheckOrInstall: () {
+                                        final controller = ref.read(
+                                          appUpdateControllerProvider.notifier,
+                                        );
+                                        if (appUpdate.downloadedPath != null) {
+                                          controller.installDownloadedUpdate();
+                                        } else {
+                                          controller.checkForUpdates(
+                                            launchInstaller: true,
+                                          );
+                                        }
+                                      },
+                                    ),
+                                    const SizedBox(height: 8),
+                                    _DeveloperUpdatePanel(
+                                      state: appUpdate,
+                                      channelFocusNode: _updateChannelFocus,
+                                      releaseHistoryFocusNode:
+                                          _releaseHistoryFocus,
+                                      onChannelSelected: ref
+                                          .read(
+                                            appUpdateControllerProvider
+                                                .notifier,
+                                          )
+                                          .setUpdateChannel,
+                                      onRefreshHistory: ref
+                                          .read(
+                                            appUpdateControllerProvider
+                                                .notifier,
+                                          )
+                                          .refreshReleaseHistory,
+                                      onReleaseSelected: ref
+                                          .read(
+                                            appUpdateControllerProvider
+                                                .notifier,
+                                          )
+                                          .installReleaseFromHistory,
+                                    ),
+                                  ],
+                                ),
+                              ),
+                              if (layout.usesTvRail) communityCard(),
+                              if (layout.usesTvRail) storageAndResetCard(),
+                              if (layout.usesTvRail) legalNoticesCard(),
+                              if (layout.usesTvRail)
+                                privacyAndDiagnosticsCard(),
+                            ],
+                          ),
+                        ),
+                        if (!layout.usesTvRail) const SizedBox(height: 12),
+                      ],
+                      if (_activeArea == _SettingsArea.accounts &&
+                          !layout.usesTvRail) ...[
+                        discordPresenceCard(),
+                        const SizedBox(height: 12),
+                      ],
+                      if (_activeArea == _SettingsArea.system &&
+                          !layout.usesTvRail) ...[
+                        _SettingsResponsiveColumns(
+                          left: communityCard(),
+                          right: Column(
+                            crossAxisAlignment: CrossAxisAlignment.stretch,
+                            children: [
+                              storageAndResetCard(),
+                              const SizedBox(height: 12),
+                              legalNoticesCard(),
+                              const SizedBox(height: 12),
+                              privacyAndDiagnosticsCard(),
+                            ],
+                          ),
+                        ),
+                      ],
+                    ],
+                  ),
+                ),
               ),
             ),
           ],

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: 'none'
 # Public and Beta artifacts built from the same source use one monotonically
 # increasing Android versionCode. The project default carries the Beta display
 # version; the Public universal APK overrides the build name to the 1.x line.
-version: 2.0.53+410030
+version: 2.0.54+410031
 
 environment:
   sdk: ^3.12.2

--- a/test/accounts_focus_test.dart
+++ b/test/accounts_focus_test.dart
@@ -960,6 +960,42 @@ void main() {
         isTrue,
       );
 
+      // Settings is already the active destination.  Activating its rail
+      // item must restore this screen's content focus, not push a duplicate
+      // AccountsScreen route with a second, competing focus graph.
+      await tester.tap(settingsAction);
+      await tester.pumpAndSettle();
+      expect(find.byType(AccountsScreen), findsOneWidget);
+      expect(FocusManager.instance.primaryFocus?.debugLabel, 'accounts.search');
+
+      // Once the list is scrolled, the fixed search header is intentionally
+      // removed. Re-activating Settings must use the visible area tab instead
+      // of handing the shell that detached search FocusNode.
+      final settingsList = tester.widget<ListView>(
+        find.byKey(const ValueKey('settings-content-list')),
+      );
+      settingsList.controller!.jumpTo(240);
+      await tester.pump();
+      await tester.pump();
+      expect(
+        find.byKey(const ValueKey('top-level-fixed-profile')),
+        findsNothing,
+      );
+      await tester.tap(settingsAction);
+      await tester.pumpAndSettle();
+      expect(find.byType(AccountsScreen), findsOneWidget);
+      expect(
+        FocusManager.instance.primaryFocus?.debugLabel,
+        'accounts.area.appearance',
+      );
+
+      // The keyboard path should have the same behavior as a click: focus can
+      // leave the content for the rail and immediately return with RIGHT.
+      settingsList.controller!.jumpTo(0);
+      await tester.pump();
+      await tester.pump();
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowLeft);
+      await tester.pump();
       await tester.sendKeyEvent(LogicalKeyboardKey.arrowRight);
       await tester.pump();
       expect(FocusManager.instance.primaryFocus?.debugLabel, 'accounts.search');
@@ -1610,6 +1646,65 @@ void main() {
     expect(
       FocusManager.instance.primaryFocus?.debugLabel,
       'top-level.active-navigation',
+    );
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('TV settings fallback rows stay inside the content list', (
+    tester,
+  ) async {
+    FlutterSecureStorage.setMockInitialValues({});
+    tester.view.physicalSize = const Size(1280, 720);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    await tester.pumpWidget(
+      const ProviderScope(
+        child: MaterialApp(home: TvShortcuts(child: AccountsScreen())),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    final displaySection = find.byWidgetPredicate(
+      (widget) =>
+          widget is TvFocusable &&
+          widget.focusNode?.debugLabel == 'accounts.section.display',
+    );
+    final displayFocus = tester.widget<TvFocusable>(displaySection).focusNode!;
+    displayFocus.requestFocus();
+    await tester.pumpAndSettle();
+
+    // The secondary Display options rows intentionally use fallback focus
+    // nodes. Two Down presses must advance through that list, not escape to
+    // the fixed Settings rail via the app-wide reading-order policy.
+    await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
+    await tester.pump();
+    final firstFallbackFocus = FocusManager.instance.primaryFocus;
+    expect(firstFallbackFocus?.debugLabel, 'TV mouse/D-pad control');
+    await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
+    await tester.pump();
+    expect(
+      FocusManager.instance.primaryFocus?.debugLabel,
+      isNot('top-level.active-navigation'),
+    );
+    await tester.sendKeyEvent(LogicalKeyboardKey.arrowUp);
+    await tester.pump();
+    expect(FocusManager.instance.primaryFocus, same(firstFallbackFocus));
+    // Even an anonymous option row must have a deterministic LEFT escape to
+    // the active Settings rail item.
+    await tester.sendKeyEvent(LogicalKeyboardKey.arrowLeft);
+    await tester.pump();
+    expect(
+      FocusManager.instance.primaryFocus?.debugLabel,
+      'top-level.active-navigation',
+    );
+    await tester.pump(const Duration(milliseconds: 120));
+    await tester.sendKeyEvent(LogicalKeyboardKey.arrowRight);
+    await tester.pumpAndSettle();
+    expect(
+      FocusManager.instance.primaryFocus?.debugLabel,
+      anyOf('accounts.search', 'accounts.area.appearance'),
     );
     expect(tester.takeException(), isNull);
   });

--- a/tool/release/native_playback_manifest.json
+++ b/tool/release/native_playback_manifest.json
@@ -375,10 +375,10 @@
     {
       "path": "lib/arm64-v8a/libapp.so",
       "size": 12387216,
-      "sha256": "af1f9134e3f0550612188e87773fb46cda4f1a655aa773b67e0df0a76757d5b9",
-      "origin": "TetoTV Flutter application AOT 2.0.53",
+      "sha256": "f43e43bd925aa3bd945ce2fa6317c16319a25a207e8d41bf4701446f773c2094",
+      "origin": "TetoTV Flutter application AOT 2.0.54",
       "license": "MIT",
-      "sourceLocator": "Git tag v2.0.53",
+      "sourceLocator": "Git tag v2.0.54",
       "noticeLocator": "LICENSE"
     },
     {
@@ -423,7 +423,7 @@
       "sha256": "dc05f53278b2733094f12aeaed54c080329309762ce49e6de4118e4bfb0fff55",
       "origin": "TetoTV source build of media-kit Android helper at 42054e5d479f39ccbb0ae604862e2bcaf59b74c2",
       "license": "MIT",
-      "sourceLocator": "TetoTV-v2.0.53-native-playback-sources.zip: sources/media-kit-android-helper-42054e5d479f39ccbb0ae604862e2bcaf59b74c2.zip",
+      "sourceLocator": "TetoTV-v2.0.54-native-playback-sources.zip: sources/media-kit-android-helper-42054e5d479f39ccbb0ae604862e2bcaf59b74c2.zip",
       "noticeLocator": "assets/legal/native/MEDIA_KIT_ANDROID_HELPER_LICENSE.txt; assets/legal/native/NATIVE_PLAYBACK_NOTICE.txt"
     },
     {
@@ -432,7 +432,7 @@
       "sha256": "a7399d0be70844e5ee94cc5b1acc1516571113c50561fe0a5d05b49101c53ef2",
       "origin": "TetoTV source build of the pinned mpv and FFmpeg native playback stack",
       "license": "LGPL-3.0-or-later (conservative combined classification) plus component terms",
-      "sourceLocator": "TetoTV-v2.0.53-native-playback-sources.zip and tool/native/build_native_playback.sh",
+      "sourceLocator": "TetoTV-v2.0.54-native-playback-sources.zip and tool/native/build_native_playback.sh",
       "noticeLocator": "assets/legal/native/NATIVE_PLAYBACK_NOTICE.txt and its referenced exact license assets"
     },
     {
@@ -450,16 +450,16 @@
       "sha256": "263ba714570fb3acfc308cce52776b00506ec8809d225617e52352336144cfa2",
       "origin": "TetoTV source build of the pinned libtorrent4j and libtorrent-rasterbar stack",
       "license": "Mixed MIT, BSD, Boost-1.0, Apache-2.0, and MPL-2.0 component terms",
-      "sourceLocator": "TetoTV-v2.0.53-native-playback-sources.zip and tool/native/build_native_playback.sh",
+      "sourceLocator": "TetoTV-v2.0.54-native-playback-sources.zip and tool/native/build_native_playback.sh",
       "noticeLocator": "assets/legal/native/DIRECT_TORRENT_NATIVE_NOTICE.txt and its referenced exact license assets"
     },
     {
       "path": "lib/armeabi-v7a/libapp.so",
       "size": 13501004,
-      "sha256": "80dc0d74c90e7f2585d39b0386dd749aaea1643d436c788b9727d6ca2315adcd",
-      "origin": "TetoTV Flutter application AOT 2.0.53",
+      "sha256": "b3c183e3ea4e6a4e978cce087c56354248f91d494dc18c0917dd319d3b5d099c",
+      "origin": "TetoTV Flutter application AOT 2.0.54",
       "license": "MIT",
-      "sourceLocator": "Git tag v2.0.53",
+      "sourceLocator": "Git tag v2.0.54",
       "noticeLocator": "LICENSE"
     },
     {
@@ -504,7 +504,7 @@
       "sha256": "8820a12e07bb3dc45f5b4286acf6918827fba4c265767e7f1cc8f07215c84b6a",
       "origin": "TetoTV source build of media-kit Android helper at 42054e5d479f39ccbb0ae604862e2bcaf59b74c2",
       "license": "MIT",
-      "sourceLocator": "TetoTV-v2.0.53-native-playback-sources.zip: sources/media-kit-android-helper-42054e5d479f39ccbb0ae604862e2bcaf59b74c2.zip",
+      "sourceLocator": "TetoTV-v2.0.54-native-playback-sources.zip: sources/media-kit-android-helper-42054e5d479f39ccbb0ae604862e2bcaf59b74c2.zip",
       "noticeLocator": "assets/legal/native/MEDIA_KIT_ANDROID_HELPER_LICENSE.txt; assets/legal/native/NATIVE_PLAYBACK_NOTICE.txt"
     },
     {
@@ -513,7 +513,7 @@
       "sha256": "d5a220fdf41edde10f161f86addc846ae9cb18137ea48e4db541cd703fec5092",
       "origin": "TetoTV source build of the pinned mpv and FFmpeg native playback stack",
       "license": "LGPL-3.0-or-later (conservative combined classification) plus component terms",
-      "sourceLocator": "TetoTV-v2.0.53-native-playback-sources.zip and tool/native/build_native_playback.sh",
+      "sourceLocator": "TetoTV-v2.0.54-native-playback-sources.zip and tool/native/build_native_playback.sh",
       "noticeLocator": "assets/legal/native/NATIVE_PLAYBACK_NOTICE.txt and its referenced exact license assets"
     },
     {
@@ -531,7 +531,7 @@
       "sha256": "ba0a19d2730969b8e6107db1847888ea8d3b8cafd14a535a3259dd04f8b28d60",
       "origin": "TetoTV source build of the pinned libtorrent4j and libtorrent-rasterbar stack",
       "license": "Mixed MIT, BSD, Boost-1.0, Apache-2.0, and MPL-2.0 component terms",
-      "sourceLocator": "TetoTV-v2.0.53-native-playback-sources.zip and tool/native/build_native_playback.sh",
+      "sourceLocator": "TetoTV-v2.0.54-native-playback-sources.zip and tool/native/build_native_playback.sh",
       "noticeLocator": "assets/legal/native/DIRECT_TORRENT_NATIVE_NOTICE.txt and its referenced exact license assets"
     }
   ],


### PR DESCRIPTION
## Summary
- keep TV Settings D-pad traversal inside the single-list content scope
- cancel stale scroll reveals and recover safely from detached focus nodes
- preserve the responsive mobile/tablet Settings layout (the latest phone diagnostic is healthy)
- coalesce repeated Home hero restore animations
- prepare the signed 2.0.54 / build 410031 Beta metadata and AI-assisted development disclosure

## Verification
- flutter analyze --no-pub
- flutter test --no-pub -r compact (1,953 passed; 17 expected skips)
- production APK built for armeabi-v7a and arm64-v8a
- native manifest updated to the APK hashes

This is a Beta-only release; no Public APK is being published.