### PR TITLE
Restore Settings toolbar and prepare Beta 2.0.55

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 
 <p align="center">
   <a href="https://github.com/LindersOSX/TetoTV-Beta/releases/latest"><strong>Download Beta</strong></a>
-  · <a href="docs/RELEASE_NOTES_2.0.54.md">What's new</a>
+  · <a href="docs/RELEASE_NOTES_2.0.55.md">What's new</a>
   · <a href="https://github.com/LindersOSX/TetoTV-Beta/issues/new">Report an issue</a>
   · <a href="https://discord.gg/juC6k7d4WY">Discord</a>
   · <a href="https://www.youtube.com/@TetoTVApp">YouTube</a>
@@ -94,10 +94,10 @@ TetoTV runs directly on the Android device with no companion server required for
 | Channel | Version | Best for |
 | --- | --- | --- |
 | Public | Not published | Source and release-readiness documents are available, but no Public APK is currently offered |
-| Beta | [2.0.54](docs/RELEASE_NOTES_2.0.54.md) | Testing TV Settings focus stability, responsive mobile Settings, and smoother D-pad navigation |
+| Beta | [2.0.55](docs/RELEASE_NOTES_2.0.55.md) | Restoring the Settings toolbar reliably and opening Settings on Appearance |
 
 > [!WARNING]
-> Beta 2.0.54 uses the repository's explicit unreviewed-Beta exception. Its native-library and corresponding-source material did not receive independent license review, and automated integrity checks are not a legal compliance determination. Read the [complete Beta disclosure](docs/RELEASE_NOTES_2.0.54.md). This exception does not apply to a future Public release.
+> Beta 2.0.55 uses the repository's explicit unreviewed-Beta exception. Its native-library and corresponding-source material did not receive independent license review, and automated integrity checks are not a legal compliance determination. Read the [complete Beta disclosure](docs/RELEASE_NOTES_2.0.55.md). This exception does not apply to a future Public release.
 
 The Public updater repository intentionally has no release while the Public build is held for review. Existing Beta installations continue to update from the Beta repository. Android never permits an in-place install of an APK with a lower build code; Developer Mode does not bypass that platform rule.
 

--- a/docs/BUILD_WINDOWS.md
+++ b/docs/BUILD_WINDOWS.md
@@ -220,39 +220,39 @@ APK containing both supported application ABIs.
 Public and Beta updates use anonymous GitHub requests. No Beta key, GitHub
 token, update-proxy URL, or update-specific Dart define is required. Every
 published APK uses the production signing identity. No Public APK is currently
-published. Beta 2.0.54 uses Android build code `410031`. Flutter reuses
+published. Beta 2.0.55 uses Android build code `410032`. Flutter reuses
 `app-release.apk`, so copy and rename the Beta artifact immediately after the
 build:
 
 ```powershell
-New-Item -ItemType Directory -Force .\build\fire-tv\v2.0.54 | Out-Null
+New-Item -ItemType Directory -Force .\build\fire-tv\v2.0.55 | Out-Null
 
-# Beta 2.0.54
+# Beta 2.0.55
 flutter build apk --release --target-platform android-arm,android-arm64 `
-  --build-name 2.0.54 --build-number 410031 --no-tree-shake-icons
+  --build-name 2.0.55 --build-number 410032 --no-tree-shake-icons
 Copy-Item .\build\app\outputs\flutter-apk\app-release.apk `
-  .\build\fire-tv\v2.0.54\TetoTV-v2.0.54-universal.apk
+  .\build\fire-tv\v2.0.55\TetoTV-v2.0.55-universal.apk
 
 .\tool\release\verify_release_apk.ps1 `
   -Channel Beta `
-  -ApkPath .\build\fire-tv\v2.0.54\TetoTV-v2.0.54-universal.apk
+  -ApkPath .\build\fire-tv\v2.0.55\TetoTV-v2.0.55-universal.apk
 
 .\tool\release\verify_native_redistribution.ps1 `
   -RequireResolvedBinaries `
   -ResolvedBinaryDirectory .\build\native-playback\outputs `
