### PR TITLE
Fix release history, lobby avatars, and prepare Beta 2.0.57

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 
 <p align="center">
   <a href="https://github.com/LindersOSX/TetoTV-Beta/releases/latest"><strong>Download Beta</strong></a>
-  · <a href="docs/RELEASE_NOTES_2.0.56.md">What's new</a>
+  · <a href="docs/RELEASE_NOTES_2.0.57.md">What's new</a>
   · <a href="https://github.com/LindersOSX/TetoTV-Beta/issues/new">Report an issue</a>
   · <a href="https://discord.gg/juC6k7d4WY">Discord</a>
   · <a href="https://www.youtube.com/@TetoTVApp">YouTube</a>
@@ -94,10 +94,10 @@ TetoTV runs directly on the Android device with no companion server required for
 | Channel | Version | Best for |
 | --- | --- | --- |
 | Public | Not published | Source and release-readiness documents are available, but no Public APK is currently offered |
-| Beta | [2.0.56](docs/RELEASE_NOTES_2.0.56.md) | A polished profile switcher with clearer TV dismissal and consistent themed notifications |
+| Beta | [2.0.57](docs/RELEASE_NOTES_2.0.57.md) | Working Developer release history, cross-tracker lobby avatars, and consistent profile/notification styling |
 
 > [!WARNING]
-> Beta 2.0.56 uses the repository's explicit unreviewed-Beta exception. Its native-library and corresponding-source material did not receive independent license review, and automated integrity checks are not a legal compliance determination. Read the [complete Beta disclosure](docs/RELEASE_NOTES_2.0.56.md). This exception does not apply to a future Public release.
+> Beta 2.0.57 uses the repository's explicit unreviewed-Beta exception. Its native-library and corresponding-source material did not receive independent license review, and automated integrity checks are not a legal compliance determination. Read the [complete Beta disclosure](docs/RELEASE_NOTES_2.0.57.md). This exception does not apply to a future Public release.
 
 The Public updater repository intentionally has no release while the Public build is held for review. Existing Beta installations continue to update from the Beta repository. Android never permits an in-place install of an APK with a lower build code; Developer Mode does not bypass that platform rule.
 

--- a/docs/BUILD_WINDOWS.md
+++ b/docs/BUILD_WINDOWS.md
@@ -220,39 +220,39 @@ APK containing both supported application ABIs.
 Public and Beta updates use anonymous GitHub requests. No Beta key, GitHub
 token, update-proxy URL, or update-specific Dart define is required. Every
 published APK uses the production signing identity. No Public APK is currently
-published. Beta 2.0.56 uses Android build code `410033`. Flutter reuses
+published. Beta 2.0.57 uses Android build code `410034`. Flutter reuses
 `app-release.apk`, so copy and rename the Beta artifact immediately after the
 build:
 
 ```powershell
-New-Item -ItemType Directory -Force .\build\fire-tv\v2.0.56 | Out-Null
+New-Item -ItemType Directory -Force .\build\fire-tv\v2.0.57 | Out-Null
 
-# Beta 2.0.56
+# Beta 2.0.57
 flutter build apk --release --target-platform android-arm,android-arm64 `
-  --build-name 2.0.56 --build-number 410033 --no-tree-shake-icons
+  --build-name 2.0.57 --build-number 410034 --no-tree-shake-icons
 Copy-Item .\build\app\outputs\flutter-apk\app-release.apk `
-  .\build\fire-tv\v2.0.56\TetoTV-v2.0.56-universal.apk
+  .\build\fire-tv\v2.0.57\TetoTV-v2.0.57-universal.apk
 
 .\tool\release\verify_release_apk.ps1 `
   -Channel Beta `
-  -ApkPath .\build\fire-tv\v2.0.56\TetoTV-v2.0.56-universal.apk
+  -ApkPath .\build\fire-tv\v2.0.57\TetoTV-v2.0.57-universal.apk
 
 .\tool\release\verify_native_redistribution.ps1 `
   -RequireResolvedBinaries `
   -ResolvedBinaryDirectory .\build\native-playback\outputs `
-  -StageBundle -ReleaseTag v2.0.56
+  -StageBundle -ReleaseTag v2.0.57
 
 .\tool\release\new_release_checksums.ps1 `
-  -ApkPath .\build\fire-tv\v2.0.56\TetoTV-v2.0.56-universal.apk `
-  -NativeSourcePath .\build\release-compliance\v2.0.56\TetoTV-v2.0.56-native-playback-sources.zip `
-  -OutputPath .\build\fire-tv\v2.0.56\SHA256SUMS
+  -ApkPath .\build\fire-tv\v2.0.57\TetoTV-v2.0.57-universal.apk `
+  -NativeSourcePath .\build\release-compliance\v2.0.57\TetoTV-v2.0.57-native-playback-sources.zip `
+  -OutputPath .\build\fire-tv\v2.0.57\SHA256SUMS
 
 .\tool\release\verify_release_payloads.ps1 `
   -Channel Beta `
-  -ApkPath .\build\fire-tv\v2.0.56\TetoTV-v2.0.56-universal.apk `
-  -NativeSourcePath .\build\release-compliance\v2.0.56\TetoTV-v2.0.56-native-playback-sources.zip `
-  -ChecksumsPath .\build\fire-tv\v2.0.56\SHA256SUMS `
-  -ReleaseNotesPath .\docs\RELEASE_NOTES_2.0.56.md
+  -ApkPath .\build\fire-tv\v2.0.57\TetoTV-v2.0.57-universal.apk `
+  -NativeSourcePath .\build\release-compliance\v2.0.57\TetoTV-v2.0.57-native-playback-sources.zip `
+  -ChecksumsPath .\build\fire-tv\v2.0.57\SHA256SUMS `
+  -ReleaseNotesPath .\docs\RELEASE_NOTES_2.0.57.md
 ```
 
 The final payload check requires all five exact, source-built native JARs

