### PR TITLE
Refresh TV keyboards and prepare Beta 2.0.59

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 
 <p align="center">
   <a href="https://github.com/LindersOSX/TetoTV-Beta/releases/latest"><strong>Download Beta</strong></a>
-  · <a href="docs/RELEASE_NOTES_2.0.58.md">What's new</a>
+  · <a href="docs/RELEASE_NOTES_2.0.59.md">What's new</a>
   · <a href="https://github.com/LindersOSX/TetoTV-Beta/issues/new">Report an issue</a>
   · <a href="https://discord.gg/juC6k7d4WY">Discord</a>
   · <a href="https://www.youtube.com/@TetoTVApp">YouTube</a>
@@ -94,10 +94,10 @@ TetoTV runs directly on the Android device with no companion server required for
 | Channel | Version | Best for |
 | --- | --- | --- |
 | Public | Not published | Source and release-readiness documents are available, but no Public APK is currently offered |
-| Beta | [2.0.58](docs/RELEASE_NOTES_2.0.58.md) | Safe controller Back handling for the shared profile switcher |
+| Beta | [2.0.59](docs/RELEASE_NOTES_2.0.59.md) | Controller-first built-in QWERTY and numeric keyboards |
 
 > [!WARNING]
-> Beta 2.0.58 uses the repository's explicit unreviewed-Beta exception. Its native-library and corresponding-source material did not receive independent license review, and automated integrity checks are not a legal compliance determination. Read the [complete Beta disclosure](docs/RELEASE_NOTES_2.0.58.md). This exception does not apply to a future Public release.
+> Beta 2.0.59 uses the repository's explicit unreviewed-Beta exception. Its native-library and corresponding-source material did not receive independent license review, and automated integrity checks are not a legal compliance determination. Read the [complete Beta disclosure](docs/RELEASE_NOTES_2.0.59.md). This exception does not apply to a future Public release.
 
 The Public updater repository intentionally has no release while the Public build is held for review. Existing Beta installations continue to update from the Beta repository. Android never permits an in-place install of an APK with a lower build code; Developer Mode does not bypass that platform rule.
 

--- a/docs/BUILD_WINDOWS.md
+++ b/docs/BUILD_WINDOWS.md
@@ -220,39 +220,39 @@ APK containing both supported application ABIs.
 Public and Beta updates use anonymous GitHub requests. No Beta key, GitHub
 token, update-proxy URL, or update-specific Dart define is required. Every
 published APK uses the production signing identity. No Public APK is currently
-published. Beta 2.0.58 uses Android build code `410035`. Flutter reuses
+published. Beta 2.0.59 uses Android build code `410036`. Flutter reuses
 `app-release.apk`, so copy and rename the Beta artifact immediately after the
 build:
 
 ```powershell
-New-Item -ItemType Directory -Force .\build\fire-tv\v2.0.58 | Out-Null
+New-Item -ItemType Directory -Force .\build\fire-tv\v2.0.59 | Out-Null
 
-# Beta 2.0.58
+# Beta 2.0.59
 flutter build apk --release --target-platform android-arm,android-arm64 `
-  --build-name 2.0.58 --build-number 410035 --no-tree-shake-icons
+  --build-name 2.0.59 --build-number 410036 --no-tree-shake-icons
 Copy-Item .\build\app\outputs\flutter-apk\app-release.apk `
-  .\build\fire-tv\v2.0.58\TetoTV-v2.0.58-universal.apk
+  .\build\fire-tv\v2.0.59\TetoTV-v2.0.59-universal.apk
 
 .\tool\release\verify_release_apk.ps1 `
   -Channel Beta `
-  -ApkPath .\build\fire-tv\v2.0.58\TetoTV-v2.0.58-universal.apk
+  -ApkPath .\build\fire-tv\v2.0.59\TetoTV-v2.0.59-universal.apk
 
 .\tool\release\verify_native_redistribution.ps1 `
   -RequireResolvedBinaries `
   -ResolvedBinaryDirectory .\build\native-playback\outputs `
-  -StageBundle -ReleaseTag v2.0.58
+  -StageBundle -ReleaseTag v2.0.59
 
 .\tool\release\new_release_checksums.ps1 `
-  -ApkPath .\build\fire-tv\v2.0.58\TetoTV-v2.0.58-universal.apk `
-  -NativeSourcePath .\build\release-compliance\v2.0.58\TetoTV-v2.0.58-native-playback-sources.zip `
-  -OutputPath .\build\fire-tv\v2.0.58\SHA256SUMS
+  -ApkPath .\build\fire-tv\v2.0.59\TetoTV-v2.0.59-universal.apk `
+  -NativeSourcePath .\build\release-compliance\v2.0.59\TetoTV-v2.0.59-native-playback-sources.zip `
+  -OutputPath .\build\fire-tv\v2.0.59\SHA256SUMS
 
 .\tool\release\verify_release_payloads.ps1 `
   -Channel Beta `
-  -ApkPath .\build\fire-tv\v2.0.58\TetoTV-v2.0.58-universal.apk `
-  -NativeSourcePath .\build\release-compliance\v2.0.58\TetoTV-v2.0.58-native-playback-sources.zip `
-  -ChecksumsPath .\build\fire-tv\v2.0.58\SHA256SUMS `
-  -ReleaseNotesPath .\docs\RELEASE_NOTES_2.0.58.md
+  -ApkPath .\build\fire-tv\v2.0.59\TetoTV-v2.0.59-universal.apk `
+  -NativeSourcePath .\build\release-compliance\v2.0.59\TetoTV-v2.0.59-native-playback-sources.zip `
+  -ChecksumsPath .\build\fire-tv\v2.0.59\SHA256SUMS `
+  -ReleaseNotesPath .\docs\RELEASE_NOTES_2.0.59.md
 ```
 
 The final payload check requires all five exact, source-built native JARs

--- a/docs/RELEASE_NOTES_2.0.59.md
+++ b/docs/RELEASE_NOTES_2.0.59.md
@@ -1,0 +1,28 @@
+# TetoTV 2.0.59 Beta
+
+> [!WARNING]
+> No independent native-license review: This Beta has not received independent native-library licensing review. Automated checks verify the APK, native-source bundle, notices, pinned inputs, and checksums, but do not establish legal compliance or reproducible builds.
+
+This Beta refreshes TetoTV's built-in keyboards with familiar controller-first layouts for search and room-code entry.
+
+## What's changed
+
+- The full built-in keyboard now uses a familiar QWERTY layout with a separate number pad and clearly grouped editing controls.
+- Search entry now presents its title, input field, active input methods, and primary Search action in one consistent TV dialog.
+- Watch Party room-code entry now uses a compact numeric keypad with dedicated Backspace, Clear, Cancel, and Done actions.
+- Keyboard focus styling and D-pad movement are aligned with TetoTV's shared TV interaction design.
+- AI-assisted development disclosure: AI tools assisted with implementation, documentation, tests, and review. The project owner directed the work, validated the changes, and remains responsible for this release.
+
+## Release assets
+
+- `TetoTV-v2.0.59-universal.apk`
+- `TetoTV-v2.0.59-native-playback-sources.zip`
+- `SHA256SUMS`
+
+## Beta notes
+
+- This is a Beta-channel build with Android build code `410036`.
+- No Public APK is being published with this release.
+- Android does not permit an in-place install over an APK with a higher build code. A future Public counterpart must use build code `410036` or newer for data-preserving channel switching.
+
+<!-- tetotv-android-version-code: 410036 -->

--- a/docs/UPDATE_CHANNELS.md
+++ b/docs/UPDATE_CHANNELS.md
@@ -35,11 +35,11 @@ Beta reads completed 2.x releases from:
 https://api.github.com/repos/LindersOSX/TetoTV-Beta/releases/latest
 ```
 
-The current Beta source build is `v2.0.58` with Android build code `410035`.
+The current Beta source build is `v2.0.59` with Android build code `410036`.
 Its release title is:
 
 ```text
-TetoTV 2.0.58 Beta - Android TV / Google TV / Fire TV
+TetoTV 2.0.59 Beta - Android TV / Google TV / Fire TV
 ```
 
 Publish it as a normal, non-draft, non-prerelease GitHub release so
@@ -72,7 +72,7 @@ proxy.
 Release notes must include the exact asset names and this build-code marker:
 
 ```html