-  -StageBundle -ReleaseTag v2.0.54
+  -StageBundle -ReleaseTag v2.0.55
 
 .\tool\release\new_release_checksums.ps1 `
-  -ApkPath .\build\fire-tv\v2.0.54\TetoTV-v2.0.54-universal.apk `
-  -NativeSourcePath .\build\release-compliance\v2.0.54\TetoTV-v2.0.54-native-playback-sources.zip `
-  -OutputPath .\build\fire-tv\v2.0.54\SHA256SUMS
+  -ApkPath .\build\fire-tv\v2.0.55\TetoTV-v2.0.55-universal.apk `
+  -NativeSourcePath .\build\release-compliance\v2.0.55\TetoTV-v2.0.55-native-playback-sources.zip `
+  -OutputPath .\build\fire-tv\v2.0.55\SHA256SUMS
 
 .\tool\release\verify_release_payloads.ps1 `
   -Channel Beta `
-  -ApkPath .\build\fire-tv\v2.0.54\TetoTV-v2.0.54-universal.apk `
-  -NativeSourcePath .\build\release-compliance\v2.0.54\TetoTV-v2.0.54-native-playback-sources.zip `
-  -ChecksumsPath .\build\fire-tv\v2.0.54\SHA256SUMS `
-  -ReleaseNotesPath .\docs\RELEASE_NOTES_2.0.54.md
+  -ApkPath .\build\fire-tv\v2.0.55\TetoTV-v2.0.55-universal.apk `
+  -NativeSourcePath .\build\release-compliance\v2.0.55\TetoTV-v2.0.55-native-playback-sources.zip `
+  -ChecksumsPath .\build\fire-tv\v2.0.55\SHA256SUMS `
+  -ReleaseNotesPath .\docs\RELEASE_NOTES_2.0.55.md
 ```
 
 The final payload check requires all five exact, source-built native JARs

--- a/docs/RELEASE_NOTES_2.0.55.md
+++ b/docs/RELEASE_NOTES_2.0.55.md
@@ -1,0 +1,31 @@
+# TetoTV 2.0.55 Beta
+
+> [!WARNING]
+> No independent native-license review: This Beta has not received independent native-library licensing review. Automated checks verify the APK, native-source bundle, notices, pinned inputs, and checksums, but do not establish legal compliance or reproducible builds.
+
+This Beta fixes Settings toolbar restoration and the initial TV focus target.
+
+## What's changed
+
+- Opening Settings now focuses **Appearance**, so the first D-pad selection is the active Settings category instead of the search field.
+- Re-selecting Settings from the navigation rail returns to the top of the current Settings area, restores the search and collapse controls, and focuses the active category.
+- Moving up from the first Settings section restores the fixed toolbar even when the content list had retained an earlier scroll offset.
+- Nested dropdowns, reorder lists, and compact controls no longer make the shell incorrectly treat the main Settings page as scrolled.
+- TV Settings options have a small focus lane between rows so the selected outline and glow no longer overlap neighboring options.
+- The Settings D-pad order remains linear in both directions, including the corrected path from Navigation back through Home screen and Theme & display.
+- Phone and tablet Settings keep the same responsive layout and touch behavior.
+- AI-assisted development disclosure: AI tools assisted with implementation, documentation, tests, and review. The project owner directed the work, validated the changes, and remains responsible for this release.
+
+## Release assets
+
+- `TetoTV-v2.0.55-universal.apk`
+- `TetoTV-v2.0.55-native-playback-sources.zip`
+- `SHA256SUMS`
+
+## Beta notes
+
+- This is a Beta-channel build with Android build code `410032`.
+- No Public APK is being published with this release.
+- Android does not permit an in-place install over an APK with a higher build code. A future Public counterpart must use build code `410032` or newer for data-preserving channel switching.
+
+<!-- tetotv-android-version-code: 410032 -->

--- a/docs/UPDATE_CHANNELS.md
+++ b/docs/UPDATE_CHANNELS.md
@@ -35,11 +35,11 @@ Beta reads completed 2.x releases from:
 https://api.github.com/repos/LindersOSX/TetoTV-Beta/releases/latest
 ```
 
-The current Beta source build is `v2.0.54` with Android build code `410031`.
+The current Beta source build is `v2.0.55` with Android build code `410032`.
 Its release title is:
 
 ```text
-TetoTV 2.0.54 Beta - Android TV / Google TV / Fire TV
+TetoTV 2.0.55 Beta - Android TV / Google TV / Fire TV
 ```
 
 Publish it as a normal, non-draft, non-prerelease GitHub release so
@@ -72,7 +72,7 @@ proxy.
 Release notes must include the exact asset names and this build-code marker:
 
 ```html