--- a/docs/RELEASE_NOTES_2.0.57.md
+++ b/docs/RELEASE_NOTES_2.0.57.md
@@ -1,0 +1,31 @@
+# TetoTV 2.0.57 Beta
+
+> [!WARNING]
+> No independent native-license review: This Beta has not received independent native-library licensing review. Automated checks verify the APK, native-source bundle, notices, pinned inputs, and checksums, but do not establish legal compliance or reproducible builds.
+
+This Beta restores the Developer release picker, improves cross-tracker Watch Party avatars, and finishes the shared notification/profile styling pass.
+
+## What's changed
+
+- Selecting **Load release history** in Developer Mode now fetches releases and immediately opens the signed-release picker.
+- Preloaded and freshly fetched release histories use the same picker and keep Android's build-code downgrade restrictions visible.
+- AniList and MyAnimeList users can now see each other's public profile pictures in the Watch Party lobby.
+- MyAnimeList's official numeric avatar cache-buster is safely removed before the public image URL is shared; arbitrary query data remains rejected.
+- In-app notification text now uses the same label typography as the rest of TetoTV.
+- The shared profile trigger, image, focus outline, and popup avatar now use one consistent rounded-square corner radius.
+- Popup profile avatars use the same accent border as the top-right profile picture.
+- AI-assisted development disclosure: AI tools assisted with implementation, documentation, tests, and review. The project owner directed the work, validated the changes, and remains responsible for this release.
+
+## Release assets
+
+- `TetoTV-v2.0.57-universal.apk`
+- `TetoTV-v2.0.57-native-playback-sources.zip`
+- `SHA256SUMS`
+
+## Beta notes
+
+- This is a Beta-channel build with Android build code `410034`.
+- No Public APK is being published with this release.
+- Android does not permit an in-place install over an APK with a higher build code. A future Public counterpart must use build code `410034` or newer for data-preserving channel switching.
+
+<!-- tetotv-android-version-code: 410034 -->

--- a/docs/UPDATE_CHANNELS.md
+++ b/docs/UPDATE_CHANNELS.md
@@ -35,11 +35,11 @@ Beta reads completed 2.x releases from:
 https://api.github.com/repos/LindersOSX/TetoTV-Beta/releases/latest
 ```
 
-The current Beta source build is `v2.0.56` with Android build code `410033`.
+The current Beta source build is `v2.0.57` with Android build code `410034`.
 Its release title is:
 
 ```text
-TetoTV 2.0.56 Beta - Android TV / Google TV / Fire TV
+TetoTV 2.0.57 Beta - Android TV / Google TV / Fire TV
 ```
 
 Publish it as a normal, non-draft, non-prerelease GitHub release so
@@ -72,7 +72,7 @@ proxy.
 Release notes must include the exact asset names and this build-code marker:
 
 ```html
