### PR TITLE
Keep Home open after profile menu Back and prepare Beta 2.0.58

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 
 <p align="center">
   <a href="https://github.com/LindersOSX/TetoTV-Beta/releases/latest"><strong>Download Beta</strong></a>
-  · <a href="docs/RELEASE_NOTES_2.0.57.md">What's new</a>
+  · <a href="docs/RELEASE_NOTES_2.0.58.md">What's new</a>
   · <a href="https://github.com/LindersOSX/TetoTV-Beta/issues/new">Report an issue</a>
   · <a href="https://discord.gg/juC6k7d4WY">Discord</a>
   · <a href="https://www.youtube.com/@TetoTVApp">YouTube</a>
@@ -94,10 +94,10 @@ TetoTV runs directly on the Android device with no companion server required for
 | Channel | Version | Best for |
 | --- | --- | --- |
 | Public | Not published | Source and release-readiness documents are available, but no Public APK is currently offered |
-| Beta | [2.0.57](docs/RELEASE_NOTES_2.0.57.md) | Working Developer release history, cross-tracker lobby avatars, and consistent profile/notification styling |
+| Beta | [2.0.58](docs/RELEASE_NOTES_2.0.58.md) | Safe controller Back handling for the shared profile switcher |
 
 > [!WARNING]
-> Beta 2.0.57 uses the repository's explicit unreviewed-Beta exception. Its native-library and corresponding-source material did not receive independent license review, and automated integrity checks are not a legal compliance determination. Read the [complete Beta disclosure](docs/RELEASE_NOTES_2.0.57.md). This exception does not apply to a future Public release.
+> Beta 2.0.58 uses the repository's explicit unreviewed-Beta exception. Its native-library and corresponding-source material did not receive independent license review, and automated integrity checks are not a legal compliance determination. Read the [complete Beta disclosure](docs/RELEASE_NOTES_2.0.58.md). This exception does not apply to a future Public release.
 
 The Public updater repository intentionally has no release while the Public build is held for review. Existing Beta installations continue to update from the Beta repository. Android never permits an in-place install of an APK with a lower build code; Developer Mode does not bypass that platform rule.
 

--- a/docs/BUILD_WINDOWS.md
+++ b/docs/BUILD_WINDOWS.md
@@ -220,39 +220,39 @@ APK containing both supported application ABIs.
 Public and Beta updates use anonymous GitHub requests. No Beta key, GitHub
 token, update-proxy URL, or update-specific Dart define is required. Every
 published APK uses the production signing identity. No Public APK is currently
-published. Beta 2.0.57 uses Android build code `410034`. Flutter reuses
+published. Beta 2.0.58 uses Android build code `410035`. Flutter reuses
 `app-release.apk`, so copy and rename the Beta artifact immediately after the
 build:
 
 ```powershell
-New-Item -ItemType Directory -Force .\build\fire-tv\v2.0.57 | Out-Null
+New-Item -ItemType Directory -Force .\build\fire-tv\v2.0.58 | Out-Null
 
-# Beta 2.0.57
+# Beta 2.0.58
 flutter build apk --release --target-platform android-arm,android-arm64 `
-  --build-name 2.0.57 --build-number 410034 --no-tree-shake-icons
+  --build-name 2.0.58 --build-number 410035 --no-tree-shake-icons
 Copy-Item .\build\app\outputs\flutter-apk\app-release.apk `
-  .\build\fire-tv\v2.0.57\TetoTV-v2.0.57-universal.apk
+  .\build\fire-tv\v2.0.58\TetoTV-v2.0.58-universal.apk
 
 .\tool\release\verify_release_apk.ps1 `
   -Channel Beta `
-  -ApkPath .\build\fire-tv\v2.0.57\TetoTV-v2.0.57-universal.apk
+  -ApkPath .\build\fire-tv\v2.0.58\TetoTV-v2.0.58-universal.apk
 
 .\tool\release\verify_native_redistribution.ps1 `
   -RequireResolvedBinaries `
   -ResolvedBinaryDirectory .\build\native-playback\outputs `