-<!-- tetotv-android-version-code: 410031 -->
+<!-- tetotv-android-version-code: 410032 -->
 ```
 
 When build-code metadata is present, the updater rejects a known lower build
@@ -94,10 +94,10 @@ These rules apply equally on phones, Android TV, Google TV, and Fire TV.
 
 ## Switching and rollback
 
-The current Beta uses build code `410031`. No Public counterpart is available.
+The current Beta uses build code `410032`. No Public counterpart is available.
 An older Public install can move to this Beta when Android accepts the higher
 build code, but it cannot move back in place until a future Public build uses
-code `410031` or higher. Uninstalling first permits an older APK but deletes
+code `410032` or higher. Uninstalling first permits an older APK but deletes
 local application data. Developer Mode and in-app settings cannot override
 this Android rule.
 

--- a/lib/core/widgets/teto_top_level_shell.dart
+++ b/lib/core/widgets/teto_top_level_shell.dart
@@ -131,11 +131,18 @@ class _TetoTopLevelShellState extends ConsumerState<TetoTopLevelShell> {
   }
 
   bool _handleContentScroll(ScrollNotification notification) {
+    // The shell header follows the destination's primary viewport only.
+    // Settings contains nested scrollables (dropdowns, reorder lists, and
+    // other compact controls); allowing one of those notifications to update
+    // this state can leave the header hidden even after the main list returns
+    // to its top.
+    if (notification.depth != 0) return false;
     _observeContentMetrics(notification.metrics);
     return false;
   }
 
   bool _handleContentMetrics(ScrollMetricsNotification notification) {
+    if (notification.depth != 0) return false;
     _observeContentMetrics(notification.metrics);
     return false;
   }

--- a/lib/features/settings/presentation/accounts_screen.dart
+++ b/lib/features/settings/presentation/accounts_screen.dart
@@ -845,12 +845,59 @@ class _AccountsScreenState extends ConsumerState<AccountsScreen> {
   }
 
   void _exitSettingsSearchHeaderDown() {
+    // Key-up is delivered to the newly focused content subtree, while the
+    // matching key-down was handled by the fixed header outside that subtree.
+    // Reset the content gate so its next D-pad direction is never mistaken
+    // for a held packet.
+    _directionalRepeatGate.reset();
     if (_settingsSearchResultsVisible ||
         _settingsSearchController.text.isNotEmpty) {
       _settingsSearchController.clear();
       setState(() => _settingsSearchResultsVisible = false);
     }
     requestTvFocusAndReveal(_areaFocusNodes[_activeArea]!);
+  }
+
+  void _scrollSettingsToTop() {
+    _settingsRevealGeneration++;
+
+    void jumpIfReady() {
+      if (!mounted || !_settingsScrollController.hasClients) return;
+      final position = _settingsScrollController.position;
+      if ((position.pixels - position.minScrollExtent).abs() > .5) {
+        position.jumpTo(position.minScrollExtent);
+      }
+    }
+
+    jumpIfReady();
+    // Area changes rebuild the list. Repeat after layout so selecting the
+    // active Settings destination or tab always restores the fixed tools.
+    WidgetsBinding.instance.addPostFrameCallback((_) => jumpIfReady());
+  }
+
+  void _restoreSettingsHeaderAndFocusSearch() {
+    _scrollSettingsToTop();
+
+    void requestWhenMounted(int remainingFrames) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (!mounted) return;
+        if (_settingsSearchFocus.context?.mounted == true &&
+            _settingsSearchFocus.canRequestFocus) {
+          _settingsSearchFocus.requestFocus();
+          return;
+        }
+        if (remainingFrames > 0) {
+          requestWhenMounted(remainingFrames - 1);
+        } else {
+          _areaFocusNodes[_activeArea]?.requestFocus();
+        }
+      });
+    }
+
+    // TetoTopLevelShell restores its fixed header after observing the list at
+    // offset zero. Give that rebuild a frame before requesting the search
+    // node, which is intentionally unmounted while the list is scrolled.
+    requestWhenMounted(2);
   }
 
   FocusNode? get _firstHomeShelfFocusNode {
@@ -1542,7 +1589,12 @@ class _AccountsScreenState extends ConsumerState<AccountsScreen> {
         target = areaNodes[areaIndex + 1];
       }
       if (key == LogicalKeyboardKey.arrowUp && tvListLayout) {
-        target = _settingsSearchFocus;
+        if (_settingsSearchFocus.context?.mounted == true) {
+          target = _settingsSearchFocus;
+        } else {
+          _restoreSettingsHeaderAndFocusSearch();
+          return KeyEventResult.handled;
+        }
       }
       if (key == LogicalKeyboardKey.arrowDown) {
         target = tvListLayout
@@ -1559,6 +1611,7 @@ class _AccountsScreenState extends ConsumerState<AccountsScreen> {
       if (key == LogicalKeyboardKey.arrowUp) {
         if (activeSectionIndex == 0) {
           target = _areaFocusNodes[_activeArea];
+          if (tvListLayout) _scrollSettingsToTop();
         } else {
           // In the TV list, an expanded section is a heading followed by its
           // rows.  Moving UP from the next section's heading should therefore
@@ -2401,11 +2454,8 @@ class _AccountsScreenState extends ConsumerState<AccountsScreen> {
     final changedArea = area != _activeArea;
     if (changedArea) {
       setState(() => _activeArea = area);
-      WidgetsBinding.instance.addPostFrameCallback((_) {
-        if (!mounted || !_settingsScrollController.hasClients) return;
-        _settingsScrollController.jumpTo(0);
-      });
     }
+    _scrollSettingsToTop();
     if (area != _SettingsArea.system) {
       _systemActivationCount = 0;
       return;
@@ -2839,7 +2889,7 @@ class _AccountsScreenState extends ConsumerState<AccountsScreen> {
       preferences: preferences,
       activeDestination: TopNavigationDestination.settings,
       firstContentFocusNode: collapsibleSettings
-          ? _settingsSearchFocus
+          ? _areaFocusNodes[_activeArea]!
           : _activeArea == _SettingsArea.appearance
           ? _customizationFocus
           : _areaFocusNodes[_activeArea]!,
@@ -2852,8 +2902,9 @@ class _AccountsScreenState extends ConsumerState<AccountsScreen> {
       // of the intermittent "right does nothing" behavior after exiting to
       // the rail.
       onActiveDestinationPressed: () {
+        _scrollSettingsToTop();
         final preferredTarget = collapsibleSettings
-            ? _settingsSearchFocus
+            ? _areaFocusNodes[_activeArea]!
             : _activeArea == _SettingsArea.appearance
             ? _customizationFocus
             : _areaFocusNodes[_activeArea]!;
@@ -2947,6 +2998,7 @@ class _AccountsScreenState extends ConsumerState<AccountsScreen> {
             _SettingsAreaTabs(
               selected: _activeArea,
               focusNodes: _areaFocusNodes,
+              autofocusSelected: collapsibleSettings,
               onSelected: _selectSettingsArea,
             ),
             SizedBox(
@@ -3768,11 +3820,13 @@ class _SettingsAreaTabs extends StatelessWidget {
   const _SettingsAreaTabs({
     required this.selected,
     required this.focusNodes,
+    required this.autofocusSelected,
     required this.onSelected,
   });
 
   final _SettingsArea selected;
   final Map<_SettingsArea, FocusNode> focusNodes;
+  final bool autofocusSelected;
   final ValueChanged<_SettingsArea> onSelected;
 
   @override
@@ -3791,7 +3845,9 @@ class _SettingsAreaTabs extends StatelessWidget {
       return TvFocusable(
         key: ValueKey('settings-area-${area.name}'),
         focusNode: focusNodes[area],
-        autofocus: area == selected && selected != _SettingsArea.appearance,
+        autofocus:
+            area == selected &&
+            (autofocusSelected || selected != _SettingsArea.appearance),
         onPressed: () => onSelected(area),
         focusScale: 1.01,
         borderRadius: BorderRadius.circular(8),
@@ -3936,7 +3992,7 @@ class _SettingsSearchHeader extends StatelessWidget {
         key: const ValueKey('settings-search-field'),
         controller: controller,
         focusNode: searchFocusNode,
-        autofocus: true,
+        autofocus: false,
         labelText: 'Search settings',
         hintText: 'Search settings',
         keyboardTitle: 'Search settings',
@@ -5119,105 +5175,111 @@ class _AppearanceActionRowState extends State<_AppearanceActionRow> {
     final mediaSize = MediaQuery.sizeOf(context);
     final tvScale =
         mediaSize.width >= 900 && mediaSize.width > mediaSize.height;
-    return TvFocusable(
-      focusNode: widget.focusNode,
-      autofocus: widget.autofocus,
-      onFocusChanged: (focused) {
-        if (_focused != focused) setState(() => _focused = focused);
-      },
-      onPressed: widget.onPressed,
-      focusScale: 1.005,
-      borderRadius: BorderRadius.circular(7),
-      child: AnimatedContainer(
-        duration: const Duration(milliseconds: 100),
-        constraints: BoxConstraints(minHeight: tvScale ? 48 : 64),
-        padding: EdgeInsets.symmetric(
-          horizontal: tvScale ? 10 : 13,
-          vertical: tvScale ? 5 : 11,
-        ),
-        decoration: BoxDecoration(
-          color: context.appPalette.surface,
-          border: Border(
-            bottom: BorderSide(
-              color: widget.showDivider
-                  ? _settingsBorderColor(context, .14)
-                  : Colors.transparent,
+    return Padding(
+      // The TV focus ring and glow render outside the option bounds. Keep a
+      // small lane around every row so the selected outline remains visually
+      // separate from the options immediately above and below it.
+      padding: EdgeInsets.symmetric(vertical: tvScale ? 3 : 0),
+      child: TvFocusable(
+        focusNode: widget.focusNode,
+        autofocus: widget.autofocus,
+        onFocusChanged: (focused) {
+          if (_focused != focused) setState(() => _focused = focused);
+        },
+        onPressed: widget.onPressed,
+        focusScale: 1.005,
+        borderRadius: BorderRadius.circular(7),
+        child: AnimatedContainer(
+          duration: const Duration(milliseconds: 100),
+          constraints: BoxConstraints(minHeight: tvScale ? 48 : 64),
+          padding: EdgeInsets.symmetric(
+            horizontal: tvScale ? 10 : 13,
+            vertical: tvScale ? 5 : 11,
+          ),
+          decoration: BoxDecoration(
+            color: context.appPalette.surface,
+            border: Border(
+              bottom: BorderSide(
+                color: widget.showDivider
+                    ? _settingsBorderColor(context, .14)
+                    : Colors.transparent,
+              ),
             ),
           ),
-        ),
-        child: Row(
-          children: [
-            Icon(
-              widget.icon,
-              size: tvScale ? 22 : 22,
-              color: widget.destructive
-                  ? context.appPalette.mutedText
-                  : (_focused
-                        ? context.appPalette.accentBright
-                        : _settingsPrimaryText(context)),
-            ),
-            SizedBox(width: tvScale ? 8 : 14),
-            Expanded(
-              child: Column(
-                mainAxisSize: MainAxisSize.min,
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Text(
-                    widget.label,
-                    maxLines: 2,
-                    overflow: TextOverflow.ellipsis,
-                    style: TextStyle(
-                      color: widget.destructive
-                          ? context.appPalette.mutedText
-                          : _settingsPrimaryText(context),
-                      fontSize: tvScale ? 16 : 14,
-                      fontWeight: FontWeight.w700,
-                    ),
-                  ),
-                  if (widget.subtitle case final subtitle?) ...[
-                    SizedBox(height: tvScale ? 2 : 3),
+          child: Row(
+            children: [
+              Icon(
+                widget.icon,
+                size: tvScale ? 22 : 22,
+                color: widget.destructive
+                    ? context.appPalette.mutedText
+                    : (_focused
+                          ? context.appPalette.accentBright
+                          : _settingsPrimaryText(context)),
+              ),
+              SizedBox(width: tvScale ? 8 : 14),
+              Expanded(
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
                     Text(
-                      subtitle,
-                      maxLines: tvScale ? 2 : 3,
+                      widget.label,
+                      maxLines: 2,
                       overflow: TextOverflow.ellipsis,
                       style: TextStyle(
-                        color: context.appPalette.mutedText,
-                        fontSize: tvScale ? 12 : 11,
-                        height: 1.25,
+                        color: widget.destructive
+                            ? context.appPalette.mutedText
+                            : _settingsPrimaryText(context),
+                        fontSize: tvScale ? 16 : 14,
+                        fontWeight: FontWeight.w700,
                       ),
                     ),
+                    if (widget.subtitle case final subtitle?) ...[
+                      SizedBox(height: tvScale ? 2 : 3),
+                      Text(
+                        subtitle,
+                        maxLines: tvScale ? 2 : 3,
+                        overflow: TextOverflow.ellipsis,
+                        style: TextStyle(
+                          color: context.appPalette.mutedText,
+                          fontSize: tvScale ? 12 : 11,
+                          height: 1.25,
+                        ),
+                      ),
+                    ],
                   ],
-                ],
-              ),
-            ),
-            if (widget.trailing case final trailing?) ...[
-              SizedBox(width: tvScale ? 6 : 10),
-              trailing,
-            ] else if (widget.value case final value?) ...[
-              SizedBox(width: tvScale ? 6 : 10),
-              Flexible(
-                child: Text(
-                  value,
-                  maxLines: 2,
-                  overflow: TextOverflow.ellipsis,
-                  textAlign: TextAlign.end,
-                  style: TextStyle(
-                    color: context.appPalette.mutedText,
-                    fontSize: tvScale ? 14 : 13,
-                    fontWeight: FontWeight.w600,
-                  ),
                 ),
               ),
+              if (widget.trailing case final trailing?) ...[
+                SizedBox(width: tvScale ? 6 : 10),
+                trailing,
+              ] else if (widget.value case final value?) ...[
+                SizedBox(width: tvScale ? 6 : 10),
+                Flexible(
+                  child: Text(
+                    value,
+                    maxLines: 2,
+                    overflow: TextOverflow.ellipsis,
+                    textAlign: TextAlign.end,
+                    style: TextStyle(
+                      color: context.appPalette.mutedText,
+                      fontSize: tvScale ? 14 : 13,
+                      fontWeight: FontWeight.w600,
+                    ),
+                  ),
+                ),
+              ],
+              if (widget.showChevron) ...[
+                SizedBox(width: tvScale ? 5 : 8),
+                Icon(
+                  Icons.chevron_right_rounded,
+                  size: tvScale ? 22 : 22,
+                  color: _settingsPrimaryText(context),
+                ),
+              ],
             ],
-            if (widget.showChevron) ...[
-              SizedBox(width: tvScale ? 5 : 8),
-              Icon(
-                Icons.chevron_right_rounded,
-                size: tvScale ? 22 : 22,
-                color: _settingsPrimaryText(context),
-              ),
-            ],
-          ],
+          ),
         ),
       ),
     );

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: 'none'
 # Public and Beta artifacts built from the same source use one monotonically
 # increasing Android versionCode. The project default carries the Beta display
 # version; the Public universal APK overrides the build name to the 1.x line.
-version: 2.0.54+410031
+version: 2.0.55+410032
 
 environment:
   sdk: ^3.12.2

--- a/test/accounts_focus_test.dart
+++ b/test/accounts_focus_test.dart
@@ -89,9 +89,6 @@ void main() {
     );
     await tester.pumpAndSettle();
 
-    expect(FocusManager.instance.primaryFocus?.debugLabel, 'accounts.search');
-    await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
-    await tester.pump();
     expect(
       FocusManager.instance.primaryFocus?.debugLabel,
       'accounts.area.appearance',
@@ -243,6 +240,24 @@ void main() {
       expect(find.text('Poster metadata'), findsOneWidget);
       expect(find.text('Continue watching'), findsWidgets);
 
+      final themeStudioFocusable = find.descendant(
+        of: find.byKey(const ValueKey('open-theme-studio')),
+        matching: find.byType(TvFocusable),
+      );
+      final titleLanguageFocusable = find.descendant(
+        of: find.byKey(
+          const ValueKey('settings-appearance-title-language'),
+        ),
+        matching: find.byType(TvFocusable),
+      );
+      final themeStudioRect = tester.getRect(themeStudioFocusable);
+      final titleLanguageRect = tester.getRect(titleLanguageFocusable);
+      expect(
+        titleLanguageRect.top - themeStudioRect.bottom,
+        greaterThanOrEqualTo(5),
+        reason: 'TV focus glows need a clear lane between Settings options.',
+      );
+
       final themeCard = tester.getRect(
         find.byKey(const ValueKey('appearance-theme-display-card')),
       );
@@ -258,7 +273,10 @@ void main() {
       expect((homeCard.width - themeCard.width).abs(), lessThan(1));
       expect(homeCard.top, greaterThan(themeCard.bottom));
       expect(navigationCard.top, greaterThan(homeCard.bottom));
-      expect(FocusManager.instance.primaryFocus?.debugLabel, 'accounts.search');
+      expect(
+        FocusManager.instance.primaryFocus?.debugLabel,
+        'accounts.area.appearance',
+      );
       expect(tester.takeException(), isNull);
     },
   );
@@ -330,13 +348,17 @@ void main() {
       await tester.pump();
       await tester.sendKeyEvent(LogicalKeyboardKey.arrowRight);
       await tester.pump();
-      expect(searchFocus.hasFocus, isTrue);
+      expect(appearanceFocus.hasFocus, isTrue);
 
       await tester.sendKeyEvent(LogicalKeyboardKey.arrowLeft);
       await tester.pump();
       expect(settingsRailFocus.hasFocus, isTrue);
       await tester.sendKeyEvent(LogicalKeyboardKey.arrowRight);
       await tester.pump();
+      expect(appearanceFocus.hasFocus, isTrue);
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowUp);
+      await tester.pump();
+      expect(FocusManager.instance.primaryFocus?.debugLabel, 'accounts.search');
       await tester.sendKeyEvent(LogicalKeyboardKey.arrowRight);
       await tester.pump();
       expect(
@@ -351,9 +373,10 @@ void main() {
       await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
       await tester.pump();
       expect(appearanceFocus.hasFocus, isTrue);
+      await tester.pump(const Duration(milliseconds: 120));
       await tester.sendKeyEvent(LogicalKeyboardKey.arrowUp);
       await tester.pump();
-      expect(searchFocus.hasFocus, isTrue);
+      expect(FocusManager.instance.primaryFocus?.debugLabel, 'accounts.search');
 
       await tester.sendKeyEvent(LogicalKeyboardKey.arrowRight);
       await tester.pump();
@@ -376,6 +399,26 @@ void main() {
       await tester.sendKeyEvent(LogicalKeyboardKey.arrowUp);
       await tester.pump();
       expect(themeHeaderFocus.hasFocus, isTrue);
+
+      final settingsList = tester.widget<ListView>(
+        find.byKey(const ValueKey('settings-content-list')),
+      );
+      settingsList.controller!.jumpTo(240);
+      await tester.pump();
+      await tester.pump();
+      expect(find.byKey(const ValueKey('settings-search-field')), findsNothing);
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowUp);
+      await tester.pumpAndSettle();
+      expect(appearanceFocus.hasFocus, isTrue);
+      expect(settingsList.controller!.offset, 0);
+      expect(
+        find.byKey(const ValueKey('settings-search-field')),
+        findsOneWidget,
+      );
+      expect(
+        find.byKey(const ValueKey('settings-toggle-all-sections')),
+        findsOneWidget,
+      );
 
       // Expanded section headers are part of the same linear TV list.  UP
       // from Home screen must return to Theme & display's final row rather
@@ -953,7 +996,10 @@ void main() {
       );
       await tester.pumpAndSettle();
 
-      expect(FocusManager.instance.primaryFocus?.debugLabel, 'accounts.search');
+      expect(
+        FocusManager.instance.primaryFocus?.debugLabel,
+        'accounts.area.appearance',
+      );
       await tester.sendKeyEvent(LogicalKeyboardKey.arrowLeft);
       await tester.pump();
       expect(
@@ -981,11 +1027,13 @@ void main() {
       await tester.tap(settingsAction);
       await tester.pumpAndSettle();
       expect(find.byType(AccountsScreen), findsOneWidget);
-      expect(FocusManager.instance.primaryFocus?.debugLabel, 'accounts.search');
+      expect(
+        FocusManager.instance.primaryFocus?.debugLabel,
+        'accounts.area.appearance',
+      );
 
       // Once the list is scrolled, the fixed search header is intentionally
-      // removed. Re-activating Settings must use the visible area tab instead
-      // of handing the shell that detached search FocusNode.
+      // removed. Re-activating Settings keeps the active area selected.
       final settingsList = tester.widget<ListView>(
         find.byKey(const ValueKey('settings-content-list')),
       );
@@ -999,20 +1047,37 @@ void main() {
       await tester.tap(settingsAction);
       await tester.pumpAndSettle();
       expect(find.byType(AccountsScreen), findsOneWidget);
+      expect(settingsList.controller!.offset, 0);
       expect(
         FocusManager.instance.primaryFocus?.debugLabel,
         'accounts.area.appearance',
       );
+      expect(
+        find.byKey(const ValueKey('settings-search-field')),
+        findsOneWidget,
+      );
+      expect(
+        find.byKey(const ValueKey('settings-toggle-all-sections')),
+        findsOneWidget,
+      );
+      expect(
+        find.byKey(const ValueKey('top-level-fixed-profile')),
+        findsOneWidget,
+      );
 
-      // The keyboard path should have the same behavior as a click: focus can
-      // leave the content for the rail and immediately return with RIGHT.
-      settingsList.controller!.jumpTo(0);
-      await tester.pump();
-      await tester.pump();
-      await tester.sendKeyEvent(LogicalKeyboardKey.arrowLeft);
-      await tester.pump();
-      await tester.sendKeyEvent(LogicalKeyboardKey.arrowRight);
-      await tester.pump();
+      // UP from the selected area focuses Search after the active Settings
+      // action has restored the list and its fixed tools.
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowUp);
+      await tester.pumpAndSettle();
+      expect(settingsList.controller!.offset, 0);
+      expect(
+        find.byKey(const ValueKey('settings-search-field')),
+        findsOneWidget,
+      );
+      expect(
+        find.byKey(const ValueKey('settings-toggle-all-sections')),
+        findsOneWidget,
+      );
       expect(FocusManager.instance.primaryFocus?.debugLabel, 'accounts.search');
       expect(tester.takeException(), isNull);
     },
@@ -1603,9 +1668,11 @@ void main() {
     ]) {
       expect(find.text(label), findsOneWidget);
     }
-    expect(FocusManager.instance.primaryFocus?.debugLabel, 'accounts.search');
-    for (final expected in const [
+    expect(
+      FocusManager.instance.primaryFocus?.debugLabel,
       'accounts.area.appearance',
+    );
+    for (final expected in const [
       'accounts.settings-section.theme-display',
       'accounts.customization.first',
       'accounts.title-language',
@@ -1719,7 +1786,7 @@ void main() {
     await tester.pumpAndSettle();
     expect(
       FocusManager.instance.primaryFocus?.debugLabel,
-      anyOf('accounts.search', 'accounts.area.appearance'),
+      'accounts.area.appearance',
     );
     expect(tester.takeException(), isNull);
   });

--- a/tool/release/native_playback_manifest.json
+++ b/tool/release/native_playback_manifest.json
@@ -375,10 +375,10 @@
     {
       "path": "lib/arm64-v8a/libapp.so",
       "size": 12387216,
-      "sha256": "f43e43bd925aa3bd945ce2fa6317c16319a25a207e8d41bf4701446f773c2094",
-      "origin": "TetoTV Flutter application AOT 2.0.54",
+      "sha256": "f42d25cd1c9eb2e821ee29f0ecaa1de1098857f2c581c500dbf2e4e1d67765dd",
+      "origin": "TetoTV Flutter application AOT 2.0.55",
       "license": "MIT",
-      "sourceLocator": "Git tag v2.0.54",
+      "sourceLocator": "Git tag v2.0.55",
       "noticeLocator": "LICENSE"
     },
     {
@@ -423,7 +423,7 @@
       "sha256": "dc05f53278b2733094f12aeaed54c080329309762ce49e6de4118e4bfb0fff55",
       "origin": "TetoTV source build of media-kit Android helper at 42054e5d479f39ccbb0ae604862e2bcaf59b74c2",
       "license": "MIT",
-      "sourceLocator": "TetoTV-v2.0.54-native-playback-sources.zip: sources/media-kit-android-helper-42054e5d479f39ccbb0ae604862e2bcaf59b74c2.zip",
+      "sourceLocator": "TetoTV-v2.0.55-native-playback-sources.zip: sources/media-kit-android-helper-42054e5d479f39ccbb0ae604862e2bcaf59b74c2.zip",
       "noticeLocator": "assets/legal/native/MEDIA_KIT_ANDROID_HELPER_LICENSE.txt; assets/legal/native/NATIVE_PLAYBACK_NOTICE.txt"
     },
     {
@@ -432,7 +432,7 @@
       "sha256": "a7399d0be70844e5ee94cc5b1acc1516571113c50561fe0a5d05b49101c53ef2",
       "origin": "TetoTV source build of the pinned mpv and FFmpeg native playback stack",
       "license": "LGPL-3.0-or-later (conservative combined classification) plus component terms",
-      "sourceLocator": "TetoTV-v2.0.54-native-playback-sources.zip and tool/native/build_native_playback.sh",
+      "sourceLocator": "TetoTV-v2.0.55-native-playback-sources.zip and tool/native/build_native_playback.sh",
       "noticeLocator": "assets/legal/native/NATIVE_PLAYBACK_NOTICE.txt and its referenced exact license assets"
     },
     {
@@ -450,16 +450,16 @@
       "sha256": "263ba714570fb3acfc308cce52776b00506ec8809d225617e52352336144cfa2",
       "origin": "TetoTV source build of the pinned libtorrent4j and libtorrent-rasterbar stack",
       "license": "Mixed MIT, BSD, Boost-1.0, Apache-2.0, and MPL-2.0 component terms",
-      "sourceLocator": "TetoTV-v2.0.54-native-playback-sources.zip and tool/native/build_native_playback.sh",
+      "sourceLocator": "TetoTV-v2.0.55-native-playback-sources.zip and tool/native/build_native_playback.sh",
       "noticeLocator": "assets/legal/native/DIRECT_TORRENT_NATIVE_NOTICE.txt and its referenced exact license assets"
     },
     {
       "path": "lib/armeabi-v7a/libapp.so",
       "size": 13501004,
-      "sha256": "b3c183e3ea4e6a4e978cce087c56354248f91d494dc18c0917dd319d3b5d099c",
-      "origin": "TetoTV Flutter application AOT 2.0.54",
+      "sha256": "46149743b78647f1d8e2a099a4ed67296d25287fd0af94412490f5072da3ff4d",
+      "origin": "TetoTV Flutter application AOT 2.0.55",
       "license": "MIT",
-      "sourceLocator": "Git tag v2.0.54",
+      "sourceLocator": "Git tag v2.0.55",
       "noticeLocator": "LICENSE"
     },
     {
@@ -504,7 +504,7 @@
       "sha256": "8820a12e07bb3dc45f5b4286acf6918827fba4c265767e7f1cc8f07215c84b6a",
       "origin": "TetoTV source build of media-kit Android helper at 42054e5d479f39ccbb0ae604862e2bcaf59b74c2",
       "license": "MIT",
-      "sourceLocator": "TetoTV-v2.0.54-native-playback-sources.zip: sources/media-kit-android-helper-42054e5d479f39ccbb0ae604862e2bcaf59b74c2.zip",
+      "sourceLocator": "TetoTV-v2.0.55-native-playback-sources.zip: sources/media-kit-android-helper-42054e5d479f39ccbb0ae604862e2bcaf59b74c2.zip",
       "noticeLocator": "assets/legal/native/MEDIA_KIT_ANDROID_HELPER_LICENSE.txt; assets/legal/native/NATIVE_PLAYBACK_NOTICE.txt"
     },
     {
@@ -513,7 +513,7 @@
       "sha256": "d5a220fdf41edde10f161f86addc846ae9cb18137ea48e4db541cd703fec5092",
       "origin": "TetoTV source build of the pinned mpv and FFmpeg native playback stack",
       "license": "LGPL-3.0-or-later (conservative combined classification) plus component terms",
-      "sourceLocator": "TetoTV-v2.0.54-native-playback-sources.zip and tool/native/build_native_playback.sh",
+      "sourceLocator": "TetoTV-v2.0.55-native-playback-sources.zip and tool/native/build_native_playback.sh",
       "noticeLocator": "assets/legal/native/NATIVE_PLAYBACK_NOTICE.txt and its referenced exact license assets"
     },
     {
@@ -531,7 +531,7 @@
       "sha256": "ba0a19d2730969b8e6107db1847888ea8d3b8cafd14a535a3259dd04f8b28d60",
       "origin": "TetoTV source build of the pinned libtorrent4j and libtorrent-rasterbar stack",
       "license": "Mixed MIT, BSD, Boost-1.0, Apache-2.0, and MPL-2.0 component terms",
-      "sourceLocator": "TetoTV-v2.0.54-native-playback-sources.zip and tool/native/build_native_playback.sh",
+      "sourceLocator": "TetoTV-v2.0.55-native-playback-sources.zip and tool/native/build_native_playback.sh",
       "noticeLocator": "assets/legal/native/DIRECT_TORRENT_NATIVE_NOTICE.txt and its referenced exact license assets"
     }
   ],


### PR DESCRIPTION
## Summary
- restore the Settings search, collapse control, and profile header whenever the main Settings list returns to the top
- focus Appearance when Settings opens or is reselected from the navigation rail
- prevent nested Settings controls from hiding the shell header
- add TV-only spacing so focus outlines do not overlap neighboring options
- prepare signed Beta 2.0.55 (Android build 410032)

## Verification
- flutter analyze
- flutter test (1,953 passed; 17 expected skips)
- focused Settings, mobile layout, and shell UI tests
- release APK verifier: package, signer, version, SDK, ARM32/ARM64, and 18-library BOM
- native redistribution bundle verifier