-<!-- tetotv-android-version-code: 410033 -->
+<!-- tetotv-android-version-code: 410034 -->
 ```
 
 When build-code metadata is present, the updater rejects a known lower build
@@ -94,10 +94,10 @@ These rules apply equally on phones, Android TV, Google TV, and Fire TV.
 
 ## Switching and rollback
 
-The current Beta uses build code `410033`. No Public counterpart is available.
+The current Beta uses build code `410034`. No Public counterpart is available.
 An older Public install can move to this Beta when Android accepts the higher
 build code, but it cannot move back in place until a future Public build uses
-code `410033` or higher. Uninstalling first permits an older APK but deletes
+code `410034` or higher. Uninstalling first permits an older APK but deletes
 local application data. Developer Mode and in-app settings cannot override
 this Android rule.
 

--- a/lib/core/theme/app_theme.dart
+++ b/lib/core/theme/app_theme.dart
@@ -30,6 +30,12 @@ abstract final class AppTheme {
 
   static ThemeData darkFor(AppThemePalette palette) {
     final accentForeground = contrastForeground(palette.accent);
+    final appLabelStyle = TextStyle(
+      color: palette.primaryText,
+      fontSize: 15,
+      fontWeight: FontWeight.w700,
+      letterSpacing: .2,
+    );
     final scheme = ColorScheme.dark(
       primary: palette.accent,
       onPrimary: accentForeground,
@@ -69,11 +75,10 @@ abstract final class AppTheme {
         actionTextColor: palette.accentBright,
         disabledActionTextColor: palette.mutedText,
         elevation: 12,
-        contentTextStyle: TextStyle(
-          color: palette.primaryText,
-          fontSize: 14,
-          fontWeight: FontWeight.w700,
-        ),
+        // SnackBars are TetoTV's in-app notification surface. Reuse the
+        // regular app label typography so notifications do not look like a
+        // separate system UI layered over the app.
+        contentTextStyle: appLabelStyle,
         shape: RoundedRectangleBorder(
           borderRadius: BorderRadius.circular(12),
           side: BorderSide(color: palette.accent.withValues(alpha: .64)),
@@ -129,12 +134,7 @@ abstract final class AppTheme {
           fontSize: 14,
           height: 1.35,
         ),
-        labelLarge: TextStyle(
-          color: palette.primaryText,
-          fontSize: 15,
-          fontWeight: FontWeight.w700,
-          letterSpacing: .2,
-        ),
+        labelLarge: appLabelStyle,
       ),
       iconTheme: IconThemeData(color: palette.primaryText),
       dividerColor: palette.primaryText.withValues(alpha: .08),

--- a/lib/features/home/presentation/main_navigation_bar.dart
+++ b/lib/features/home/presentation/main_navigation_bar.dart
@@ -1558,7 +1558,10 @@ class _ProfileMenuButton extends StatelessWidget {
           onKeyEvent: onKeyEvent,
           onFocusChanged: onFocusChanged,
           onPressed: isLoading ? () {} : () => _openMenu(buttonContext),
-          borderRadius: BorderRadius.circular(compactAvatar ? 11 : 9),
+          // Keep the focus outline and clipped avatar on the same rounded-
+          // square geometry. A different outer radius made the border look
+          // circular even after the profile image itself became square.
+          borderRadius: _profileAvatarBorderRadius,
           focusScale: compactAvatar ? 1.01 : 1.02,
           child: Container(
             key: ValueKey('main-nav-profile-$slug'),
@@ -1985,7 +1988,11 @@ class _ProfileMenuStats extends StatelessWidget {
         children: [
           Row(
             children: [
-              const _LocalProfileAvatar(size: 34, identify: false),
+              const _LocalProfileAvatar(
+                size: 34,
+                identify: false,
+                outlined: true,
+              ),
               const SizedBox(width: 9),
               Expanded(
                 child: Text(
@@ -2024,7 +2031,12 @@ class _ProfileMenuStats extends StatelessWidget {
       children: [
         Row(
           children: [
-            _ProfileAvatar(profile: profile, size: 34, identify: false),
+            _ProfileAvatar(
+              profile: profile,
+              size: 34,
+              identify: false,
+              outlined: true,
+            ),
             const SizedBox(width: 9),
             Expanded(
               child: Text(
@@ -2184,13 +2196,13 @@ class _ProfileAvatar extends StatelessWidget {
     return Container(
       key: identify
           ? ValueKey('main-nav-profile-avatar-${profile.provider.slug}')
-          : null,
+          : ValueKey('main-nav-profile-menu-avatar-${profile.provider.slug}'),
       width: size,
       height: size,
       clipBehavior: Clip.antiAlias,
       decoration: BoxDecoration(
         shape: BoxShape.rectangle,
-        borderRadius: BorderRadius.circular(size >= 40 ? 10 : 7),
+        borderRadius: _profileAvatarBorderRadius,
         color: context.appPalette.surfaceRaised,
         border: outlined
             ? Border.all(color: context.appPalette.accentBright, width: 2)
@@ -2218,12 +2230,14 @@ class _LocalProfileAvatar extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) => Container(
-    key: identify ? const ValueKey('main-nav-profile-avatar-local') : null,
+    key: identify
+        ? const ValueKey('main-nav-profile-avatar-local')
+        : const ValueKey('main-nav-profile-menu-avatar-local'),
     width: size,
     height: size,
     decoration: BoxDecoration(
       shape: BoxShape.rectangle,
-      borderRadius: BorderRadius.circular(size >= 40 ? 10 : 7),
+      borderRadius: _profileAvatarBorderRadius,
       color: context.appPalette.secondaryAccent.withValues(alpha: .18),
       border: outlined
           ? Border.all(color: context.appPalette.accentBright, width: 2)
@@ -2236,6 +2250,8 @@ class _LocalProfileAvatar extends StatelessWidget {
     ),
   );
 }
+
+const _profileAvatarBorderRadius = BorderRadius.all(Radius.circular(10));
 
 class _NavigationAction extends StatelessWidget {
   const _NavigationAction({

--- a/lib/features/settings/presentation/accounts_screen.dart
+++ b/lib/features/settings/presentation/accounts_screen.dart
@@ -3757,12 +3757,19 @@ class _AccountsScreenState extends ConsumerState<AccountsScreen> {
                                                 .notifier,
                                           )
                                           .setUpdateChannel,
-                                      onRefreshHistory: ref
-                                          .read(
-                                            appUpdateControllerProvider
-                                                .notifier,
-                                          )
-                                          .refreshReleaseHistory,
+                                      onRefreshHistory: () async {
+                                        final controller = ref.read(
+                                          appUpdateControllerProvider.notifier,
+                                        );
+                                        await controller
+                                            .refreshReleaseHistory();
+                                        if (!mounted) {
+                                          return const <AppReleaseInfo>[];
+                                        }
+                                        return ref
+                                            .read(appUpdateControllerProvider)
+                                            .releaseHistory;
+                                      },
                                       onReleaseSelected: ref
                                           .read(
                                             appUpdateControllerProvider
@@ -5538,6 +5545,124 @@ class _SettingsOption<T> {
   final bool enabled;
 }
 
+Future<T?> _showSettingsSelectionDialog<T>({
+  required BuildContext context,
+  required String label,
+  required T value,
+  required List<_SettingsOption<T>> options,
+}) => showDialog<T>(
+  context: context,
+  barrierDismissible: true,
+  builder: (context) {
+    final tvScale = _usesTvSettingsScale(context);
+    return Dialog(
+      backgroundColor: Colors.transparent,
+      child: Container(
+        width: tvScale ? 430 : 560,
+        padding: EdgeInsets.all(tvScale ? 11 : 22),
+        decoration: BoxDecoration(
+          color: context.appPalette.surface,
+          borderRadius: BorderRadius.circular(14),
+          border: Border.all(
+            color: context.appPalette.accent.withValues(alpha: .7),
+          ),
+        ),
+        child: ConstrainedBox(
+          constraints: BoxConstraints(
+            maxHeight: MediaQuery.sizeOf(context).height * .78,
+          ),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                label,
+                style: Theme.of(context).textTheme.titleLarge?.copyWith(
+                  fontSize: tvScale ? 18 : null,
+                  fontWeight: FontWeight.w800,
+                ),
+              ),
+              SizedBox(height: tvScale ? 7 : 14),
+              Flexible(
+                child: ListView.separated(
+                  shrinkWrap: true,
+                  itemCount: options.length,
+                  separatorBuilder: (_, _) => SizedBox(height: tvScale ? 4 : 8),
+                  itemBuilder: (context, index) {
+                    final option = options[index];
+                    final optionControl = TvFocusable(
+                      autofocus: option.enabled && option.value == value,
+                      onPressed: () => Navigator.of(context).pop(option.value),
+                      borderRadius: BorderRadius.circular(9),
+                      child: Container(
+                        width: double.infinity,
+                        padding: EdgeInsets.symmetric(
+                          horizontal: tvScale ? 9 : 16,
+                          vertical: tvScale ? 6 : 13,
+                        ),
+                        decoration: BoxDecoration(
+                          color: option.value == value
+                              ? context.appPalette.accent.withValues(alpha: .28)
+                              : context.appPalette.surfaceRaised,
+                          borderRadius: BorderRadius.circular(9),
+                        ),
+                        child: Row(
+                          children: [
+                            Icon(
+                              option.value == value
+                                  ? Icons.radio_button_checked_rounded
+                                  : Icons.radio_button_off_rounded,
+                              color: option.value == value
+                                  ? context.appPalette.accentBright
+                                  : context.appPalette.mutedText,
+                            ),
+                            SizedBox(width: tvScale ? 7 : 12),
+                            Expanded(
+                              child: Column(
+                                crossAxisAlignment: CrossAxisAlignment.start,
+                                children: [
+                                  Text(
+                                    option.label,
+                                    style: TextStyle(
+                                      color: _settingsPrimaryText(context),
+                                      fontWeight: FontWeight.w900,
+                                    ),
+                                  ),
+                                  if (option.detail case final detail?) ...[
+                                    const SizedBox(height: 2),
+                                    Text(
+                                      detail,
+                                      style: TextStyle(
+                                        color: context.appPalette.mutedText,
+                                        fontSize: tvScale ? 12 : 11,
+                                      ),
+                                    ),
+                                  ],
+                                ],
+                              ),
+                            ),
+                          ],
+                        ),
+                      ),
+                    );
+                    if (option.enabled) return optionControl;
+                    return ExcludeFocus(
+                      excluding: true,
+                      child: IgnorePointer(
+                        child: Opacity(opacity: .45, child: optionControl),
+                      ),
+                    );
+                  },
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  },
+);
+
 class _SettingsSelection<T> extends StatelessWidget {
   const _SettingsSelection({
     required this.label,
@@ -5567,131 +5692,11 @@ class _SettingsSelection<T> extends StatelessWidget {
       focusNode: focusNode,
       showDivider: showDivider,
       onPressed: () async {
-        final result = await showDialog<T>(
+        final result = await _showSettingsSelectionDialog<T>(
           context: context,
-          barrierDismissible: true,
-          builder: (context) {
-            final tvScale = _usesTvSettingsScale(context);
-            return Dialog(
-              backgroundColor: Colors.transparent,
-              child: Container(
-                width: tvScale ? 430 : 560,
-                padding: EdgeInsets.all(tvScale ? 11 : 22),
-                decoration: BoxDecoration(
-                  color: context.appPalette.surface,
-                  borderRadius: BorderRadius.circular(14),
-                  border: Border.all(
-                    color: context.appPalette.accent.withValues(alpha: .7),
-                  ),
-                ),
-                child: ConstrainedBox(
-                  constraints: BoxConstraints(
-                    maxHeight: MediaQuery.sizeOf(context).height * .78,
-                  ),
-                  child: Column(
-                    mainAxisSize: MainAxisSize.min,
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      Text(
-                        label,
-                        style: Theme.of(context).textTheme.titleLarge?.copyWith(
-                          fontSize: tvScale ? 18 : null,
-                          fontWeight: FontWeight.w800,
-                        ),
-                      ),
-                      SizedBox(height: tvScale ? 7 : 14),
-                      Flexible(
-                        child: ListView.separated(
-                          shrinkWrap: true,
-                          itemCount: options.length,
-                          separatorBuilder: (_, _) =>
-                              SizedBox(height: tvScale ? 4 : 8),
-                          itemBuilder: (context, index) {
-                            final option = options[index];
-                            final optionControl = TvFocusable(
-                              autofocus:
-                                  option.enabled && option.value == value,
-                              onPressed: () =>
-                                  Navigator.of(context).pop(option.value),
-                              borderRadius: BorderRadius.circular(9),
-                              child: Container(
-                                width: double.infinity,
-                                padding: EdgeInsets.symmetric(
-                                  horizontal: tvScale ? 9 : 16,
-                                  vertical: tvScale ? 6 : 13,
-                                ),
-                                decoration: BoxDecoration(
-                                  color: option.value == value
-                                      ? context.appPalette.accent.withValues(
-                                          alpha: .28,
-                                        )
-                                      : context.appPalette.surfaceRaised,
-                                  borderRadius: BorderRadius.circular(9),
-                                ),
-                                child: Row(
-                                  children: [
-                                    Icon(
-                                      option.value == value
-                                          ? Icons.radio_button_checked_rounded
-                                          : Icons.radio_button_off_rounded,
-                                      color: option.value == value
-                                          ? context.appPalette.accentBright
-                                          : context.appPalette.mutedText,
-                                    ),
-                                    SizedBox(width: tvScale ? 7 : 12),
-                                    Expanded(
-                                      child: Column(
-                                        crossAxisAlignment:
-                                            CrossAxisAlignment.start,
-                                        children: [
-                                          Text(
-                                            option.label,
-                                            style: TextStyle(
-                                              color: _settingsPrimaryText(
-                                                context,
-                                              ),
-                                              fontWeight: FontWeight.w900,
-                                            ),
-                                          ),
-                                          if (option.detail
-                                              case final detail?) ...[
-                                            const SizedBox(height: 2),
-                                            Text(
-                                              detail,
-                                              style: TextStyle(
-                                                color: context
-                                                    .appPalette
-                                                    .mutedText,
-                                                fontSize: tvScale ? 12 : 11,
-                                              ),
-                                            ),
-                                          ],
-                                        ],
-                                      ),
-                                    ),
-                                  ],
-                                ),
-                              ),
-                            );
-                            if (option.enabled) return optionControl;
-                            return ExcludeFocus(
-                              excluding: true,
-                              child: IgnorePointer(
-                                child: Opacity(
-                                  opacity: .45,
-                                  child: optionControl,
-                                ),
-                              ),
-                            );
-                          },
-                        ),
-                      ),
-                    ],
-                  ),
-                ),
-              ),
-            );
-          },
+          label: label,
+          value: value,
+          options: options,
         );
         if (result != null) onSelected(result);
       },
@@ -7275,7 +7280,7 @@ class _DeveloperUpdatePanel extends StatelessWidget {
   final FocusNode channelFocusNode;
   final FocusNode releaseHistoryFocusNode;
   final ValueChanged<AppUpdateChannel> onChannelSelected;
-  final VoidCallback onRefreshHistory;
+  final Future<List<AppReleaseInfo>> Function() onRefreshHistory;
   final ValueChanged<AppReleaseInfo> onReleaseSelected;
 
   String _releaseCompatibilityDetail(AppReleaseInfo release) {
@@ -7297,6 +7302,29 @@ class _DeveloperUpdatePanel extends StatelessWidget {
       return 'Older release • Android build compatibility checked before download';
     }
     return 'Newer release • package and signature checked before install';
+  }
+
+  Future<void> _loadAndOpenReleaseHistory(BuildContext context) async {
+    final releases = await onRefreshHistory();
+    if (!context.mounted || releases.isEmpty) return;
+    final selected = await _showSettingsSelectionDialog<AppReleaseInfo>(
+      context: context,
+      label: 'Choose a compatible signed release',
+      value: releases.first,
+      options: [
+        for (final release in releases)
+          _SettingsOption(
+            value: release,
+            label: appReleaseDisplayLabel(release, state.updateChannel),
+            detail: _releaseCompatibilityDetail(release),
+            enabled: !isKnownAndroidVersionDowngrade(
+              currentVersion: state.currentVersion,
+              releaseVersionCode: release.androidVersionCode,
+            ),
+          ),
+      ],
+    );
+    if (selected != null) onReleaseSelected(selected);
   }
 
   @override
@@ -7376,7 +7404,7 @@ class _DeveloperUpdatePanel extends StatelessWidget {
               focusNode: releaseHistoryFocusNode,
               onPressed: state.isBusy || state.releaseHistoryLoading
                   ? null
-                  : onRefreshHistory,
+                  : () => _loadAndOpenReleaseHistory(context),
             ),
           SizedBox(height: _usesTvSettingsScale(context) ? 4 : 7),
           Text(

--- a/lib/features/watch_together/domain/watch_party_models.dart
+++ b/lib/features/watch_together/domain/watch_party_models.dart
@@ -171,18 +171,33 @@ String? _safeWatchPartyAvatarUrl(Object? value) {
     return null;
   }
   final uri = Uri.tryParse(value);
+  final host = uri?.host.toLowerCase();
+  final isMalAvatarHost =
+      host == 'cdn.myanimelist.net' || host == 'api-cdn.myanimelist.net';
+  final query = uri?.queryParametersAll ?? const <String, List<String>>{};
+  // MAL's official profile API appends a public numeric `t` cache-buster to
+  // user pictures. It is not part of the image identity and the Watch Party
+  // broker intentionally rejects every query string, so discard this one
+  // documented cosmetic value before sharing the already-public URL. Keep all
+  // other query keys rejected so account tokens or tracking values can never
+  // enter a room payload.
+  final hasSafeMalCacheBuster =
+      isMalAvatarHost &&
+      query.length == 1 &&
+      query['t']?.length == 1 &&
+      RegExp(r'^\d{1,16}$').hasMatch(query['t']!.single);
   if (uri == null ||
       uri.scheme != 'https' ||
       uri.host.isEmpty ||
       uri.userInfo.isNotEmpty ||
-      uri.hasQuery ||
+      (uri.hasQuery && !hasSafeMalCacheBuster) ||
       uri.hasFragment ||
       (uri.hasPort && uri.port != 443) ||
       uri.path.contains('\\') ||
-      !_watchPartyAvatarHosts.contains(uri.host.toLowerCase())) {
+      !_watchPartyAvatarHosts.contains(host)) {
     return null;
   }
-  return uri.toString();
+  return uri.hasQuery ? value.substring(0, value.indexOf('?')) : uri.toString();
 }
 
 @immutable

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: 'none'
 # Public and Beta artifacts built from the same source use one monotonically
 # increasing Android versionCode. The project default carries the Beta display
 # version; the Public universal APK overrides the build name to the 1.x line.
-version: 2.0.56+410033
+version: 2.0.57+410034
 
 environment:
   sdk: ^3.12.2

--- a/test/app_theme_palette_test.dart
+++ b/test/app_theme_palette_test.dart
@@ -105,6 +105,12 @@ void main() {
     expect(theme.snackBarTheme.behavior, SnackBarBehavior.floating);
     expect(theme.snackBarTheme.backgroundColor, palette.surfaceRaised);
     expect(theme.snackBarTheme.actionTextColor, palette.accentBright);
+    final notificationText = theme.snackBarTheme.contentTextStyle!;
+    final appLabelText = theme.textTheme.labelLarge!;
+    expect(notificationText.color, appLabelText.color);
+    expect(notificationText.fontSize, appLabelText.fontSize);
+    expect(notificationText.fontWeight, appLabelText.fontWeight);
+    expect(notificationText.letterSpacing, appLabelText.letterSpacing);
     expect(snackShape.borderRadius, BorderRadius.circular(12));
     expect(snackShape.side.color, palette.accent.withValues(alpha: .64));
   });

--- a/test/app_update_release_date_ui_test.dart
+++ b/test/app_update_release_date_ui_test.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 import 'package:anime_tv/features/settings/application/app_update_controller.dart';
 import 'package:anime_tv/features/settings/presentation/accounts_screen.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -75,6 +76,53 @@ void main() {
     expect(tester.takeException(), isNull);
   });
 
+  testWidgets('Load release history opens the release picker after fetching', (
+    tester,
+  ) async {
+    final latest = _release(
+      '2.0.10',
+      releasedAtUtc: DateTime.utc(2026, 8, 20, 2, 5),
+    );
+    final previous = _release(
+      '2.0.9',
+      releasedAtUtc: DateTime.utc(2026, 8, 12, 17, 30),
+    );
+    await _pumpSystemUpdates(
+      tester,
+      AppUpdateState(
+        currentVersion: '2.0.10+410010',
+        latestVersion: latest.version,
+        release: latest,
+        updateChannel: AppUpdateChannel.beta,
+        developerMode: true,
+      ),
+      releaseHistoryOnRefresh: [latest, previous],
+    );
+
+    for (var index = 0; index < 9; index++) {
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
+      await tester.pumpAndSettle();
+    }
+    expect(
+      FocusManager.instance.primaryFocus?.debugLabel,
+      'accounts.updates.release-history',
+    );
+    await tester.sendKeyEvent(LogicalKeyboardKey.enter);
+    await tester.pumpAndSettle();
+
+    expect(find.byType(Dialog), findsOneWidget);
+    expect(
+      find.descendant(
+        of: find.byType(Dialog),
+        matching: find.text('Choose a compatible signed release'),
+      ),
+      findsOneWidget,
+    );
+    expect(find.text('2.0.10 Beta • Aug 20, 2026'), findsWidgets);
+    expect(find.text('2.0.9 Beta • Aug 12, 2026'), findsOneWidget);
+    expect(tester.takeException(), isNull);
+  });
+
   testWidgets('missing GitHub dates leave the version label clean', (
     tester,
   ) async {
@@ -138,14 +186,18 @@ void main() {
 
 Future<void> _pumpSystemUpdates(
   WidgetTester tester,
-  AppUpdateState state,
-) async {
+  AppUpdateState state, {
+  List<AppReleaseInfo>? releaseHistoryOnRefresh,
+}) async {
   FlutterSecureStorage.setMockInitialValues({});
   tester.view.physicalSize = const Size(1280, 720);
   tester.view.devicePixelRatio = 1;
   addTearDown(tester.view.resetPhysicalSize);
   addTearDown(tester.view.resetDevicePixelRatio);
-  final controller = _FixedAppUpdateController(state);
+  final controller = _FixedAppUpdateController(
+    state,
+    releaseHistoryOnRefresh: releaseHistoryOnRefresh,
+  );
 
   await tester.pumpWidget(
     ProviderScope(
@@ -180,16 +232,27 @@ AppReleaseInfo _release(
 );
 
 class _FixedAppUpdateController extends AppUpdateController {
-  _FixedAppUpdateController(AppUpdateState fixedState)
-    : super(
-        const FlutterSecureStorage(),
-        _UnusedReleaseSource(),
-        () async => fixedState.currentVersion,
-        () async => const [],
-        () async => Directory.systemTemp,
-        (_) async => '',
-      ) {
+  _FixedAppUpdateController(
+    AppUpdateState fixedState, {
+    this.releaseHistoryOnRefresh,
+  }) : super(
+         const FlutterSecureStorage(),
+         _UnusedReleaseSource(),
+         () async => fixedState.currentVersion,
+         () async => const [],
+         () async => Directory.systemTemp,
+         (_) async => '',
+       ) {
     state = fixedState;
+  }
+
+  final List<AppReleaseInfo>? releaseHistoryOnRefresh;
+
+  @override
+  Future<void> refreshReleaseHistory() async {
+    final releases = releaseHistoryOnRefresh;
+    if (releases == null) return;
+    state = state.copyWith(releaseHistory: releases);
   }
 }
 

--- a/test/my_list_screen_test.dart
+++ b/test/my_list_screen_test.dart
@@ -361,7 +361,7 @@ void main() {
     final profileFocusable = tester.widget<TvFocusable>(
       find.descendant(of: profileSwitcher, matching: find.byType(TvFocusable)),
     );
-    expect(profileFocusable.borderRadius, BorderRadius.circular(11));
+    expect(profileFocusable.borderRadius, BorderRadius.circular(10));
     expect(find.byKey(const ValueKey('main-nav-settings')), findsOneWidget);
     expect(find.text('TetoFan'), findsNothing);
     expect(find.text('MALFan'), findsNothing);
@@ -400,6 +400,14 @@ void main() {
     expect(surfaceDecoration.color, AppThemePalette.defaults.surface);
     expect(surfaceDecoration.borderRadius, BorderRadius.circular(14));
     expect(surfaceDecoration.border, isNotNull);
+    final menuAvatar = tester.widget<Container>(
+      find.byKey(const ValueKey('main-nav-profile-menu-avatar-anilist')),
+    );
+    final menuAvatarDecoration = menuAvatar.decoration! as BoxDecoration;
+    expect(menuAvatarDecoration.shape, BoxShape.rectangle);
+    expect(menuAvatarDecoration.borderRadius, BorderRadius.circular(10));
+    expect(menuAvatarDecoration.border, isNotNull);
+    expect(menuAvatarDecoration.border!.top.width, 2);
 
     final activeProfileRow = find.byKey(
       const ValueKey('main-nav-switch-profile-anilist-anilist-tetofan'),

--- a/test/watch_party_public_roster_test.dart
+++ b/test/watch_party_public_roster_test.dart
@@ -63,7 +63,7 @@ void main() {
       provider: TrackingProvider.myAnimeList,
       username: 'MAL Guest',
       avatarUrl:
-          'https://api-cdn.myanimelist.net/images/userimages/456/avatar.jpg',
+          'https://api-cdn.myanimelist.net/images/userimages/456/avatar.jpg?t=1725123456',
     );
 
     final snapshot = _crossTrackerSnapshot(host: host, guest: guest);
@@ -79,6 +79,33 @@ void main() {
       snapshot.participants[1].avatarUrl,
       'https://api-cdn.myanimelist.net/images/userimages/456/avatar.jpg',
     );
+  });
+
+  test('MAL cache-buster is removed without accepting private query data', () {
+    final identity = WatchPartyPublicIdentity.tryCreate(
+      displayName: 'MAL Viewer',
+      avatarUrl:
+          'https://api-cdn.myanimelist.net/images/userimages/456.jpg?t=1619168400',
+    );
+
+    expect(identity?.toJson(), {
+      'display_name': 'MAL Viewer',
+      'avatar_url': 'https://api-cdn.myanimelist.net/images/userimages/456.jpg',
+    });
+    for (final unsafeUrl in <String>[
+      'https://api-cdn.myanimelist.net/images/userimages/456.jpg?token=secret',
+      'https://api-cdn.myanimelist.net/images/userimages/456.jpg?t=1&token=secret',
+      'https://s4.anilist.co/avatar.jpg?t=1619168400',
+    ]) {
+      expect(
+        WatchPartyPublicIdentity.tryCreate(
+          displayName: 'MAL Viewer',
+          avatarUrl: unsafeUrl,
+        )?.toJson(),
+        {'display_name': 'MAL Viewer'},
+        reason: unsafeUrl,
+      );
+    }
   });
 
   test('MAL host and AniList guest exchange public avatars', () {

--- a/tool/release/native_playback_manifest.json
+++ b/tool/release/native_playback_manifest.json
@@ -374,11 +374,11 @@
   "apkNativeLibraries": [
     {
       "path": "lib/arm64-v8a/libapp.so",
-      "size": 12321680,
-      "sha256": "9d0d2464d40bbe6058056a5f0efe8bd694d8946dbc8a32330f5cd18cf357ef52",
-      "origin": "TetoTV Flutter application AOT 2.0.56",
+      "size": 12387216,
+      "sha256": "4f697d249cdbf4a2b019f29be29031acd484b384bc7ba55e54d2976004db0994",
+      "origin": "TetoTV Flutter application AOT 2.0.57",
       "license": "MIT",
-      "sourceLocator": "Git tag v2.0.56",
+      "sourceLocator": "Git tag v2.0.57",
       "noticeLocator": "LICENSE"
     },
     {
@@ -423,7 +423,7 @@
       "sha256": "dc05f53278b2733094f12aeaed54c080329309762ce49e6de4118e4bfb0fff55",
       "origin": "TetoTV source build of media-kit Android helper at 42054e5d479f39ccbb0ae604862e2bcaf59b74c2",
       "license": "MIT",
-      "sourceLocator": "TetoTV-v2.0.56-native-playback-sources.zip: sources/media-kit-android-helper-42054e5d479f39ccbb0ae604862e2bcaf59b74c2.zip",
+      "sourceLocator": "TetoTV-v2.0.57-native-playback-sources.zip: sources/media-kit-android-helper-42054e5d479f39ccbb0ae604862e2bcaf59b74c2.zip",
       "noticeLocator": "assets/legal/native/MEDIA_KIT_ANDROID_HELPER_LICENSE.txt; assets/legal/native/NATIVE_PLAYBACK_NOTICE.txt"
     },
     {
@@ -432,7 +432,7 @@
       "sha256": "a7399d0be70844e5ee94cc5b1acc1516571113c50561fe0a5d05b49101c53ef2",
       "origin": "TetoTV source build of the pinned mpv and FFmpeg native playback stack",
       "license": "LGPL-3.0-or-later (conservative combined classification) plus component terms",
-      "sourceLocator": "TetoTV-v2.0.56-native-playback-sources.zip and tool/native/build_native_playback.sh",
+      "sourceLocator": "TetoTV-v2.0.57-native-playback-sources.zip and tool/native/build_native_playback.sh",
       "noticeLocator": "assets/legal/native/NATIVE_PLAYBACK_NOTICE.txt and its referenced exact license assets"
     },
     {
@@ -450,16 +450,16 @@
       "sha256": "263ba714570fb3acfc308cce52776b00506ec8809d225617e52352336144cfa2",
       "origin": "TetoTV source build of the pinned libtorrent4j and libtorrent-rasterbar stack",
       "license": "Mixed MIT, BSD, Boost-1.0, Apache-2.0, and MPL-2.0 component terms",
-      "sourceLocator": "TetoTV-v2.0.56-native-playback-sources.zip and tool/native/build_native_playback.sh",
+      "sourceLocator": "TetoTV-v2.0.57-native-playback-sources.zip and tool/native/build_native_playback.sh",
       "noticeLocator": "assets/legal/native/DIRECT_TORRENT_NATIVE_NOTICE.txt and its referenced exact license assets"
     },
     {
       "path": "lib/armeabi-v7a/libapp.so",
       "size": 13501004,
-      "sha256": "566bdb2d1578099e5a3a2bcf1fffd71c919a154015186243fdcdfe3cbf221a95",
-      "origin": "TetoTV Flutter application AOT 2.0.56",
+      "sha256": "5f1f3a435b67726292679dc10a7f77991743e84b9470160ca318b50fed019815",
+      "origin": "TetoTV Flutter application AOT 2.0.57",
       "license": "MIT",
-      "sourceLocator": "Git tag v2.0.56",
+      "sourceLocator": "Git tag v2.0.57",
       "noticeLocator": "LICENSE"
     },
     {
@@ -504,7 +504,7 @@
       "sha256": "8820a12e07bb3dc45f5b4286acf6918827fba4c265767e7f1cc8f07215c84b6a",
       "origin": "TetoTV source build of media-kit Android helper at 42054e5d479f39ccbb0ae604862e2bcaf59b74c2",
       "license": "MIT",
-      "sourceLocator": "TetoTV-v2.0.56-native-playback-sources.zip: sources/media-kit-android-helper-42054e5d479f39ccbb0ae604862e2bcaf59b74c2.zip",
+      "sourceLocator": "TetoTV-v2.0.57-native-playback-sources.zip: sources/media-kit-android-helper-42054e5d479f39ccbb0ae604862e2bcaf59b74c2.zip",
       "noticeLocator": "assets/legal/native/MEDIA_KIT_ANDROID_HELPER_LICENSE.txt; assets/legal/native/NATIVE_PLAYBACK_NOTICE.txt"
     },
     {
@@ -513,7 +513,7 @@
       "sha256": "d5a220fdf41edde10f161f86addc846ae9cb18137ea48e4db541cd703fec5092",
       "origin": "TetoTV source build of the pinned mpv and FFmpeg native playback stack",
       "license": "LGPL-3.0-or-later (conservative combined classification) plus component terms",
-      "sourceLocator": "TetoTV-v2.0.56-native-playback-sources.zip and tool/native/build_native_playback.sh",
+      "sourceLocator": "TetoTV-v2.0.57-native-playback-sources.zip and tool/native/build_native_playback.sh",
       "noticeLocator": "assets/legal/native/NATIVE_PLAYBACK_NOTICE.txt and its referenced exact license assets"
     },
     {
@@ -531,7 +531,7 @@
       "sha256": "ba0a19d2730969b8e6107db1847888ea8d3b8cafd14a535a3259dd04f8b28d60",
       "origin": "TetoTV source build of the pinned libtorrent4j and libtorrent-rasterbar stack",
       "license": "Mixed MIT, BSD, Boost-1.0, Apache-2.0, and MPL-2.0 component terms",
-      "sourceLocator": "TetoTV-v2.0.56-native-playback-sources.zip and tool/native/build_native_playback.sh",
+      "sourceLocator": "TetoTV-v2.0.57-native-playback-sources.zip and tool/native/build_native_playback.sh",
       "noticeLocator": "assets/legal/native/DIRECT_TORRENT_NATIVE_NOTICE.txt and its referenced exact license assets"
     }
   ],


### PR DESCRIPTION
## Summary
- open the signed-release picker immediately after Developer Mode history loads
- preserve MyAnimeList public avatars by safely stripping its numeric cache-buster
- match in-app notification typography to TetoTV labels
- unify the profile trigger, image, focus outline, and popup avatar corner radius/border
- prepare verified Beta 2.0.57 release metadata

## Verification
- flutter analyze
- flutter test: 1,956 passed; 17 intentionally skipped
- live AniList/MAL production broker avatar exchange
- signed APK, native redistribution, checksums, and release payload verification