-<!-- tetotv-android-version-code: 410035 -->
+<!-- tetotv-android-version-code: 410036 -->
 ```
 
 When build-code metadata is present, the updater rejects a known lower build
@@ -94,10 +94,10 @@ These rules apply equally on phones, Android TV, Google TV, and Fire TV.
 
 ## Switching and rollback
 
-The current Beta uses build code `410035`. No Public counterpart is available.
+The current Beta uses build code `410036`. No Public counterpart is available.
 An older Public install can move to this Beta when Android accepts the higher
 build code, but it cannot move back in place until a future Public build uses
-code `410035` or higher. Uninstalling first permits an older APK but deletes
+code `410036` or higher. Uninstalling first permits an older APK but deletes
 local application data. Developer Mode and in-app settings cannot override
 this Android rule.
 

--- a/lib/core/widgets/tv_text_input.dart
+++ b/lib/core/widgets/tv_text_input.dart
@@ -593,20 +593,15 @@ class _TvKeyboardDialogState extends State<TvKeyboardDialog> {
   static const _letterRows = <List<String>>[
     ['q', 'w', 'e', 'r', 't', 'y', 'u', 'i', 'o', 'p'],
     ['a', 's', 'd', 'f', 'g', 'h', 'j', 'k', 'l'],
-    ['z', 'x', 'c', 'v', 'b', 'n', 'm', ',', '.'],
+    ['z', 'x', 'c', 'v', 'b', 'n', 'm', '.', ','],
   ];
   static const _symbolRows = <List<String>>[
-    ['!', '@', '#', r'$', '%', '^', '&', '*', '(', ')'],
+    ['1', '2', '3', '4', '5', '6', '7', '8', '9', '0'],
     ['-', '_', '=', '+', '[', ']', '{', '}', r'\', '|'],
     ['.', ',', ':', ';', '/', '?', '"', "'", '<', '>'],
   ];
-  static const _numberRows = <List<String>>[
-    ['7', '8', '9'],
-    ['4', '5', '6'],
-    ['1', '2', '3'],
-  ];
-
   late String _value;
+  late int _cursorOffset;
   bool _shift = false;
   bool _symbols = false;
   late bool _reveal;
@@ -615,45 +610,90 @@ class _TvKeyboardDialogState extends State<TvKeyboardDialog> {
   void initState() {
     super.initState();
     _value = widget.initialValue;
+    _cursorOffset = _value.length;
     _reveal = !widget.obscureText;
   }
 
   void _append(String value) {
     final appended = _shift && !_symbols ? value.toUpperCase() : value;
     setState(() {
-      _value = _formatValue('$_value$appended');
+      final candidate =
+          '${_value.substring(0, _cursorOffset)}$appended${_value.substring(_cursorOffset)}';
+      final formatted = _formatValue(
+        candidate,
+        selectionOffset: _cursorOffset + appended.length,
+      );
+      _value = formatted.text;
+      _cursorOffset = formatted.selection.baseOffset.clamp(0, _value.length);
       if (_shift) _shift = false;
     });
   }
 
   void _backspace() {
-    if (_value.isEmpty) return;
-    setState(() => _value = _value.substring(0, _value.length - 1));
+    if (_value.isEmpty || _cursorOffset == 0) return;
+    setState(() {
+      final candidate =
+          '${_value.substring(0, _cursorOffset - 1)}${_value.substring(_cursorOffset)}';
+      final formatted = _formatValue(
+        candidate,
+        selectionOffset: _cursorOffset - 1,
+      );
+      _value = formatted.text;
+      _cursorOffset = formatted.selection.baseOffset.clamp(0, _value.length);
+    });
+  }
+
+  void _moveCursor(int delta) {
+    setState(() {
+      _cursorOffset = (_cursorOffset + delta).clamp(0, _value.length);
+    });
+  }
+
+  void _clear() {
+    setState(() {
+      _value = '';
+      _cursorOffset = 0;
+    });
   }
 
   Future<void> _paste() async {
     final data = await Clipboard.getData(Clipboard.kTextPlain);
     final value = data?.text;
     if (value == null || value.isEmpty || !mounted) return;
-    setState(
-      () => _value = _formatValue(
-        '$_value${value.replaceAll(RegExp(r'[\r\n]+'), '')}',
-      ),
-    );
+    final pasted = value.replaceAll(RegExp(r'[\r\n]+'), '');
+    setState(() {
+      final candidate =
+          '${_value.substring(0, _cursorOffset)}$pasted${_value.substring(_cursorOffset)}';
+      final formatted = _formatValue(
+        candidate,
+        selectionOffset: _cursorOffset + pasted.length,
+      );
+      _value = formatted.text;
+      _cursorOffset = formatted.selection.baseOffset.clamp(0, _value.length);
+    });
   }
 
   void _autofill(String value) {
-    setState(() => _value = _formatValue(value));
+    setState(() {
+      final formatted = _formatValue(value, selectionOffset: value.length);
+      _value = formatted.text;
+      _cursorOffset = formatted.selection.baseOffset.clamp(0, _value.length);
+    });
   }
 
-  String _formatValue(String candidate) {
+  TextEditingValue _formatValue(
+    String candidate, {
+    required int selectionOffset,
+  }) {
     var value = TextEditingValue(
       text: candidate,
-      selection: TextSelection.collapsed(offset: candidate.length),
+      selection: TextSelection.collapsed(
+        offset: selectionOffset.clamp(0, candidate.length),
+      ),
     );
     final oldValue = TextEditingValue(
       text: _value,
-      selection: TextSelection.collapsed(offset: _value.length),
+      selection: TextSelection.collapsed(offset: _cursorOffset),
     );
     for (final formatter in widget.inputFormatters) {
       value = formatter.formatEditUpdate(oldValue, value);
@@ -663,10 +703,12 @@ class _TvKeyboardDialogState extends State<TvKeyboardDialog> {
       final clipped = value.text.characters.take(maximum).toString();
       value = TextEditingValue(
         text: clipped,
-        selection: TextSelection.collapsed(offset: clipped.length),
+        selection: TextSelection.collapsed(
+          offset: value.selection.baseOffset.clamp(0, clipped.length),
+        ),
       );
     }
-    return value.text;
+    return value;
   }
 
   KeyEventResult _handlePhysicalKeyboard(FocusNode _, KeyEvent event) {
@@ -677,7 +719,9 @@ class _TvKeyboardDialogState extends State<TvKeyboardDialog> {
       _backspace();
       return KeyEventResult.handled;
     }
-    if (event.logicalKey == LogicalKeyboardKey.escape) {
+    if (event.logicalKey == LogicalKeyboardKey.escape ||
+        event.logicalKey == LogicalKeyboardKey.goBack ||
+        event.logicalKey == LogicalKeyboardKey.browserBack) {
       Navigator.of(context).pop();
       return KeyEventResult.handled;
     }
@@ -686,11 +730,25 @@ class _TvKeyboardDialogState extends State<TvKeyboardDialog> {
       Navigator.of(context).pop(_value);
       return KeyEventResult.handled;
     }
+    final pressed = HardwareKeyboard.instance.logicalKeysPressed;
+    final pasteShortcut =
+        event.logicalKey == LogicalKeyboardKey.keyV &&
+        (pressed.contains(LogicalKeyboardKey.controlLeft) ||
+            pressed.contains(LogicalKeyboardKey.controlRight) ||
+            pressed.contains(LogicalKeyboardKey.metaLeft) ||
+            pressed.contains(LogicalKeyboardKey.metaRight));
+    if (pasteShortcut ||
+        (event.logicalKey == LogicalKeyboardKey.insert &&
+            (pressed.contains(LogicalKeyboardKey.shiftLeft) ||
+                pressed.contains(LogicalKeyboardKey.shiftRight)))) {
+      _paste();
+      return KeyEventResult.handled;
+    }
     final character = event.character;
     if (character != null &&
         character.length == 1 &&
         character.codeUnitAt(0) >= 32) {
-      setState(() => _value = _formatValue('$_value$character'));
+      _append(character);
       return KeyEventResult.handled;
     }
     return KeyEventResult.ignored;
@@ -703,328 +761,547 @@ class _TvKeyboardDialogState extends State<TvKeyboardDialog> {
         ? List.filled(_value.length, '\u2022').join()
         : _value;
     final rows = _symbols ? _symbolRows : _letterRows;
-    final availableWidth = MediaQuery.sizeOf(context).width;
-    final panelWidth = widget.numericOnly
-        ? (availableWidth < 340 ? availableWidth - 20 : 320.0)
-        : (availableWidth < 600 ? availableWidth - 20 : 560.0);
+    final availableSize = MediaQuery.sizeOf(context);
+    final availableWidth = availableSize.width;
+    final availableHeight = availableSize.height;
+    final narrow = availableWidth < 720;
+    final horizontalInset = narrow ? 10.0 : 20.0;
+    final maximumPanelWidth = (availableWidth - (horizontalInset * 2)).clamp(
+      0.0,
+      double.infinity,
+    );
+    final desiredWidth = widget.numericOnly ? 820.0 : 1160.0;
+    final panelWidth = desiredWidth.clamp(0.0, maximumPanelWidth).toDouble();
+    final widthScale = (panelWidth / desiredWidth).clamp(.64, 1.0);
+    final heightTarget = availableHeight < 500
+        ? (widget.numericOnly ? 720.0 : 620.0)
+        : (widget.numericOnly ? 640.0 : 525.0);
+    final heightScale = (availableHeight / heightTarget).clamp(.48, 1.0);
+    final scale = narrow
+        ? (widthScale < heightScale ? widthScale : heightScale)
+        : heightScale;
+    final keyHeight = (widget.numericOnly ? 64.0 : 58.0) * scale;
+    final actionHeight = (widget.numericOnly ? 68.0 : 58.0) * scale;
+    final keyGap = (widget.numericOnly ? 10.0 : 8.0) * scale;
+    final panelPadding = (widget.numericOnly ? 26.0 : 28.0) * scale;
+    final titleSize = (widget.numericOnly ? 30.0 : 28.0) * scale;
+    final inputHeight = (widget.numericOnly ? 70.0 : 62.0) * scale;
+    final inputFontSize = (widget.numericOnly ? 25.0 : 23.0) * scale;
+    final submitLabel = widget.title.toLowerCase().contains('search')
+        ? 'Search'
+        : 'Done';
+
+    Widget keyboardKey({
+      required String id,
+      String? label,
+      IconData? icon,
+      String? semanticLabel,
+      required VoidCallback onPressed,
+      bool autofocus = false,
+      bool primary = false,
+      bool selected = false,
+      double? height,
+      double? fontSize,
+    }) {
+      return _KeyboardKey(
+        key: ValueKey('tv-keyboard-key-$id'),
+        label: label,
+        icon: icon,
+        semanticLabel: semanticLabel ?? label ?? id,
+        autofocus: autofocus,
+        primary: primary,
+        selected: selected,
+        height: height ?? keyHeight,
+        fontSize: fontSize ?? (21 * scale).clamp(12, 21),
+        onPressed: onPressed,
+      );
+    }
+
+    Widget flexKey({
+      required String id,
+      String? label,
+      IconData? icon,
+      String? semanticLabel,
+      required VoidCallback onPressed,
+      int flex = 10,
+      bool autofocus = false,
+      bool primary = false,
+      bool selected = false,
+      double? height,
+      double? fontSize,
+    }) {
+      return Expanded(
+        flex: flex,
+        child: keyboardKey(
+          id: id,
+          label: label,
+          icon: icon,
+          semanticLabel: semanticLabel,
+          onPressed: onPressed,
+          autofocus: autofocus,
+          primary: primary,
+          selected: selected,
+          height: height,
+          fontSize: fontSize,
+        ),
+      );
+    }
+
+    Widget textRow(
+      List<String> labels, {
+      double leftInset = 0,
+      bool autofocusFirst = false,
+    }) {
+      return Padding(
+        padding: EdgeInsets.only(left: leftInset),
+        child: Row(
+          children: [
+            for (var index = 0; index < labels.length; index++) ...[
+              flexKey(
+                id: 'text-${labels[index]}-$index',
+                label: _shift && !_symbols
+                    ? labels[index].toUpperCase()
+                    : labels[index],
+                autofocus: autofocusFirst && index == 0,
+                onPressed: () => _append(labels[index]),
+              ),
+              if (index != labels.length - 1) SizedBox(width: keyGap),
+            ],
+          ],
+        ),
+      );
+    }
+
+    Widget numericRow(List<String> labels, {String? autofocusLabel}) {
+      return Row(
+        children: [
+          for (var index = 0; index < labels.length; index++) ...[
+            flexKey(
+              id: 'number-${labels[index]}',
+              label: labels[index],
+              autofocus: labels[index] == autofocusLabel,
+              onPressed: () => _append(labels[index]),
+              height: keyHeight,
+            ),
+            if (index != labels.length - 1) SizedBox(width: keyGap),
+          ],
+        ],
+      );
+    }
+
+    Widget qwertyKeyboard() {
+      final numberPadWidth = narrow ? 0.0 : panelWidth * .225;
+      final thirdRow = rows[2];
+      return Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Expanded(
+            child: Column(
+              children: [
+                textRow(rows[0], autofocusFirst: true),
+                SizedBox(height: keyGap),
+                textRow(rows[1], leftInset: 28 * scale),
+                SizedBox(height: keyGap),
+                Row(
+                  children: [
+                    flexKey(
+                      id: 'shift',
+                      icon: Icons.arrow_upward_rounded,
+                      semanticLabel: 'Shift',
+                      flex: 14,
+                      selected: _shift,
+                      onPressed: () => setState(() {
+                        if (_symbols) {
+                          _symbols = false;
+                          _shift = true;
+                        } else {
+                          _shift = !_shift;
+                        }
+                      }),
+                    ),
+                    SizedBox(width: keyGap),
+                    for (var index = 0; index < thirdRow.length; index++) ...[
+                      flexKey(
+                        id: 'text-${thirdRow[index]}-third-$index',
+                        label: _shift && !_symbols
+                            ? thirdRow[index].toUpperCase()
+                            : thirdRow[index],
+                        onPressed: () => _append(thirdRow[index]),
+                      ),
+                      if (index != thirdRow.length - 1) SizedBox(width: keyGap),
+                    ],
+                  ],
+                ),
+                SizedBox(height: keyGap),
+                Row(
+                  children: [
+                    flexKey(
+                      id: 'symbols',
+                      label: _symbols ? 'ABC' : '123?',
+                      semanticLabel: _symbols
+                          ? 'Letters keyboard'
+                          : 'Symbols keyboard',
+                      flex: 14,
+                      fontSize: (17 * scale).clamp(10, 17),
+                      selected: _symbols,
+                      onPressed: () => setState(() {
+                        _symbols = !_symbols;
+                        _shift = false;
+                      }),
+                    ),
+                    SizedBox(width: keyGap),
+                    flexKey(
+                      id: 'cursor-left',
+                      icon: Icons.arrow_left_rounded,
+                      semanticLabel: 'Cursor left',
+                      flex: 9,
+                      onPressed: () => _moveCursor(-1),
+                    ),
+                    SizedBox(width: keyGap),
+                    flexKey(
+                      id: 'cursor-right',
+                      icon: Icons.arrow_right_rounded,
+                      semanticLabel: 'Cursor right',
+                      flex: 9,
+                      onPressed: () => _moveCursor(1),
+                    ),
+                    SizedBox(width: keyGap),
+                    flexKey(
+                      id: 'space',
+                      icon: Icons.space_bar_rounded,
+                      semanticLabel: 'Space',
+                      flex: 44,
+                      onPressed: () => _append(' '),
+                    ),
+                    SizedBox(width: keyGap),
+                    flexKey(
+                      id: 'minus',
+                      label: '-',
+                      flex: 9,
+                      onPressed: () => _append('-'),
+                    ),
+                    SizedBox(width: keyGap),
+                    flexKey(
+                      id: 'underscore',
+                      label: '_',
+                      flex: 9,
+                      onPressed: () => _append('_'),
+                    ),
+                    SizedBox(width: keyGap),
+                    flexKey(
+                      id: 'number-0',
+                      label: '0',
+                      flex: 9,
+                      onPressed: () => _append('0'),
+                    ),
+                  ],
+                ),
+                if (narrow) ...[
+                  SizedBox(height: keyGap),
+                  Row(
+                    children: [
+                      flexKey(
+                        id: 'backspace',
+                        icon: Icons.backspace_outlined,
+                        semanticLabel: 'Backspace',
+                        onPressed: _backspace,
+                      ),
+                      SizedBox(width: keyGap),
+                      flexKey(
+                        id: 'submit',
+                        label: submitLabel,
+                        semanticLabel: submitLabel,
+                        primary: true,
+                        onPressed: () => Navigator.of(context).pop(_value),
+                      ),
+                    ],
+                  ),
+                ],
+              ],
+            ),
+          ),
+          if (!narrow) ...[
+            SizedBox(width: keyGap * 1.5),
+            SizedBox(
+              width: numberPadWidth,
+              child: Column(
+                children: [
+                  numericRow(const ['1', '2', '3']),
+                  SizedBox(height: keyGap),
+                  numericRow(const ['4', '5', '6']),
+                  SizedBox(height: keyGap),
+                  numericRow(const ['7', '8', '9']),
+                  SizedBox(height: keyGap),
+                  Row(
+                    children: [
+                      flexKey(
+                        id: 'backspace',
+                        icon: Icons.backspace_outlined,
+                        semanticLabel: 'Backspace',
+                        onPressed: _backspace,
+                      ),
+                      SizedBox(width: keyGap),
+                      flexKey(
+                        id: 'submit',
+                        label: submitLabel,
+                        semanticLabel: submitLabel,
+                        primary: true,
+                        fontSize: (18 * scale).clamp(11, 18),
+                        onPressed: () => Navigator.of(context).pop(_value),
+                      ),
+                    ],
+                  ),
+                ],
+              ),
+            ),
+          ],
+        ],
+      );
+    }
+
+    Widget numericKeyboard() {
+      return Column(
+        children: [
+          numericRow(const ['1', '2', '3']),
+          SizedBox(height: keyGap),
+          numericRow(const ['4', '5', '6']),
+          SizedBox(height: keyGap),
+          numericRow(const ['7', '8', '9'], autofocusLabel: '7'),
+          SizedBox(height: keyGap),
+          Row(
+            children: [
+              flexKey(
+                id: 'backspace',
+                icon: Icons.backspace_outlined,
+                semanticLabel: 'Backspace',
+                onPressed: _backspace,
+              ),
+              SizedBox(width: keyGap),
+              flexKey(
+                id: 'number-0',
+                label: '0',
+                onPressed: () => _append('0'),
+              ),
+              SizedBox(width: keyGap),
+              flexKey(
+                id: 'clear',
+                label: 'CLEAR',
+                fontSize: (18 * scale).clamp(11, 18),
+                onPressed: _clear,
+              ),
+            ],
+          ),
+          SizedBox(height: keyGap * 1.35),
+          Row(
+            children: [
+              flexKey(
+                id: 'cancel',
+                label: 'CANCEL',
+                height: actionHeight,
+                fontSize: (19 * scale).clamp(12, 19),
+                onPressed: () => Navigator.of(context).pop(),
+              ),
+              SizedBox(width: keyGap * 1.5),
+              flexKey(
+                id: 'submit',
+                label: 'DONE',
+                height: actionHeight,
+                fontSize: (19 * scale).clamp(12, 19),
+                primary: true,
+                onPressed: () => Navigator.of(context).pop(_value),
+              ),
+            ],
+          ),
+        ],
+      );
+    }
+
     return Dialog(
-      alignment: Alignment.bottomCenter,
-      insetPadding: EdgeInsets.fromLTRB(
-        availableWidth < 600 ? 10 : 24,
-        availableWidth < 600 ? 48 : 160,
-        availableWidth < 600 ? 10 : 24,
-        18,
+      alignment: widget.numericOnly ? Alignment.center : Alignment.bottomCenter,
+      insetPadding: EdgeInsets.symmetric(
+        horizontal: horizontalInset,
+        vertical: narrow ? 10 : 12,
       ),
       backgroundColor: Colors.transparent,
       child: Focus(
         canRequestFocus: false,
         onKeyEvent: _handlePhysicalKeyboard,
-        child: Container(
-          key: const ValueKey('tv-keyboard-panel'),
-          width: panelWidth,
-          padding: const EdgeInsets.fromLTRB(9, 7, 9, 8),
-          decoration: BoxDecoration(
-            color: Color.alphaBlend(
-              palette.surface.withValues(alpha: .40),
-              palette.background,
-            ).withValues(alpha: 247 / 255),
-            borderRadius: BorderRadius.circular(12),
-            border: Border.all(color: palette.accent.withValues(alpha: .32)),
-            boxShadow: const [
-              BoxShadow(
-                color: Color(0x88000000),
-                blurRadius: 22,
-                offset: Offset(0, -4),
+        child: SingleChildScrollView(
+          child: Container(
+            key: const ValueKey('tv-keyboard-panel'),
+            width: panelWidth,
+            padding: EdgeInsets.all(panelPadding),
+            decoration: BoxDecoration(
+              color: Color.alphaBlend(
+                palette.surface.withValues(alpha: .58),
+                palette.background,
+              ).withValues(alpha: .97),
+              borderRadius: BorderRadius.circular(20 * scale),
+              border: Border.all(
+                color: palette.accentBright.withValues(alpha: .82),
+                width: 1.5,
               ),
-            ],
-          ),
-          child: Column(
-            mainAxisSize: MainAxisSize.min,
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Row(
-                children: [
-                  Expanded(
-                    child: Text(
-                      widget.title,
-                      style: TextStyle(
-                        color: palette.primaryText,
-                        fontSize: 14,
-                        fontWeight: FontWeight.w800,
-                      ),
-                    ),
-                  ),
-                  Text(
-                    'REMOTE  /  CONTROLLER  /  KEYBOARD',
-                    style: TextStyle(
-                      color: palette.mutedText,
-                      fontSize: 7,
-                      fontWeight: FontWeight.w800,
-                      letterSpacing: .6,
-                    ),
-                  ),
-                ],
-              ),
-              const SizedBox(height: 4),
-              Container(
-                width: double.infinity,
-                height: 30,
-                padding: const EdgeInsets.symmetric(horizontal: 9),
-                alignment: Alignment.centerLeft,
-                decoration: BoxDecoration(
-                  color: palette.background,
-                  borderRadius: BorderRadius.circular(8),
-                  border: Border.all(
-                    color: palette.accentBright.withValues(alpha: .62),
-                  ),
-                ),
-                child: Text(
-                  displayValue.isEmpty ? 'Start typing…' : displayValue,
-                  maxLines: 1,
-                  overflow: TextOverflow.ellipsis,
-                  style: TextStyle(
-                    color: displayValue.isEmpty
-                        ? palette.mutedText
-                        : palette.primaryText,
-                    fontSize: 12,
-                    letterSpacing: widget.obscureText ? 1.4 : 0,
-                  ),
-                ),
-              ),
-              if (widget.autofillSuggestions.isNotEmpty) ...[
-                const SizedBox(height: 4),
-                Row(
-                  children: [
-                    Text(
-                      'AUTOFILL',
-                      style: TextStyle(
-                        color: palette.accentBright,
-                        fontSize: 8,
-                        fontWeight: FontWeight.w900,
-                        letterSpacing: 1.2,
-                      ),
-                    ),
-                    const SizedBox(width: 7),
-                    for (final suggestion in widget.autofillSuggestions.take(
-                      3,
-                    )) ...[
-                      _AutofillChip(
-                        label: suggestion,
-                        icon: Icons.auto_awesome_rounded,
-                        onPressed: () => _autofill(suggestion),
-                      ),
-                    ],
-                  ],
+              boxShadow: [
+                BoxShadow(
+                  color: Colors.black.withValues(alpha: .72),
+                  blurRadius: 28,
+                  offset: const Offset(0, -6),
                 ),
               ],
-              const SizedBox(height: 5),
-              FocusTraversalGroup(
-                policy: ReadingOrderTraversalPolicy(),
-                child: Row(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    if (!widget.numericOnly)
-                      Expanded(
-                        child: Column(
-                          children: [
-                            for (
-                              var rowIndex = 0;
-                              rowIndex < rows.length;
-                              rowIndex++
-                            )
-                              Padding(
-                                padding: EdgeInsets.only(
-                                  left: rowIndex == 1 ? 12 : 0,
-                                  right: rowIndex == 1 ? 12 : 0,
-                                  bottom: 3,
-                                ),
-                                child: Row(
-                                  children: [
-                                    for (
-                                      var keyIndex = 0;
-                                      keyIndex < rows[rowIndex].length;
-                                      keyIndex++
-                                    ) ...[
-                                      Expanded(
-                                        child: _KeyboardKey(
-                                          label: _shift && !_symbols
-                                              ? rows[rowIndex][keyIndex]
-                                                    .toUpperCase()
-                                              : rows[rowIndex][keyIndex],
-                                          autofocus:
-                                              rowIndex == 0 && keyIndex == 0,
-                                          onPressed: () =>
-                                              _append(rows[rowIndex][keyIndex]),
-                                        ),
-                                      ),
-                                      if (keyIndex != rows[rowIndex].length - 1)
-                                        const SizedBox(width: 3),
-                                    ],
-                                  ],
-                                ),
-                              ),
-                            Row(
-                              children: [
-                                _KeyboardAction(
-                                  label: _shift ? 'Aa ON' : 'Aa',
-                                  icon: Icons.arrow_upward_rounded,
-                                  selected: _shift,
-                                  onPressed: () => setState(() {
-                                    if (_symbols) {
-                                      _symbols = false;
-                                      _shift = true;
-                                    } else {
-                                      _shift = !_shift;
-                                    }
-                                  }),
-                                ),
-                                const SizedBox(width: 3),
-                                _KeyboardAction(
-                                  label: _symbols ? 'ABC' : '#?&',
-                                  icon: Icons.alternate_email_rounded,
-                                  flex: 2,
-                                  selected: _symbols,
-                                  onPressed: () => setState(() {
-                                    _symbols = !_symbols;
-                                    _shift = false;
-                                  }),
-                                ),
-                                const SizedBox(width: 3),
-                                _KeyboardAction(
-                                  label: 'SPACE',
-                                  icon: Icons.space_bar_rounded,
-                                  flex: 3,
-                                  onPressed: () => _append(' '),
-                                ),
-                                const SizedBox(width: 3),
-                                _KeyboardAction(
-                                  label: 'DEL',
-                                  icon: Icons.backspace_outlined,
-                                  flex: 2,
-                                  onPressed: _backspace,
-                                ),
-                                const SizedBox(width: 3),
-                                _KeyboardAction(
-                                  label: 'PASTE',
-                                  icon: Icons.content_paste_rounded,
-                                  flex: 2,
-                                  onPressed: _paste,
-                                ),
-                                if (widget.obscureText) ...[
-                                  const SizedBox(width: 3),
-                                  _KeyboardAction(
-                                    label: _reveal ? 'HIDE' : 'SHOW',
-                                    icon: _reveal
-                                        ? Icons.visibility_off_rounded
-                                        : Icons.visibility_rounded,
-                                    flex: 2,
-                                    onPressed: () =>
-                                        setState(() => _reveal = !_reveal),
-                                  ),
-                                ],
-                                const SizedBox(width: 3),
-                                _KeyboardAction(
-                                  label: 'DONE',
-                                  icon: Icons.search_rounded,
-                                  flex: 2,
-                                  primary: true,
-                                  onPressed: () =>
-                                      Navigator.of(context).pop(_value),
-                                ),
-                              ],
-                            ),
-                          ],
+            ),
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                if (narrow)
+                  Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        widget.title,
+                        maxLines: 2,
+                        overflow: TextOverflow.ellipsis,
+                        style: TextStyle(
+                          color: palette.primaryText,
+                          fontSize: titleSize,
+                          fontWeight: FontWeight.w800,
+                          height: 1.08,
                         ),
                       ),
-                    if (!widget.numericOnly) const SizedBox(width: 8),
-                    SizedBox(
-                      width: widget.numericOnly ? panelWidth - 20 : 110,
-                      child: Column(
-                        children: [
-                          for (final numberRow in _numberRows)
-                            Padding(
-                              padding: const EdgeInsets.only(bottom: 3),
-                              child: Row(
-                                children: [
-                                  for (
-                                    var index = 0;
-                                    index < numberRow.length;
-                                    index++
-                                  ) ...[
-                                    Expanded(
-                                      child: _KeyboardKey(
-                                        label: numberRow[index],
-                                        autofocus:
-                                            widget.numericOnly &&
-                                            numberRow.first == '7' &&
-                                            index == 0,
-                                        onPressed: () =>
-                                            _append(numberRow[index]),
-                                      ),
-                                    ),
-                                    if (index != numberRow.length - 1)
-                                      const SizedBox(width: 3),
-                                  ],
-                                ],
-                              ),
+                      SizedBox(height: 7 * scale),
+                      Align(
+                        alignment: Alignment.centerRight,
+                        child: FittedBox(
+                          fit: BoxFit.scaleDown,
+                          child: Text(
+                            'REMOTE  /  CONTROLLER  /  KEYBOARD',
+                            key: const ValueKey('tv-keyboard-input-modes'),
+                            style: TextStyle(
+                              color: palette.primaryText.withValues(alpha: .90),
+                              fontSize: (16 * scale).clamp(8, 16),
+                              fontWeight: FontWeight.w800,
+                              letterSpacing: .35,
                             ),
-                          Row(
-                            children: [
-                              Expanded(
-                                child: _KeyboardKey(
-                                  label: '0',
-                                  onPressed: () => _append('0'),
-                                ),
-                              ),
-                              const SizedBox(width: 3),
-                              Expanded(
-                                child: _KeyboardKey(
-                                  label: 'BACKSPACE',
-                                  compactLabel: true,
-                                  onPressed: _backspace,
-                                ),
-                              ),
-                              const SizedBox(width: 3),
-                              Expanded(
-                                child: _KeyboardKey(
-                                  label: 'CLEAR',
-                                  compactLabel: true,
-                                  onPressed: () => setState(() => _value = ''),
-                                ),
-                              ),
-                            ],
                           ),
-                          if (widget.numericOnly) ...[
-                            const SizedBox(height: 3),
-                            Row(
-                              children: [
-                                Expanded(
-                                  child: _KeyboardKey(
-                                    label: 'CANCEL',
-                                    compactLabel: true,
-                                    onPressed: () =>
-                                        Navigator.of(context).pop(),
-                                  ),
-                                ),
-                                const SizedBox(width: 3),
-                                Expanded(
-                                  child: _KeyboardKey(
-                                    label: 'DONE',
-                                    compactLabel: true,
-                                    onPressed: () =>
-                                        Navigator.of(context).pop(_value),
-                                  ),
-                                ),
-                              ],
-                            ),
-                          ],
-                        ],
+                        ),
                       ),
+                    ],
+                  )
+                else
+                  Row(
+                    children: [
+                      Expanded(
+                        child: Text(
+                          widget.title,
+                          maxLines: widget.numericOnly ? 2 : 1,
+                          overflow: TextOverflow.ellipsis,
+                          style: TextStyle(
+                            color: palette.primaryText,
+                            fontSize: titleSize,
+                            fontWeight: FontWeight.w800,
+                            height: 1.08,
+                          ),
+                        ),
+                      ),
+                      SizedBox(width: 18 * scale),
+                      Text(
+                        'REMOTE  /  CONTROLLER  /  KEYBOARD',
+                        key: const ValueKey('tv-keyboard-input-modes'),
+                        style: TextStyle(
+                          color: palette.primaryText.withValues(alpha: .90),
+                          fontSize: (16 * scale).clamp(8, 16),
+                          fontWeight: FontWeight.w800,
+                          letterSpacing: .35,
+                        ),
+                      ),
+                    ],
+                  ),
+                SizedBox(height: 14 * scale),
+                Container(
+                  key: const ValueKey('tv-keyboard-input'),
+                  width: double.infinity,
+                  height: inputHeight,
+                  padding: EdgeInsets.symmetric(horizontal: 18 * scale),
+                  alignment: Alignment.centerLeft,
+                  decoration: BoxDecoration(
+                    color: Colors.black.withValues(alpha: .58),
+                    borderRadius: BorderRadius.circular(18 * scale),
+                    border: Border.all(
+                      color: palette.accentBright.withValues(alpha: .88),
+                      width: 1.8,
                     ),
-                  ],
+                  ),
+                  child: Row(
+                    children: [
+                      Expanded(
+                        child: Text(
+                          displayValue.isEmpty ? 'Start typing…' : displayValue,
+                          maxLines: 1,
+                          overflow: TextOverflow.ellipsis,
+                          style: TextStyle(
+                            color: displayValue.isEmpty
+                                ? palette.mutedText
+                                : palette.primaryText,
+                            fontSize: inputFontSize,
+                            letterSpacing: widget.obscureText ? 1.4 : 0,
+                          ),
+                        ),
+                      ),
+                      if (widget.obscureText) ...[
+                        SizedBox(width: 8 * scale),
+                        SizedBox(
+                          width: inputHeight * .72,
+                          child: keyboardKey(
+                            id: 'reveal',
+                            icon: _reveal
+                                ? Icons.visibility_off_rounded
+                                : Icons.visibility_rounded,
+                            semanticLabel: _reveal
+                                ? 'Hide entered text'
+                                : 'Show entered text',
+                            height: inputHeight * .68,
+                            onPressed: () => setState(() => _reveal = !_reveal),
+                          ),
+                        ),
+                      ],
+                    ],
+                  ),
                 ),
-              ),
-            ],
+                if (widget.autofillSuggestions.isNotEmpty) ...[
+                  SizedBox(height: 8 * scale),
+                  Row(
+                    children: [
+                      Text(
+                        'AUTOFILL',
+                        style: TextStyle(
+                          color: palette.accentBright,
+                          fontSize: (12 * scale).clamp(8, 12),
+                          fontWeight: FontWeight.w900,
+                          letterSpacing: 1.2,
+                        ),
+                      ),
+                      const SizedBox(width: 7),
+                      for (final suggestion in widget.autofillSuggestions.take(
+                        3,
+                      )) ...[
+                        _AutofillChip(
+                          label: suggestion,
+                          icon: Icons.auto_awesome_rounded,
+                          onPressed: () => _autofill(suggestion),
+                        ),
+                      ],
+                    ],
+                  ),
+                ],
+                SizedBox(height: 16 * scale),
+                FocusTraversalGroup(
+                  policy: ReadingOrderTraversalPolicy(),
+                  child: widget.numericOnly
+                      ? numericKeyboard()
+                      : qwertyKeyboard(),
+                ),
+              ],
+            ),
           ),
         ),
       ),
@@ -1034,105 +1311,80 @@ class _TvKeyboardDialogState extends State<TvKeyboardDialog> {
 
 class _KeyboardKey extends StatelessWidget {
   const _KeyboardKey({
-    required this.label,
     required this.onPressed,
+    required this.height,
+    required this.fontSize,
+    required this.semanticLabel,
+    this.label,
+    this.icon,
     this.autofocus = false,
-    this.compactLabel = false,
-  });
-
-  final String label;
-  final VoidCallback onPressed;
-  final bool autofocus;
-  final bool compactLabel;
-
-  @override
-  Widget build(BuildContext context) {
-    return TvFocusable(
-      autofocus: autofocus,
-      focusScale: 1.04,
-      borderRadius: BorderRadius.circular(8),
-      onPressed: onPressed,
-      child: Container(
-        height: 26,
-        alignment: Alignment.center,
-        color: context.appPalette.selectableSurface,
-        child: Text(
-          label,
-          style: TextStyle(
-            fontSize: compactLabel ? 6 : 11,
-            fontWeight: FontWeight.w800,
-          ),
-        ),
-      ),
-    );
-  }
-}
-
-class _KeyboardAction extends StatelessWidget {
-  const _KeyboardAction({
-    required this.label,
-    required this.icon,
-    required this.onPressed,
-    this.flex = 1,
     this.primary = false,
     this.selected = false,
+    super.key,
   });
 
-  final String label;
-  final IconData icon;
+  final String? label;
+  final IconData? icon;
+  final String semanticLabel;
   final VoidCallback onPressed;
-  final int flex;
+  final double height;
+  final double fontSize;
+  final bool autofocus;
   final bool primary;
   final bool selected;
 
   @override
   Widget build(BuildContext context) {
-    return Flexible(
-      flex: flex,
+    final palette = context.appPalette;
+    final radius = BorderRadius.circular((height * .18).clamp(7, 12));
+    final keyColor = primary
+        ? palette.accent
+        : selected
+        ? Color.alphaBlend(
+            palette.accent.withValues(alpha: .42),
+            palette.surfaceRaised,
+          )
+        : Color.alphaBlend(
+            Colors.white.withValues(alpha: .075),
+            palette.surface,
+          );
+    return Semantics(
+      label: semanticLabel,
+      button: true,
+      excludeSemantics: true,
       child: TvFocusable(
+        autofocus: autofocus,
         focusScale: 1.025,
-        borderRadius: BorderRadius.circular(8),
+        borderRadius: radius,
         onPressed: onPressed,
         child: Container(
-          height: 26,
-          padding: const EdgeInsets.symmetric(horizontal: 5),
-          color: primary
-              ? context.appPalette.accent
-              : selected
-              ? context.appPalette.accent.withValues(alpha: .45)
-              : context.appPalette.selectableSurface,
-          child: LayoutBuilder(
-            builder: (context, constraints) {
-              if (constraints.maxWidth < 28) {
-                return Center(
-                  child: Icon(
-                    icon,
-                    size: constraints.maxWidth.clamp(7, 11).toDouble(),
-                  ),
-                );
-              }
-              return Row(
-                mainAxisAlignment: MainAxisAlignment.center,
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  const SizedBox(width: 1),
-                  Icon(icon, size: 11),
-                  const SizedBox(width: 3),
-                  Flexible(
-                    child: Text(
-                      label,
-                      overflow: TextOverflow.ellipsis,
-                      style: const TextStyle(
-                        fontSize: 7,
-                        fontWeight: FontWeight.w900,
-                      ),
-                    ),
-                  ),
-                  const SizedBox(width: 1),
-                ],
-              );
-            },
+          height: height,
+          alignment: Alignment.center,
+          decoration: BoxDecoration(
+            color: keyColor,
+            borderRadius: radius,
+            border: Border.all(
+              color: primary
+                  ? palette.accentBright.withValues(alpha: .34)
+                  : palette.primaryText.withValues(alpha: .07),
+            ),
           ),
+          child: icon != null
+              ? Icon(
+                  icon,
+                  size: (fontSize * 1.35).clamp(16, 30),
+                  color: palette.primaryText,
+                )
+              : Text(
+                  label ?? '',
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                  style: TextStyle(
+                    color: palette.primaryText,
+                    fontSize: fontSize,
+                    fontWeight: FontWeight.w700,
+                  ),
+                ),
         ),
       ),
     );

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: 'none'
 # Public and Beta artifacts built from the same source use one monotonically
 # increasing Android versionCode. The project default carries the Beta display
 # version; the Public universal APK overrides the build name to the 1.x line.
-version: 2.0.58+410035
+version: 2.0.59+410036
 
 environment:
   sdk: ^3.12.2

--- a/test/home_header_search_test.dart
+++ b/test/home_header_search_test.dart
@@ -74,7 +74,9 @@ void main() {
           for (final letter in const ['f', 'r', 'i', 'e', 'r', 'e', 'n']) {
             await tester.tap(find.text(letter));
           }
-          await tester.tap(find.text('DONE'));
+          await tester.tap(
+            find.byKey(const ValueKey('tv-keyboard-key-submit')),
+          );
         } else {
           final field = find.byType(TextField);
           expect(field, findsOneWidget);

--- a/test/search_screen_test.dart
+++ b/test/search_screen_test.dart
@@ -45,11 +45,13 @@ void main() {
 
     await tester.tap(find.byType(TvTextInput));
     await tester.pump(const Duration(milliseconds: 300));
-    await tester.tap(find.text('CLEAR'));
+    for (var index = 0; index < 'old'.length; index++) {
+      await tester.tap(find.byKey(const ValueKey('tv-keyboard-key-backspace')));
+    }
     await tester.tap(find.text('n'));
     await tester.tap(find.text('e'));
     await tester.tap(find.text('w'));
-    await tester.tap(find.text('DONE'));
+    await tester.tap(find.byKey(const ValueKey('tv-keyboard-key-submit')));
     await tester.pump();
     expect(client.requests, contains('new'));
 
@@ -129,7 +131,7 @@ void main() {
     await tester.tap(find.text('c'));
     await tester.tap(find.text('o'));
     await tester.tap(find.text('w'));
-    await tester.tap(find.text('DONE'));
+    await tester.tap(find.byKey(const ValueKey('tv-keyboard-key-submit')));
     await tester.pump();
     client.complete('cow', [_anime(11, 'Cowboy Bebop')]);
     await tester.pump();
@@ -209,7 +211,7 @@ void main() {
       await tester.tap(find.text('c'));
       await tester.tap(find.text('o'));
       await tester.tap(find.text('w'));
-      await tester.tap(find.text('DONE'));
+      await tester.tap(find.byKey(const ValueKey('tv-keyboard-key-submit')));
       await tester.pump();
       client.complete('cow', [
         _anime(11, 'Cowboy Bebop'),

--- a/test/setup_pairing_theme_palette_test.dart
+++ b/test/setup_pairing_theme_palette_test.dart
@@ -104,9 +104,17 @@ void main() {
     final panelDecoration = panel.decoration! as BoxDecoration;
     expect(
       panelDecoration.border!.top.color,
-      _customPalette.accent.withValues(alpha: .32),
+      _customPalette.accentBright.withValues(alpha: .82),
     );
-    expect(_paintedColors(tester), contains(_customPalette.selectableSurface));
+    expect(
+      _paintedColors(tester),
+      contains(
+        Color.alphaBlend(
+          Colors.white.withValues(alpha: .075),
+          _customPalette.surface,
+        ),
+      ),
+    );
     expect(tester.takeException(), isNull);
   });
 }

--- a/test/tv_text_input_test.dart
+++ b/test/tv_text_input_test.dart
@@ -5,14 +5,20 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 
+Finder _keyboardText(String value) => find.descendant(
+  of: find.byType(TvKeyboardDialog),
+  matching: find.text(value),
+);
+
 void main() {
-  testWidgets('opens an app-owned keyboard without an EditableText', (
+  testWidgets('search keyboard exposes the TV QWERTY and number-pad layout', (
     tester,
   ) async {
     FlutterSecureStorage.setMockInitialValues({
       'input_use_built_in_keyboard': 'true',
     });
     final controller = TextEditingController();
+    String? submitted;
     addTearDown(controller.dispose);
 
     await tester.pumpWidget(
@@ -22,7 +28,12 @@ void main() {
             body: Center(
               child: SizedBox(
                 width: 500,
-                child: TvTextInput(controller: controller, labelText: 'Search'),
+                child: TvTextInput(
+                  controller: controller,
+                  labelText: 'Search',
+                  keyboardTitle: 'Search anime',
+                  onSubmitted: (value) => submitted = value,
+                ),
               ),
             ),
           ),
@@ -36,15 +47,89 @@ void main() {
 
     expect(find.byType(TvKeyboardDialog), findsOneWidget);
     expect(find.byType(EditableText), findsNothing);
-    expect(find.text('PASTE'), findsOneWidget);
-    expect(find.text('DONE'), findsOneWidget);
-    final keyboardSize = tester.getSize(
-      find.byKey(const ValueKey('tv-keyboard-panel')),
+    expect(_keyboardText('Search anime'), findsOneWidget);
+    expect(_keyboardText('REMOTE  /  CONTROLLER  /  KEYBOARD'), findsOneWidget);
+    expect(_keyboardText('Start typing…'), findsOneWidget);
+
+    for (final key in const [
+      'q',
+      'w',
+      'e',
+      'r',
+      't',
+      'y',
+      'u',
+      'i',
+      'o',
+      'p',
+      'a',
+      's',
+      'd',
+      'f',
+      'g',
+      'h',
+      'j',
+      'k',
+      'l',
+      'z',
+      'x',
+      'c',
+      'v',
+      'b',
+      'n',
+      'm',
+      '1',
+      '2',
+      '3',
+      '4',
+      '5',
+      '6',
+      '7',
+      '8',
+      '9',
+      '123?',
+      '-',
+      '_',
+      '0',
+      'Search',
+    ]) {
+      expect(
+        _keyboardText(key),
+        findsOneWidget,
+        reason: 'missing keyboard key $key',
+      );
+    }
+    expect(find.bySemanticsLabel('Cursor left'), findsOneWidget);
+    expect(find.bySemanticsLabel('Cursor right'), findsOneWidget);
+    expect(find.bySemanticsLabel('Space'), findsOneWidget);
+    expect(find.bySemanticsLabel('Backspace'), findsOneWidget);
+
+    // The right-side number pad keeps conventional ascending rows and stays
+    // to the right of the QWERTY keys without pinning the test to pixels.
+    expect(
+      tester.getCenter(_keyboardText('1')).dx,
+      greaterThan(tester.getCenter(_keyboardText('p')).dx),
     );
-    expect(keyboardSize.width, inInclusiveRange(540, 560));
-    expect(keyboardSize.height, lessThan(250));
-    expect(find.text('7'), findsOneWidget);
-    expect(find.text('#?&'), findsOneWidget);
+    expect(
+      tester.getCenter(_keyboardText('1')).dy,
+      lessThan(tester.getCenter(_keyboardText('4')).dy),
+    );
+    expect(
+      tester.getCenter(_keyboardText('4')).dy,
+      lessThan(tester.getCenter(_keyboardText('7')).dy),
+    );
+
+    await tester.tap(_keyboardText('q'));
+    await tester.tap(_keyboardText('1'));
+    await tester.tap(_keyboardText('-'));
+    await tester.tap(_keyboardText('_'));
+    await tester.tap(_keyboardText('0'));
+    await tester.tap(find.bySemanticsLabel('Backspace'));
+    await tester.tap(_keyboardText('Search'));
+    await tester.pumpAndSettle();
+
+    expect(controller.text, 'q1-_');
+    expect(submitted, 'q1-_');
   });
 
   testWidgets('physical Enter commits the TV keyboard value', (tester) async {
@@ -112,22 +197,61 @@ void main() {
     await tester.tap(find.text('Room code'));
     await tester.pumpAndSettle();
     expect(find.byType(TvKeyboardDialog), findsOneWidget);
-    expect(find.text('q'), findsNothing);
-    expect(find.text('#?&'), findsNothing);
-    final keyboardSize = tester.getSize(
-      find.byKey(const ValueKey('tv-keyboard-panel')),
+    expect(_keyboardText('Room code'), findsOneWidget);
+    expect(_keyboardText('REMOTE  /  CONTROLLER  /  KEYBOARD'), findsOneWidget);
+    expect(_keyboardText('Start typing…'), findsOneWidget);
+    expect(_keyboardText('q'), findsNothing);
+    expect(_keyboardText('123?'), findsNothing);
+    for (final key in const [
+      '1',
+      '2',
+      '3',
+      '4',
+      '5',
+      '6',
+      '7',
+      '8',
+      '9',
+      '0',
+      'CLEAR',
+      'CANCEL',
+      'DONE',
+    ]) {
+      expect(
+        _keyboardText(key),
+        findsOneWidget,
+        reason: 'missing numeric key $key',
+      );
+    }
+    expect(find.bySemanticsLabel('Backspace'), findsOneWidget);
+
+    // The room-code pad reads naturally from 1 through 9.
+    expect(
+      tester.getCenter(_keyboardText('1')).dx,
+      lessThan(tester.getCenter(_keyboardText('2')).dx),
     );
-    expect(keyboardSize.width, lessThanOrEqualTo(320));
+    expect(
+      tester.getCenter(_keyboardText('2')).dx,
+      lessThan(tester.getCenter(_keyboardText('3')).dx),
+    );
+    expect(
+      tester.getCenter(_keyboardText('1')).dy,
+      lessThan(tester.getCenter(_keyboardText('4')).dy),
+    );
+    expect(
+      tester.getCenter(_keyboardText('4')).dy,
+      lessThan(tester.getCenter(_keyboardText('7')).dy),
+    );
 
     for (final key in const ['2', '0', '9', '1', '8']) {
-      await tester.tap(find.text(key));
+      await tester.tap(_keyboardText(key));
       await tester.pump();
     }
-    await tester.tap(find.text('BACKSPACE'));
+    await tester.tap(find.bySemanticsLabel('Backspace'));
     await tester.pump();
-    await tester.tap(find.text('8'));
+    await tester.tap(_keyboardText('8'));
     await tester.pump();
-    await tester.tap(find.text('DONE'));
+    await tester.tap(_keyboardText('DONE'));
     await tester.pumpAndSettle();
     expect(controller.text, '298');
   });

--- a/tool/release/native_playback_manifest.json
+++ b/tool/release/native_playback_manifest.json
@@ -375,10 +375,10 @@
     {
       "path": "lib/arm64-v8a/libapp.so",
       "size": 12387216,
-      "sha256": "bb7fa25497da5d85672b4927de379fa5c5673975355c745568ccb0ce103750b3",
-      "origin": "TetoTV Flutter application AOT 2.0.58",
+      "sha256": "10fc392ef713125640bac13eab37aa17976fe274ae9525938e440932c5abd21f",
+      "origin": "TetoTV Flutter application AOT 2.0.59",
       "license": "MIT",
-      "sourceLocator": "Git tag v2.0.58",
+      "sourceLocator": "Git tag v2.0.59",
       "noticeLocator": "LICENSE"
     },
     {
@@ -423,7 +423,7 @@
       "sha256": "dc05f53278b2733094f12aeaed54c080329309762ce49e6de4118e4bfb0fff55",
       "origin": "TetoTV source build of media-kit Android helper at 42054e5d479f39ccbb0ae604862e2bcaf59b74c2",
       "license": "MIT",
-      "sourceLocator": "TetoTV-v2.0.58-native-playback-sources.zip: sources/media-kit-android-helper-42054e5d479f39ccbb0ae604862e2bcaf59b74c2.zip",
+      "sourceLocator": "TetoTV-v2.0.59-native-playback-sources.zip: sources/media-kit-android-helper-42054e5d479f39ccbb0ae604862e2bcaf59b74c2.zip",
       "noticeLocator": "assets/legal/native/MEDIA_KIT_ANDROID_HELPER_LICENSE.txt; assets/legal/native/NATIVE_PLAYBACK_NOTICE.txt"
     },
     {
@@ -432,7 +432,7 @@
       "sha256": "a7399d0be70844e5ee94cc5b1acc1516571113c50561fe0a5d05b49101c53ef2",
       "origin": "TetoTV source build of the pinned mpv and FFmpeg native playback stack",
       "license": "LGPL-3.0-or-later (conservative combined classification) plus component terms",
-      "sourceLocator": "TetoTV-v2.0.58-native-playback-sources.zip and tool/native/build_native_playback.sh",
+      "sourceLocator": "TetoTV-v2.0.59-native-playback-sources.zip and tool/native/build_native_playback.sh",
       "noticeLocator": "assets/legal/native/NATIVE_PLAYBACK_NOTICE.txt and its referenced exact license assets"
     },
     {
@@ -450,16 +450,16 @@
       "sha256": "263ba714570fb3acfc308cce52776b00506ec8809d225617e52352336144cfa2",
       "origin": "TetoTV source build of the pinned libtorrent4j and libtorrent-rasterbar stack",
       "license": "Mixed MIT, BSD, Boost-1.0, Apache-2.0, and MPL-2.0 component terms",
-      "sourceLocator": "TetoTV-v2.0.58-native-playback-sources.zip and tool/native/build_native_playback.sh",
+      "sourceLocator": "TetoTV-v2.0.59-native-playback-sources.zip and tool/native/build_native_playback.sh",
       "noticeLocator": "assets/legal/native/DIRECT_TORRENT_NATIVE_NOTICE.txt and its referenced exact license assets"
     },
     {
       "path": "lib/armeabi-v7a/libapp.so",
-      "size": 13501004,
-      "sha256": "4482d7bc3ed3a9ea3075425d0a01229a45b75dd05b41948180740c9acb32bd48",
-      "origin": "TetoTV Flutter application AOT 2.0.58",
+      "size": 13533772,
+      "sha256": "740b33c168544645b063cbb76b669d154897a3dc20bbdc52d378e2336aa7852d",
+      "origin": "TetoTV Flutter application AOT 2.0.59",
       "license": "MIT",
-      "sourceLocator": "Git tag v2.0.58",
+      "sourceLocator": "Git tag v2.0.59",
       "noticeLocator": "LICENSE"
     },
     {
@@ -504,7 +504,7 @@
       "sha256": "8820a12e07bb3dc45f5b4286acf6918827fba4c265767e7f1cc8f07215c84b6a",
       "origin": "TetoTV source build of media-kit Android helper at 42054e5d479f39ccbb0ae604862e2bcaf59b74c2",
       "license": "MIT",
-      "sourceLocator": "TetoTV-v2.0.58-native-playback-sources.zip: sources/media-kit-android-helper-42054e5d479f39ccbb0ae604862e2bcaf59b74c2.zip",
+      "sourceLocator": "TetoTV-v2.0.59-native-playback-sources.zip: sources/media-kit-android-helper-42054e5d479f39ccbb0ae604862e2bcaf59b74c2.zip",
       "noticeLocator": "assets/legal/native/MEDIA_KIT_ANDROID_HELPER_LICENSE.txt; assets/legal/native/NATIVE_PLAYBACK_NOTICE.txt"
     },
     {
@@ -513,7 +513,7 @@
       "sha256": "d5a220fdf41edde10f161f86addc846ae9cb18137ea48e4db541cd703fec5092",
       "origin": "TetoTV source build of the pinned mpv and FFmpeg native playback stack",
       "license": "LGPL-3.0-or-later (conservative combined classification) plus component terms",
-      "sourceLocator": "TetoTV-v2.0.58-native-playback-sources.zip and tool/native/build_native_playback.sh",
+      "sourceLocator": "TetoTV-v2.0.59-native-playback-sources.zip and tool/native/build_native_playback.sh",
       "noticeLocator": "assets/legal/native/NATIVE_PLAYBACK_NOTICE.txt and its referenced exact license assets"
     },
     {
@@ -531,7 +531,7 @@
       "sha256": "ba0a19d2730969b8e6107db1847888ea8d3b8cafd14a535a3259dd04f8b28d60",
       "origin": "TetoTV source build of the pinned libtorrent4j and libtorrent-rasterbar stack",
       "license": "Mixed MIT, BSD, Boost-1.0, Apache-2.0, and MPL-2.0 component terms",
-      "sourceLocator": "TetoTV-v2.0.58-native-playback-sources.zip and tool/native/build_native_playback.sh",
+      "sourceLocator": "TetoTV-v2.0.59-native-playback-sources.zip and tool/native/build_native_playback.sh",
       "noticeLocator": "assets/legal/native/DIRECT_TORRENT_NATIVE_NOTICE.txt and its referenced exact license assets"
     }
   ],


### PR DESCRIPTION
## Summary
- refresh the built-in TV QWERTY/search keyboard to match the supplied controller-first layout
- refresh the Watch Party room-code keypad with dedicated Backspace, Clear, Cancel, and Done actions
- preserve and reverify the release-history picker, cross-provider Watch Party avatars, notification typography, and square profile styling shipped in the current Beta line
- prepare and document Beta 2.0.59 (Android build 410036)

## Validation
- flutter analyze: passed
- flutter test: 1,957 passed, 17 intentional skips
- responsive keyboard QA: passed at TV, phone, portrait, and landscape sizes
- release APK/native payload verification: passed