-  -StageBundle -ReleaseTag v2.0.57
+  -StageBundle -ReleaseTag v2.0.58
 
 .\tool\release\new_release_checksums.ps1 `
-  -ApkPath .\build\fire-tv\v2.0.57\TetoTV-v2.0.57-universal.apk `
-  -NativeSourcePath .\build\release-compliance\v2.0.57\TetoTV-v2.0.57-native-playback-sources.zip `
-  -OutputPath .\build\fire-tv\v2.0.57\SHA256SUMS
+  -ApkPath .\build\fire-tv\v2.0.58\TetoTV-v2.0.58-universal.apk `
+  -NativeSourcePath .\build\release-compliance\v2.0.58\TetoTV-v2.0.58-native-playback-sources.zip `
+  -OutputPath .\build\fire-tv\v2.0.58\SHA256SUMS
 
 .\tool\release\verify_release_payloads.ps1 `
   -Channel Beta `
-  -ApkPath .\build\fire-tv\v2.0.57\TetoTV-v2.0.57-universal.apk `
-  -NativeSourcePath .\build\release-compliance\v2.0.57\TetoTV-v2.0.57-native-playback-sources.zip `
-  -ChecksumsPath .\build\fire-tv\v2.0.57\SHA256SUMS `
-  -ReleaseNotesPath .\docs\RELEASE_NOTES_2.0.57.md
+  -ApkPath .\build\fire-tv\v2.0.58\TetoTV-v2.0.58-universal.apk `
+  -NativeSourcePath .\build\release-compliance\v2.0.58\TetoTV-v2.0.58-native-playback-sources.zip `
+  -ChecksumsPath .\build\fire-tv\v2.0.58\SHA256SUMS `
+  -ReleaseNotesPath .\docs\RELEASE_NOTES_2.0.58.md
 ```
 
 The final payload check requires all five exact, source-built native JARs

--- a/docs/RELEASE_NOTES_2.0.58.md
+++ b/docs/RELEASE_NOTES_2.0.58.md
@@ -1,0 +1,28 @@
+# TetoTV 2.0.58 Beta
+
+> [!WARNING]
+> No independent native-license review: This Beta has not received independent native-library licensing review. Automated checks verify the APK, native-source bundle, notices, pinned inputs, and checksums, but do not establish legal compliance or reproducible builds.
+
+This Beta keeps TetoTV open when a television remote dismisses the shared profile switcher.
+
+## What's changed
+
+- Controller Back now consumes its complete key-down/key-up sequence while the profile switcher is open.
+- The profile switcher closes on Back without leaking the remaining key event to Android and exiting the app.
+- Native Android Back continues to close the profile switcher while Home remains visible.
+- Left still closes the profile menu immediately, preserving the existing D-pad navigation behavior.
+- AI-assisted development disclosure: AI tools assisted with implementation, documentation, tests, and review. The project owner directed the work, validated the changes, and remains responsible for this release.
+
+## Release assets
+
+- `TetoTV-v2.0.58-universal.apk`
+- `TetoTV-v2.0.58-native-playback-sources.zip`
+- `SHA256SUMS`
+
+## Beta notes
+
+- This is a Beta-channel build with Android build code `410035`.
+- No Public APK is being published with this release.
+- Android does not permit an in-place install over an APK with a higher build code. A future Public counterpart must use build code `410035` or newer for data-preserving channel switching.
+
+<!-- tetotv-android-version-code: 410035 -->

--- a/docs/UPDATE_CHANNELS.md
+++ b/docs/UPDATE_CHANNELS.md
@@ -35,11 +35,11 @@ Beta reads completed 2.x releases from:
 https://api.github.com/repos/LindersOSX/TetoTV-Beta/releases/latest
 ```
 
-The current Beta source build is `v2.0.57` with Android build code `410034`.
+The current Beta source build is `v2.0.58` with Android build code `410035`.
 Its release title is:
 
 ```text
-TetoTV 2.0.57 Beta - Android TV / Google TV / Fire TV
+TetoTV 2.0.58 Beta - Android TV / Google TV / Fire TV
 ```
 
 Publish it as a normal, non-draft, non-prerelease GitHub release so
@@ -72,7 +72,7 @@ proxy.
 Release notes must include the exact asset names and this build-code marker:
 
 ```html
-<!-- tetotv-android-version-code: 410034 -->
+<!-- tetotv-android-version-code: 410035 -->
 ```
 
 When build-code metadata is present, the updater rejects a known lower build
@@ -94,10 +94,10 @@ These rules apply equally on phones, Android TV, Google TV, and Fire TV.
 
 ## Switching and rollback
 
-The current Beta uses build code `410034`. No Public counterpart is available.
+The current Beta uses build code `410035`. No Public counterpart is available.
 An older Public install can move to this Beta when Android accepts the higher
 build code, but it cannot move back in place until a future Public build uses
-code `410034` or higher. Uninstalling first permits an older APK but deletes
+code `410035` or higher. Uninstalling first permits an older APK but deletes
 local application data. Developer Mode and in-app settings cannot override
 this Android rule.
 

--- a/lib/features/home/presentation/main_navigation_bar.dart
+++ b/lib/features/home/presentation/main_navigation_bar.dart
@@ -1655,15 +1655,27 @@ class _ProfileMenuOverlay extends StatelessWidget {
     FocusNode _,
     KeyEvent event,
   ) {
-    if (event is! KeyDownEvent) return KeyEventResult.ignored;
     final key = event.logicalKey;
-    if (key != LogicalKeyboardKey.arrowLeft &&
-        key != LogicalKeyboardKey.escape &&
-        key != LogicalKeyboardKey.goBack &&
-        key != LogicalKeyboardKey.browserBack) {
+    final isLeft = key == LogicalKeyboardKey.arrowLeft;
+    final isBack =
+        key == LogicalKeyboardKey.escape ||
+        key == LogicalKeyboardKey.goBack ||
+        key == LogicalKeyboardKey.browserBack;
+    if (!isLeft && !isBack) {
       return KeyEventResult.ignored;
     }
-    Navigator.of(context).pop();
+
+    // A TV remote sends Back as a down/up pair. Removing this route on the
+    // down packet lets the matching up packet reach the page underneath and
+    // some Android devices reinterpret it as another app-level Back, closing
+    // TetoTV. Consume the complete pair and dismiss only while handling the
+    // key-up packet so Home remains open.
+    if (isBack) {
+      if (event is KeyUpEvent) Navigator.of(context).pop();
+      return KeyEventResult.handled;
+    }
+
+    if (event is KeyDownEvent) Navigator.of(context).pop();
     return KeyEventResult.handled;
   }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: 'none'
 # Public and Beta artifacts built from the same source use one monotonically
 # increasing Android versionCode. The project default carries the Beta display
 # version; the Public universal APK overrides the build name to the 1.x line.
-version: 2.0.57+410034
+version: 2.0.58+410035
 
 environment:
   sdk: ^3.12.2

--- a/test/profile_management_navigation_test.dart
+++ b/test/profile_management_navigation_test.dart
@@ -6,12 +6,95 @@ import 'package:anime_tv/features/settings/application/settings_preferences_cont
 import 'package:anime_tv/features/settings/application/tracking_accounts_controller.dart';
 import 'package:anime_tv/features/settings/presentation/accounts_screen.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
 
 void main() {
+  testWidgets('controller Back closes the profile menu without leaving Home', (
+    tester,
+  ) async {
+    tester.view.physicalSize = const Size(1280, 720);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    final router = GoRouter(
+      routes: [
+        GoRoute(
+          path: '/',
+          builder: (context, state) => const Scaffold(
+            body: Stack(
+              children: [
+                Text('Home', key: ValueKey('home-page')),
+                MainNavigationBar(
+                  active: MainNavigationDestination.home,
+                  preferences: SettingsPreferences(),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ],
+    );
+    addTearDown(router.dispose);
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          trackingAccountsControllerProvider.overrideWith(
+            (_) => _StaticTrackingAccountsController(
+              const TrackingAccountsState(
+                profiles: {
+                  TrackingProvider.anilist: TrackingAccountProfile(
+                    provider: TrackingProvider.anilist,
+                    username: 'TetoFan',
+                  ),
+                },
+              ),
+            ),
+          ),
+        ],
+        child: MaterialApp.router(routerConfig: router),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    final profile = find.byKey(const ValueKey('main-nav-profile-summary'));
+    final menu = find.byKey(const ValueKey('main-nav-profile-menu-surface'));
+    await tester.tap(profile);
+    await tester.pumpAndSettle();
+    expect(menu, findsOneWidget);
+
+    await tester.sendKeyDownEvent(
+      LogicalKeyboardKey.goBack,
+      physicalKey: PhysicalKeyboardKey.escape,
+    );
+    await tester.pump();
+    expect(menu, findsOneWidget);
+
+    await tester.sendKeyUpEvent(
+      LogicalKeyboardKey.goBack,
+      physicalKey: PhysicalKeyboardKey.escape,
+    );
+    await tester.pumpAndSettle();
+    expect(menu, findsNothing);
+    expect(find.byKey(const ValueKey('home-page')), findsOneWidget);
+    expect(router.routeInformationProvider.value.uri.path, '/');
+
+    await tester.tap(profile);
+    await tester.pumpAndSettle();
+    expect(menu, findsOneWidget);
+    await tester.binding.handlePopRoute();
+    await tester.pumpAndSettle();
+    expect(menu, findsNothing);
+    expect(find.byKey(const ValueKey('home-page')), findsOneWidget);
+    expect(router.routeInformationProvider.value.uri.path, '/');
+    expect(tester.takeException(), isNull);
+  });
+
   testWidgets('profile menu opens the tracker profile settings entry point', (
     tester,
   ) async {

--- a/tool/release/native_playback_manifest.json
+++ b/tool/release/native_playback_manifest.json
@@ -375,10 +375,10 @@
     {
       "path": "lib/arm64-v8a/libapp.so",
       "size": 12387216,
-      "sha256": "4f697d249cdbf4a2b019f29be29031acd484b384bc7ba55e54d2976004db0994",
-      "origin": "TetoTV Flutter application AOT 2.0.57",
+      "sha256": "bb7fa25497da5d85672b4927de379fa5c5673975355c745568ccb0ce103750b3",
+      "origin": "TetoTV Flutter application AOT 2.0.58",
       "license": "MIT",
-      "sourceLocator": "Git tag v2.0.57",
+      "sourceLocator": "Git tag v2.0.58",
       "noticeLocator": "LICENSE"
     },
     {
@@ -423,7 +423,7 @@
       "sha256": "dc05f53278b2733094f12aeaed54c080329309762ce49e6de4118e4bfb0fff55",
       "origin": "TetoTV source build of media-kit Android helper at 42054e5d479f39ccbb0ae604862e2bcaf59b74c2",
       "license": "MIT",
-      "sourceLocator": "TetoTV-v2.0.57-native-playback-sources.zip: sources/media-kit-android-helper-42054e5d479f39ccbb0ae604862e2bcaf59b74c2.zip",
+      "sourceLocator": "TetoTV-v2.0.58-native-playback-sources.zip: sources/media-kit-android-helper-42054e5d479f39ccbb0ae604862e2bcaf59b74c2.zip",
       "noticeLocator": "assets/legal/native/MEDIA_KIT_ANDROID_HELPER_LICENSE.txt; assets/legal/native/NATIVE_PLAYBACK_NOTICE.txt"
     },
     {
@@ -432,7 +432,7 @@
       "sha256": "a7399d0be70844e5ee94cc5b1acc1516571113c50561fe0a5d05b49101c53ef2",
       "origin": "TetoTV source build of the pinned mpv and FFmpeg native playback stack",
       "license": "LGPL-3.0-or-later (conservative combined classification) plus component terms",
-      "sourceLocator": "TetoTV-v2.0.57-native-playback-sources.zip and tool/native/build_native_playback.sh",
+      "sourceLocator": "TetoTV-v2.0.58-native-playback-sources.zip and tool/native/build_native_playback.sh",
       "noticeLocator": "assets/legal/native/NATIVE_PLAYBACK_NOTICE.txt and its referenced exact license assets"
     },
     {
@@ -450,16 +450,16 @@
       "sha256": "263ba714570fb3acfc308cce52776b00506ec8809d225617e52352336144cfa2",
       "origin": "TetoTV source build of the pinned libtorrent4j and libtorrent-rasterbar stack",
       "license": "Mixed MIT, BSD, Boost-1.0, Apache-2.0, and MPL-2.0 component terms",
-      "sourceLocator": "TetoTV-v2.0.57-native-playback-sources.zip and tool/native/build_native_playback.sh",
+      "sourceLocator": "TetoTV-v2.0.58-native-playback-sources.zip and tool/native/build_native_playback.sh",
       "noticeLocator": "assets/legal/native/DIRECT_TORRENT_NATIVE_NOTICE.txt and its referenced exact license assets"
     },
     {
       "path": "lib/armeabi-v7a/libapp.so",
       "size": 13501004,
-      "sha256": "5f1f3a435b67726292679dc10a7f77991743e84b9470160ca318b50fed019815",
-      "origin": "TetoTV Flutter application AOT 2.0.57",
+      "sha256": "4482d7bc3ed3a9ea3075425d0a01229a45b75dd05b41948180740c9acb32bd48",
+      "origin": "TetoTV Flutter application AOT 2.0.58",
       "license": "MIT",
-      "sourceLocator": "Git tag v2.0.57",
+      "sourceLocator": "Git tag v2.0.58",
       "noticeLocator": "LICENSE"
     },
     {
@@ -504,7 +504,7 @@
       "sha256": "8820a12e07bb3dc45f5b4286acf6918827fba4c265767e7f1cc8f07215c84b6a",
       "origin": "TetoTV source build of media-kit Android helper at 42054e5d479f39ccbb0ae604862e2bcaf59b74c2",
       "license": "MIT",
-      "sourceLocator": "TetoTV-v2.0.57-native-playback-sources.zip: sources/media-kit-android-helper-42054e5d479f39ccbb0ae604862e2bcaf59b74c2.zip",
+      "sourceLocator": "TetoTV-v2.0.58-native-playback-sources.zip: sources/media-kit-android-helper-42054e5d479f39ccbb0ae604862e2bcaf59b74c2.zip",
       "noticeLocator": "assets/legal/native/MEDIA_KIT_ANDROID_HELPER_LICENSE.txt; assets/legal/native/NATIVE_PLAYBACK_NOTICE.txt"
     },
     {
@@ -513,7 +513,7 @@
       "sha256": "d5a220fdf41edde10f161f86addc846ae9cb18137ea48e4db541cd703fec5092",
       "origin": "TetoTV source build of the pinned mpv and FFmpeg native playback stack",
       "license": "LGPL-3.0-or-later (conservative combined classification) plus component terms",
-      "sourceLocator": "TetoTV-v2.0.57-native-playback-sources.zip and tool/native/build_native_playback.sh",
+      "sourceLocator": "TetoTV-v2.0.58-native-playback-sources.zip and tool/native/build_native_playback.sh",
       "noticeLocator": "assets/legal/native/NATIVE_PLAYBACK_NOTICE.txt and its referenced exact license assets"
     },
     {
@@ -531,7 +531,7 @@
       "sha256": "ba0a19d2730969b8e6107db1847888ea8d3b8cafd14a535a3259dd04f8b28d60",
       "origin": "TetoTV source build of the pinned libtorrent4j and libtorrent-rasterbar stack",
       "license": "Mixed MIT, BSD, Boost-1.0, Apache-2.0, and MPL-2.0 component terms",
-      "sourceLocator": "TetoTV-v2.0.57-native-playback-sources.zip and tool/native/build_native_playback.sh",
+      "sourceLocator": "TetoTV-v2.0.58-native-playback-sources.zip and tool/native/build_native_playback.sh",
       "noticeLocator": "assets/legal/native/DIRECT_TORRENT_NATIVE_NOTICE.txt and its referenced exact license assets"
     }
   ],


### PR DESCRIPTION
## Summary
- consume the complete TV remote Back key sequence inside the profile switcher
- keep Home open instead of leaking Back to Android app exit
- add controller and native-pop regression coverage
- prepare the verified v2.0.58 Beta metadata and native manifest

## Verification
- flutter analyze
- flutter test (1,957 passed; 17 intentionally skipped)
- production-signed universal APK verification
- native redistribution and release payload verification