### PR TITLE
Fix runtime regressions and prepare Beta 2.0.60

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 
 <p align="center">
   <a href="https://github.com/LindersOSX/TetoTV-Beta/releases/latest"><strong>Download Beta</strong></a>
-  · <a href="docs/RELEASE_NOTES_2.0.59.md">What's new</a>
+  · <a href="docs/RELEASE_NOTES_2.0.60.md">What's new</a>
   · <a href="https://github.com/LindersOSX/TetoTV-Beta/issues/new">Report an issue</a>
   · <a href="https://discord.gg/juC6k7d4WY">Discord</a>
   · <a href="https://www.youtube.com/@TetoTVApp">YouTube</a>
@@ -94,10 +94,10 @@ TetoTV runs directly on the Android device with no companion server required for
 | Channel | Version | Best for |
 | --- | --- | --- |
 | Public | Not published | Source and release-readiness documents are available, but no Public APK is currently offered |
-| Beta | [2.0.59](docs/RELEASE_NOTES_2.0.59.md) | Controller-first built-in QWERTY and numeric keyboards |
+| Beta | [2.0.60](docs/RELEASE_NOTES_2.0.60.md) | Runtime fixes and compact controller keyboards |
 
 > [!WARNING]
-> Beta 2.0.59 uses the repository's explicit unreviewed-Beta exception. Its native-library and corresponding-source material did not receive independent license review, and automated integrity checks are not a legal compliance determination. Read the [complete Beta disclosure](docs/RELEASE_NOTES_2.0.59.md). This exception does not apply to a future Public release.
+> Beta 2.0.60 uses the repository's explicit unreviewed-Beta exception. Its native-library and corresponding-source material did not receive independent license review, and automated integrity checks are not a legal compliance determination. Read the [complete Beta disclosure](docs/RELEASE_NOTES_2.0.60.md). This exception does not apply to a future Public release.
 
 The Public updater repository intentionally has no release while the Public build is held for review. Existing Beta installations continue to update from the Beta repository. Android never permits an in-place install of an APK with a lower build code; Developer Mode does not bypass that platform rule.
 

--- a/docs/BUILD_WINDOWS.md
+++ b/docs/BUILD_WINDOWS.md
@@ -220,39 +220,39 @@ APK containing both supported application ABIs.
 Public and Beta updates use anonymous GitHub requests. No Beta key, GitHub
 token, update-proxy URL, or update-specific Dart define is required. Every
 published APK uses the production signing identity. No Public APK is currently
-published. Beta 2.0.59 uses Android build code `410036`. Flutter reuses
+published. Beta 2.0.60 uses Android build code `410037`. Flutter reuses
 `app-release.apk`, so copy and rename the Beta artifact immediately after the
 build:
 
 ```powershell
-New-Item -ItemType Directory -Force .\build\fire-tv\v2.0.59 | Out-Null
+New-Item -ItemType Directory -Force .\build\fire-tv\v2.0.60 | Out-Null
 
-# Beta 2.0.59
+# Beta 2.0.60
 flutter build apk --release --target-platform android-arm,android-arm64 `
-  --build-name 2.0.59 --build-number 410036 --no-tree-shake-icons
+  --build-name 2.0.60 --build-number 410037 --no-tree-shake-icons
 Copy-Item .\build\app\outputs\flutter-apk\app-release.apk `
-  .\build\fire-tv\v2.0.59\TetoTV-v2.0.59-universal.apk
+  .\build\fire-tv\v2.0.60\TetoTV-v2.0.60-universal.apk
 
 .\tool\release\verify_release_apk.ps1 `
   -Channel Beta `
-  -ApkPath .\build\fire-tv\v2.0.59\TetoTV-v2.0.59-universal.apk
+  -ApkPath .\build\fire-tv\v2.0.60\TetoTV-v2.0.60-universal.apk
 
 .\tool\release\verify_native_redistribution.ps1 `
   -RequireResolvedBinaries `
   -ResolvedBinaryDirectory .\build\native-playback\outputs `
-  -StageBundle -ReleaseTag v2.0.59
+  -StageBundle -ReleaseTag v2.0.60
 
 .\tool\release\new_release_checksums.ps1 `
-  -ApkPath .\build\fire-tv\v2.0.59\TetoTV-v2.0.59-universal.apk `
-  -NativeSourcePath .\build\release-compliance\v2.0.59\TetoTV-v2.0.59-native-playback-sources.zip `
-  -OutputPath .\build\fire-tv\v2.0.59\SHA256SUMS
+  -ApkPath .\build\fire-tv\v2.0.60\TetoTV-v2.0.60-universal.apk `
+  -NativeSourcePath .\build\release-compliance\v2.0.60\TetoTV-v2.0.60-native-playback-sources.zip `
+  -OutputPath .\build\fire-tv\v2.0.60\SHA256SUMS
 
 .\tool\release\verify_release_payloads.ps1 `
   -Channel Beta `
-  -ApkPath .\build\fire-tv\v2.0.59\TetoTV-v2.0.59-universal.apk `
-  -NativeSourcePath .\build\release-compliance\v2.0.59\TetoTV-v2.0.59-native-playback-sources.zip `
-  -ChecksumsPath .\build\fire-tv\v2.0.59\SHA256SUMS `
-  -ReleaseNotesPath .\docs\RELEASE_NOTES_2.0.59.md
+  -ApkPath .\build\fire-tv\v2.0.60\TetoTV-v2.0.60-universal.apk `
+  -NativeSourcePath .\build\release-compliance\v2.0.60\TetoTV-v2.0.60-native-playback-sources.zip `
+  -ChecksumsPath .\build\fire-tv\v2.0.60\SHA256SUMS `
+  -ReleaseNotesPath .\docs\RELEASE_NOTES_2.0.60.md
 ```
 
 The final payload check requires all five exact, source-built native JARs

--- a/docs/RELEASE_NOTES_2.0.60.md
+++ b/docs/RELEASE_NOTES_2.0.60.md
@@ -1,0 +1,29 @@
+# TetoTV 2.0.60 Beta
+
+> [!WARNING]
+> No independent native-license review: This Beta has not received independent native-library licensing review. Automated checks verify the APK, native-source bundle, notices, pinned inputs, and checksums, but do not establish legal compliance or reproducible builds.
+
+This Beta fixes several runtime issues reported after 2.0.59 and restores the refreshed controller keyboards to a compact lower-screen footprint.
+
+## What's changed
+
+- Developer release history now ignores non-installable companion release tags so the downgrade picker can open normally.
+- Watch Party public identities stay synchronized at provider scope, allowing AniList and MyAnimeList participants to share profile pictures throughout the lobby flow.
+- Watch Party notifications now use TetoTV's shared typography and consistent square avatar styling.
+- Profile trigger and avatar outlines now use matching rounded-square geometry.
+- The refreshed QWERTY and numeric controller keyboards keep their new layouts while using the compact lower-screen height of the original keyboard.
+- AI-assisted development disclosure: AI tools assisted with implementation, documentation, tests, and review. The project owner directed the work, validated the changes, and remains responsible for this release.
+
+## Release assets
+
+- `TetoTV-v2.0.60-universal.apk`
+- `TetoTV-v2.0.60-native-playback-sources.zip`
+- `SHA256SUMS`
+
+## Beta notes
+
+- This is a Beta-channel build with Android build code `410037`.
+- No Public APK is being published with this release.
+- Android does not permit an in-place install over an APK with a higher build code. A future Public counterpart must use build code `410037` or newer for data-preserving channel switching.
+
+<!-- tetotv-android-version-code: 410037 -->

--- a/docs/UPDATE_CHANNELS.md
+++ b/docs/UPDATE_CHANNELS.md
@@ -35,11 +35,11 @@ Beta reads completed 2.x releases from:
 https://api.github.com/repos/LindersOSX/TetoTV-Beta/releases/latest
 ```
 
-The current Beta source build is `v2.0.59` with Android build code `410036`.
+The current Beta source build is `v2.0.60` with Android build code `410037`.
 Its release title is:
 
 ```text
-TetoTV 2.0.59 Beta - Android TV / Google TV / Fire TV
+TetoTV 2.0.60 Beta - Android TV / Google TV / Fire TV
 ```
 
 Publish it as a normal, non-draft, non-prerelease GitHub release so
@@ -72,7 +72,7 @@ proxy.
 Release notes must include the exact asset names and this build-code marker:
 
 ```html
-<!-- tetotv-android-version-code: 410036 -->
+<!-- tetotv-android-version-code: 410037 -->
 ```
 
 When build-code metadata is present, the updater rejects a known lower build
@@ -94,10 +94,10 @@ These rules apply equally on phones, Android TV, Google TV, and Fire TV.
 
 ## Switching and rollback
 
-The current Beta uses build code `410036`. No Public counterpart is available.
+The current Beta uses build code `410037`. No Public counterpart is available.
 An older Public install can move to this Beta when Android accepts the higher
 build code, but it cannot move back in place until a future Public build uses
-code `410036` or higher. Uninstalling first permits an older APK but deletes
+code `410037` or higher. Uninstalling first permits an older APK but deletes
 local application data. Developer Mode and in-app settings cannot override
 this Android rule.
 

--- a/lib/core/widgets/tv_text_input.dart
+++ b/lib/core/widgets/tv_text_input.dart
@@ -777,9 +777,16 @@ class _TvKeyboardDialogState extends State<TvKeyboardDialog> {
         ? (widget.numericOnly ? 720.0 : 620.0)
         : (widget.numericOnly ? 640.0 : 525.0);
     final heightScale = (availableHeight / heightTarget).clamp(.48, 1.0);
-    final scale = narrow
-        ? (widthScale < heightScale ? widthScale : heightScale)
-        : heightScale;
+    final responsiveScale = widthScale < heightScale ? widthScale : heightScale;
+    // Keep the controller keyboard in the same compact lower-screen footprint
+    // as TetoTV's original keyboard. The refreshed layout has larger nominal
+    // key metrics, so allowing a wide TV to use a 1:1 scale makes the dialog
+    // consume most of a 1080p viewport. Phones still use the fully responsive
+    // scale because they need the extra touch target size.
+    final wideTvScaleCap = widget.numericOnly ? .36 : .40;
+    final scale = !narrow && responsiveScale > wideTvScaleCap
+        ? wideTvScaleCap
+        : responsiveScale;
     final keyHeight = (widget.numericOnly ? 64.0 : 58.0) * scale;
     final actionHeight = (widget.numericOnly ? 68.0 : 58.0) * scale;
     final keyGap = (widget.numericOnly ? 10.0 : 8.0) * scale;
@@ -1117,7 +1124,7 @@ class _TvKeyboardDialogState extends State<TvKeyboardDialog> {
     }
 
     return Dialog(
-      alignment: widget.numericOnly ? Alignment.center : Alignment.bottomCenter,
+      alignment: Alignment.bottomCenter,
       insetPadding: EdgeInsets.symmetric(
         horizontal: horizontalInset,
         vertical: narrow ? 10 : 12,

--- a/lib/features/home/presentation/main_navigation_bar.dart
+++ b/lib/features/home/presentation/main_navigation_bar.dart
@@ -1558,10 +1558,13 @@ class _ProfileMenuButton extends StatelessWidget {
           onKeyEvent: onKeyEvent,
           onFocusChanged: onFocusChanged,
           onPressed: isLoading ? () {} : () => _openMenu(buttonContext),
-          // Keep the focus outline and clipped avatar on the same rounded-
-          // square geometry. A different outer radius made the border look
-          // circular even after the profile image itself became square.
-          borderRadius: _profileAvatarBorderRadius,
+          // The trigger is 52px while the compact avatar is 40px. Scale the
+          // outer corner to the same 25% radius instead of reusing the inner
+          // 10px value; equal pixel radii on differently sized squares do not
+          // form concentric corners and made the focus ring look mismatched.
+          borderRadius: compactAvatar
+              ? _profileTriggerBorderRadius
+              : _profileAvatarBorderRadius,
           focusScale: compactAvatar ? 1.01 : 1.02,
           child: Container(
             key: ValueKey('main-nav-profile-$slug'),
@@ -2216,6 +2219,12 @@ class _ProfileAvatar extends StatelessWidget {
         shape: BoxShape.rectangle,
         borderRadius: _profileAvatarBorderRadius,
         color: context.appPalette.surfaceRaised,
+      ),
+      // Paint the outline above the artwork. A background decoration border
+      // can be covered by the child image and leave a visibly different
+      // corner at runtime even though both values use the same radius.
+      foregroundDecoration: BoxDecoration(
+        borderRadius: _profileAvatarBorderRadius,
         border: outlined
             ? Border.all(color: context.appPalette.accentBright, width: 2)
             : null,
@@ -2251,6 +2260,9 @@ class _LocalProfileAvatar extends StatelessWidget {
       shape: BoxShape.rectangle,
       borderRadius: _profileAvatarBorderRadius,
       color: context.appPalette.secondaryAccent.withValues(alpha: .18),
+    ),
+    foregroundDecoration: BoxDecoration(
+      borderRadius: _profileAvatarBorderRadius,
       border: outlined
           ? Border.all(color: context.appPalette.accentBright, width: 2)
           : null,
@@ -2264,6 +2276,7 @@ class _LocalProfileAvatar extends StatelessWidget {
 }
 
 const _profileAvatarBorderRadius = BorderRadius.all(Radius.circular(10));
+const _profileTriggerBorderRadius = BorderRadius.all(Radius.circular(13));
 
 class _NavigationAction extends StatelessWidget {
   const _NavigationAction({

--- a/lib/features/player/presentation/watch_party_membership_notice.dart
+++ b/lib/features/player/presentation/watch_party_membership_notice.dart
@@ -129,10 +129,21 @@ class _NoticeAvatar extends StatelessWidget {
     final palette = context.appPalette;
     final displayName = notice.displayName;
     final avatarUrl = notice.avatarUrl;
-    return SizedBox.square(
+    return Container(
       key: ValueKey('watch-party-membership-avatar-${notice.sequence}'),
-      dimension: 36,
-      child: ClipOval(
+      width: 36,
+      height: 36,
+      clipBehavior: Clip.antiAlias,
+      decoration: BoxDecoration(
+        color: palette.accent.withValues(alpha: .3),
+        borderRadius: _noticeAvatarBorderRadius,
+      ),
+      foregroundDecoration: BoxDecoration(
+        borderRadius: _noticeAvatarBorderRadius,
+        border: Border.all(color: palette.accentBright.withValues(alpha: .72)),
+      ),
+      child: ClipRRect(
+        borderRadius: _noticeAvatarBorderRadius,
         child: avatarUrl != null
             ? NetworkArtwork(
                 url: avatarUrl,
@@ -170,6 +181,12 @@ class _NoticeCopy extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final palette = context.appPalette;
+    final notificationStyle = theme.textTheme.labelLarge!.copyWith(
+      color: palette.primaryText,
+      decoration: TextDecoration.none,
+    );
     final displayName = notice.displayName;
     final actionText = notice.actionText;
     if (!notice.isParticipantEvent ||
@@ -180,9 +197,7 @@ class _NoticeCopy extends StatelessWidget {
         key: ValueKey('watch-party-membership-message-${notice.sequence}'),
         maxLines: 2,
         overflow: TextOverflow.ellipsis,
-        style: const TextStyle(
-          color: Colors.white,
-          decoration: TextDecoration.none,
+        style: notificationStyle.copyWith(
           fontSize: 13,
           fontWeight: FontWeight.w700,
           height: 1.18,
@@ -198,9 +213,7 @@ class _NoticeCopy extends StatelessWidget {
           key: ValueKey('watch-party-membership-name-${notice.sequence}'),
           maxLines: 1,
           overflow: TextOverflow.ellipsis,
-          style: const TextStyle(
-            color: Colors.white,
-            decoration: TextDecoration.none,
+          style: notificationStyle.copyWith(
             fontSize: 14,
             fontWeight: FontWeight.w900,
             height: 1.05,
@@ -212,9 +225,7 @@ class _NoticeCopy extends StatelessWidget {
           key: ValueKey('watch-party-membership-action-${notice.sequence}'),
           maxLines: 1,
           overflow: TextOverflow.ellipsis,
-          style: const TextStyle(
-            color: Colors.white,
-            decoration: TextDecoration.none,
+          style: notificationStyle.copyWith(
             fontSize: 12,
             fontWeight: FontWeight.w600,
             height: 1.05,
@@ -224,6 +235,8 @@ class _NoticeCopy extends StatelessWidget {
     );
   }
 }
+
+const _noticeAvatarBorderRadius = BorderRadius.all(Radius.circular(9));
 
 String _initial(String value) {
   final normalized = value.trim();

--- a/lib/features/settings/application/app_update_controller.dart
+++ b/lib/features/settings/application/app_update_controller.dart
@@ -322,7 +322,15 @@ class GitHubAppReleaseSource implements AppReleaseSource {
         continue;
       }
       final tag = _optionalString(item['tag_name']);
-      if (tag == null || appVersionMajor(tag) != releaseMajor) continue;
+      // A repository can also publish companion artifacts under tags such as
+      // `v2.0.54-compliance`. Those are valid GitHub releases, but they are not
+      // installable app versions. Filter them before strict release parsing so
+      // one companion entry cannot make the complete history picker disappear.
+      if (tag == null ||
+          !RegExp(r'^v\d+\.\d+\.\d+$').hasMatch(tag) ||
+          appVersionMajor(tag) != releaseMajor) {
+        continue;
+      }
       releases.add(_parseCompletedRelease(item, deviceAbis));
     }
     _validateReleaseHistoryOrder(releases);

--- a/lib/features/watch_together/application/watch_party_controller.dart
+++ b/lib/features/watch_together/application/watch_party_controller.dart
@@ -2,15 +2,30 @@ import 'dart:async';
 
 import 'package:anime_tv/core/config/app_config.dart';
 import 'package:anime_tv/core/storage/tetotv_database.dart';
+import 'package:anime_tv/features/watch_together/application/watch_party_public_identity_provider.dart';
 import 'package:anime_tv/features/watch_together/data/watch_party_client.dart';
 import 'package:anime_tv/features/watch_together/domain/watch_party_models.dart';
 import 'package:anime_tv/features/watch_together/domain/watch_party_source_descriptor.dart';
 import 'package:anime_tv/features/watch_together/domain/watch_party_timeline.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-final watchPartyClientProvider = Provider<WatchPartyClient>(
-  (_) => WatchPartyClient(baseUrl: AppConfig.watchTogetherBaseUrl),
-);
+final watchPartyClientProvider = Provider<WatchPartyClient>((ref) {
+  final client = WatchPartyClient(baseUrl: AppConfig.watchTogetherBaseUrl);
+
+  // Watch Parties can be opened directly from an episode or the player, so
+  // the identity cannot be initialized only by WatchTogetherScreen. Keep the
+  // long-lived client synchronized at provider scope without rebuilding the
+  // controller (and disconnecting an active room) when tracker data finishes
+  // loading or the selected profile changes.
+  client.setPublicIdentity(ref.read(watchPartyPublicIdentityProvider));
+  ref.listen<WatchPartyPublicIdentity?>(watchPartyPublicIdentityProvider, (
+    _,
+    identity,
+  ) {
+    client.setPublicIdentity(identity);
+  });
+  return client;
+});
 
 final watchPartyControllerProvider =
     StateNotifierProvider<WatchPartyController, WatchPartyState>((ref) {

--- a/lib/features/watch_together/data/watch_party_client.dart
+++ b/lib/features/watch_together/data/watch_party_client.dart
@@ -1,5 +1,6 @@
 import 'package:anime_tv/features/watch_together/domain/watch_party_models.dart';
 import 'package:dio/dio.dart';
+import 'package:flutter/foundation.dart';
 
 class WatchPartyClientException implements Exception {
   const WatchPartyClientException(this.code, {this.retryAfter});
@@ -56,6 +57,9 @@ class WatchPartyClient {
   void setPublicIdentity(WatchPartyPublicIdentity? identity) {
     _publicIdentity = identity;
   }
+
+  @visibleForTesting
+  WatchPartyPublicIdentity? get publicIdentityForTesting => _publicIdentity;
 
   Future<bool> health() async {
     final response = await _request(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: 'none'
 # Public and Beta artifacts built from the same source use one monotonically
 # increasing Android versionCode. The project default carries the Beta display
 # version; the Public universal APK overrides the build name to the 1.x line.
-version: 2.0.59+410036
+version: 2.0.60+410037
 
 environment:
   sdk: ^3.12.2

--- a/test/app_update_controller_test.dart
+++ b/test/app_update_controller_test.dart
@@ -514,7 +514,7 @@ void main() {
     );
 
     test(
-      'Beta history is repository-scoped and accepts either release flag',
+      'Beta history skips companion tags and accepts either release flag',
       () async {
         RequestOptions? request;
         final dio = _listMetadataDio((options) {
@@ -524,6 +524,11 @@ void main() {
               '2.0.5',
               repository: tetoTvBetaReleaseRepository,
               prerelease: false,
+            ),
+            _githubRelease(
+              '2.0.4-compliance',
+              repository: tetoTvBetaReleaseRepository,
+              prerelease: true,
             ),
             _githubRelease(
               '2.0.4',

--- a/test/home_tv_navigation_test.dart
+++ b/test/home_tv_navigation_test.dart
@@ -1133,9 +1133,12 @@ void main() {
         find.byKey(const ValueKey('main-nav-profile-avatar-anilist')),
       );
       final avatarDecoration = avatar.decoration! as BoxDecoration;
+      final avatarForeground = avatar.foregroundDecoration! as BoxDecoration;
       expect(avatarDecoration.shape, BoxShape.rectangle);
       expect(avatarDecoration.borderRadius, BorderRadius.circular(10));
-      expect(avatarDecoration.border, isNotNull);
+      expect(avatarDecoration.border, isNull);
+      expect(avatarForeground.borderRadius, BorderRadius.circular(10));
+      expect(avatarForeground.border, isNotNull);
       expect(
         tester.getSize(
           find.byKey(const ValueKey('main-nav-profile-avatar-anilist')),

--- a/test/my_list_screen_test.dart
+++ b/test/my_list_screen_test.dart
@@ -355,13 +355,16 @@ void main() {
       find.byKey(const ValueKey('main-nav-profile-avatar-anilist')),
     );
     final avatarDecoration = avatar.decoration! as BoxDecoration;
+    final avatarForeground = avatar.foregroundDecoration! as BoxDecoration;
     expect(avatarDecoration.shape, BoxShape.rectangle);
     expect(avatarDecoration.borderRadius, BorderRadius.circular(10));
-    expect(avatarDecoration.border, isNotNull);
+    expect(avatarDecoration.border, isNull);
+    expect(avatarForeground.borderRadius, BorderRadius.circular(10));
+    expect(avatarForeground.border, isNotNull);
     final profileFocusable = tester.widget<TvFocusable>(
       find.descendant(of: profileSwitcher, matching: find.byType(TvFocusable)),
     );
-    expect(profileFocusable.borderRadius, BorderRadius.circular(10));
+    expect(profileFocusable.borderRadius, BorderRadius.circular(13));
     expect(find.byKey(const ValueKey('main-nav-settings')), findsOneWidget);
     expect(find.text('TetoFan'), findsNothing);
     expect(find.text('MALFan'), findsNothing);
@@ -404,10 +407,14 @@ void main() {
       find.byKey(const ValueKey('main-nav-profile-menu-avatar-anilist')),
     );
     final menuAvatarDecoration = menuAvatar.decoration! as BoxDecoration;
+    final menuAvatarForeground =
+        menuAvatar.foregroundDecoration! as BoxDecoration;
     expect(menuAvatarDecoration.shape, BoxShape.rectangle);
     expect(menuAvatarDecoration.borderRadius, BorderRadius.circular(10));
-    expect(menuAvatarDecoration.border, isNotNull);
-    expect(menuAvatarDecoration.border!.top.width, 2);
+    expect(menuAvatarDecoration.border, isNull);
+    expect(menuAvatarForeground.borderRadius, BorderRadius.circular(10));
+    expect(menuAvatarForeground.border, isNotNull);
+    expect(menuAvatarForeground.border!.top.width, 2);
 
     final activeProfileRow = find.byKey(
       const ValueKey('main-nav-switch-profile-anilist-anilist-tetofan'),
@@ -877,7 +884,15 @@ void main() {
                 )
                 .decoration!
             as BoxDecoration;
-    expect(avatarDecoration.border, isNotNull);
+    final avatarForeground =
+        tester
+                .widget<Container>(
+                  find.byKey(const ValueKey('main-nav-profile-avatar-anilist')),
+                )
+                .foregroundDecoration!
+            as BoxDecoration;
+    expect(avatarDecoration.border, isNull);
+    expect(avatarForeground.border, isNotNull);
     expect(avatarDecoration.shape, BoxShape.rectangle);
     expect(avatarDecoration.borderRadius, BorderRadius.circular(10));
     expect(

--- a/test/top_level_ui_consistency_test.dart
+++ b/test/top_level_ui_consistency_test.dart
@@ -497,9 +497,12 @@ void main() {
         ),
       );
       final avatarDecoration = avatar.decoration! as BoxDecoration;
+      final avatarForeground = avatar.foregroundDecoration! as BoxDecoration;
       expect(avatarDecoration.shape, BoxShape.rectangle);
       expect(avatarDecoration.borderRadius, BorderRadius.circular(10));
-      expect(avatarDecoration.border, isNotNull);
+      expect(avatarDecoration.border, isNull);
+      expect(avatarForeground.borderRadius, BorderRadius.circular(10));
+      expect(avatarForeground.border, isNotNull);
       final profileDetector = tester.widget<FocusableActionDetector>(
         find
             .descendant(

--- a/test/tv_text_input_test.dart
+++ b/test/tv_text_input_test.dart
@@ -14,6 +14,12 @@ void main() {
   testWidgets('search keyboard exposes the TV QWERTY and number-pad layout', (
     tester,
   ) async {
+    tester.view.physicalSize = const Size(1280, 720);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(() {
+      tester.view.resetPhysicalSize();
+      tester.view.resetDevicePixelRatio();
+    });
     FlutterSecureStorage.setMockInitialValues({
       'input_use_built_in_keyboard': 'true',
     });
@@ -104,6 +110,19 @@ void main() {
     expect(find.bySemanticsLabel('Space'), findsOneWidget);
     expect(find.bySemanticsLabel('Backspace'), findsOneWidget);
 
+    final keyboardPanel = find.byKey(const ValueKey('tv-keyboard-panel'));
+    final keyboardRect = tester.getRect(keyboardPanel);
+    expect(
+      keyboardRect.height,
+      lessThanOrEqualTo(210),
+      reason: 'the TV keyboard must retain the original compact height',
+    );
+    expect(
+      keyboardRect.bottom,
+      greaterThan(700),
+      reason: 'the compact keyboard stays anchored to the lower screen edge',
+    );
+
     // The right-side number pad keeps conventional ascending rows and stays
     // to the right of the QWERTY keys without pinning the test to pixels.
     expect(
@@ -168,6 +187,12 @@ void main() {
   testWidgets('numeric TV input opens explicitly and applies room-code rules', (
     tester,
   ) async {
+    tester.view.physicalSize = const Size(1280, 720);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(() {
+      tester.view.resetPhysicalSize();
+      tester.view.resetDevicePixelRatio();
+    });
     FlutterSecureStorage.setMockInitialValues({
       'input_use_built_in_keyboard': 'true',
     });
@@ -224,6 +249,20 @@ void main() {
       );
     }
     expect(find.bySemanticsLabel('Backspace'), findsOneWidget);
+
+    final numericPanelRect = tester.getRect(
+      find.byKey(const ValueKey('tv-keyboard-panel')),
+    );
+    expect(
+      numericPanelRect.height,
+      lessThanOrEqualTo(225),
+      reason: 'the room-code keyboard must keep the compact TV footprint',
+    );
+    expect(
+      numericPanelRect.bottom,
+      greaterThan(700),
+      reason: 'the room-code keyboard stays in the lower screen area',
+    );
 
     // The room-code pad reads naturally from 1 through 9.
     expect(

--- a/test/watch_party_membership_notice_test.dart
+++ b/test/watch_party_membership_notice_test.dart
@@ -51,6 +51,9 @@ void main() {
             message: 'Host controls transferred to Dana.',
           ),
         ]);
+      final themedAppTypography = AppTheme.dark.copyWith(
+        textTheme: AppTheme.dark.textTheme.apply(fontFamily: 'TetoTestSans'),
+      );
 
       await tester.pumpWidget(
         ProviderScope(
@@ -58,7 +61,7 @@ void main() {
             watchPartyControllerProvider.overrideWith((_) => controller),
           ],
           child: MaterialApp(
-            theme: AppTheme.dark,
+            theme: themedAppTypography,
             home: const MediaQuery(
               data: MediaQueryData(
                 size: Size(1280, 720),
@@ -117,14 +120,30 @@ void main() {
         find.byKey(const ValueKey('watch-party-membership-name-1')),
       );
       expect(emphasizedName.style?.fontWeight, FontWeight.w900);
-      expect(emphasizedName.style?.color, Colors.white);
+      expect(emphasizedName.style?.color, AppColors.textPrimary);
       expect(emphasizedName.style?.decoration, TextDecoration.none);
+      expect(
+        emphasizedName.style?.letterSpacing,
+        themedAppTypography.textTheme.labelLarge?.letterSpacing,
+      );
+      expect(
+        emphasizedName.style?.fontFamily,
+        themedAppTypography.textTheme.labelLarge?.fontFamily,
+      );
       for (var sequence = 1; sequence <= 4; sequence++) {
         final action = tester.widget<Text>(
           find.byKey(ValueKey('watch-party-membership-action-$sequence')),
         );
-        expect(action.style?.color, Colors.white);
+        expect(action.style?.color, AppColors.textPrimary);
         expect(action.style?.decoration, TextDecoration.none);
+        expect(
+          action.style?.letterSpacing,
+          themedAppTypography.textTheme.labelLarge?.letterSpacing,
+        );
+        expect(
+          action.style?.fontFamily,
+          themedAppTypography.textTheme.labelLarge?.fontFamily,
+        );
       }
       final liveRegion = tester.widget<Semantics>(
         find.byKey(const ValueKey('watch-party-membership-notice-1')),
@@ -142,10 +161,19 @@ void main() {
       expect(
         find.descendant(
           of: find.byKey(const ValueKey('watch-party-membership-avatar-2')),
-          matching: find.byType(ClipOval),
+          matching: find.byType(ClipRRect),
         ),
         findsOneWidget,
       );
+      final avatar = tester.widget<Container>(
+        find.byKey(const ValueKey('watch-party-membership-avatar-1')),
+      );
+      final avatarDecoration = avatar.decoration! as BoxDecoration;
+      final avatarForeground = avatar.foregroundDecoration! as BoxDecoration;
+      expect(avatarDecoration.shape, BoxShape.rectangle);
+      expect(avatarDecoration.borderRadius, BorderRadius.circular(9));
+      expect(avatarForeground.borderRadius, BorderRadius.circular(9));
+      expect(avatarForeground.border, isNotNull);
 
       final decoration = tester.widget<DecoratedBox>(
         find

--- a/test/watch_party_public_roster_test.dart
+++ b/test/watch_party_public_roster_test.dart
@@ -2,13 +2,61 @@ import 'dart:convert';
 
 import 'package:anime_tv/features/auth/domain/tracking_provider.dart';
 import 'package:anime_tv/features/settings/application/tracking_accounts_controller.dart';
+import 'package:anime_tv/features/watch_together/application/watch_party_controller.dart';
 import 'package:anime_tv/features/watch_together/application/watch_party_public_identity_provider.dart';
 import 'package:anime_tv/features/watch_together/data/watch_party_client.dart';
 import 'package:anime_tv/features/watch_together/domain/watch_party_models.dart';
 import 'package:dio/dio.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
+  test(
+    'provider keeps the Watch Party client identity current outside the lobby',
+    () async {
+      final identityState = StateProvider<WatchPartyPublicIdentity?>((_) {
+        return WatchPartyPublicIdentity.tryCreate(
+          displayName: 'AniList Host',
+          avatarUrl: 'https://img.anili.st/user/123/avatar.png',
+        );
+      });
+      final container = ProviderContainer(
+        overrides: [
+          watchPartyPublicIdentityProvider.overrideWith(
+            (ref) => ref.watch(identityState),
+          ),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      final client = container.read(watchPartyClientProvider);
+      expect(client.publicIdentityForTesting?.toJson(), {
+        'display_name': 'AniList Host',
+        'avatar_url': 'https://img.anili.st/user/123/avatar.png',
+      });
+
+      container
+          .read(identityState.notifier)
+          .state = WatchPartyPublicIdentity.tryCreate(
+        displayName: 'MAL Guest',
+        avatarUrl:
+            'https://api-cdn.myanimelist.net/images/userimages/456.jpg?t=1725123456',
+      );
+      await Future<void>.delayed(Duration.zero);
+
+      expect(
+        identical(container.read(watchPartyClientProvider), client),
+        isTrue,
+        reason: 'an active room must not lose its long-lived client',
+      );
+      expect(client.publicIdentityForTesting?.toJson(), {
+        'display_name': 'MAL Guest',
+        'avatar_url':
+            'https://api-cdn.myanimelist.net/images/userimages/456.jpg',
+      });
+    },
+  );
+
   test('public identity keeps only a bounded name and allowlisted avatar', () {
     final identity = WatchPartyPublicIdentity.tryCreate(
       displayName: '  Teto   Fan  ',

--- a/tool/release/native_playback_manifest.json
+++ b/tool/release/native_playback_manifest.json
@@ -375,10 +375,10 @@
     {
       "path": "lib/arm64-v8a/libapp.so",
       "size": 12387216,
-      "sha256": "10fc392ef713125640bac13eab37aa17976fe274ae9525938e440932c5abd21f",
-      "origin": "TetoTV Flutter application AOT 2.0.59",
+      "sha256": "cc3b6b3a257cde3d5d5797771d0b2a3152d7a5ffe5c653a5a580d480424a82d2",
+      "origin": "TetoTV Flutter application AOT 2.0.60",
       "license": "MIT",
-      "sourceLocator": "Git tag v2.0.59",
+      "sourceLocator": "Git tag v2.0.60",
       "noticeLocator": "LICENSE"
     },
     {
@@ -423,7 +423,7 @@
       "sha256": "dc05f53278b2733094f12aeaed54c080329309762ce49e6de4118e4bfb0fff55",
       "origin": "TetoTV source build of media-kit Android helper at 42054e5d479f39ccbb0ae604862e2bcaf59b74c2",
       "license": "MIT",
-      "sourceLocator": "TetoTV-v2.0.59-native-playback-sources.zip: sources/media-kit-android-helper-42054e5d479f39ccbb0ae604862e2bcaf59b74c2.zip",
+      "sourceLocator": "TetoTV-v2.0.60-native-playback-sources.zip: sources/media-kit-android-helper-42054e5d479f39ccbb0ae604862e2bcaf59b74c2.zip",
       "noticeLocator": "assets/legal/native/MEDIA_KIT_ANDROID_HELPER_LICENSE.txt; assets/legal/native/NATIVE_PLAYBACK_NOTICE.txt"
     },
     {
@@ -432,7 +432,7 @@
       "sha256": "a7399d0be70844e5ee94cc5b1acc1516571113c50561fe0a5d05b49101c53ef2",
       "origin": "TetoTV source build of the pinned mpv and FFmpeg native playback stack",
       "license": "LGPL-3.0-or-later (conservative combined classification) plus component terms",
-      "sourceLocator": "TetoTV-v2.0.59-native-playback-sources.zip and tool/native/build_native_playback.sh",
+      "sourceLocator": "TetoTV-v2.0.60-native-playback-sources.zip and tool/native/build_native_playback.sh",
       "noticeLocator": "assets/legal/native/NATIVE_PLAYBACK_NOTICE.txt and its referenced exact license assets"
     },
     {
@@ -450,16 +450,16 @@
       "sha256": "263ba714570fb3acfc308cce52776b00506ec8809d225617e52352336144cfa2",
       "origin": "TetoTV source build of the pinned libtorrent4j and libtorrent-rasterbar stack",
       "license": "Mixed MIT, BSD, Boost-1.0, Apache-2.0, and MPL-2.0 component terms",
-      "sourceLocator": "TetoTV-v2.0.59-native-playback-sources.zip and tool/native/build_native_playback.sh",
+      "sourceLocator": "TetoTV-v2.0.60-native-playback-sources.zip and tool/native/build_native_playback.sh",
       "noticeLocator": "assets/legal/native/DIRECT_TORRENT_NATIVE_NOTICE.txt and its referenced exact license assets"
     },
     {
       "path": "lib/armeabi-v7a/libapp.so",
       "size": 13533772,
-      "sha256": "740b33c168544645b063cbb76b669d154897a3dc20bbdc52d378e2336aa7852d",
-      "origin": "TetoTV Flutter application AOT 2.0.59",
+      "sha256": "e1e9b0045dc609eb434eb01233edde017b3fc49ddb564bd062c4a81010adb953",
+      "origin": "TetoTV Flutter application AOT 2.0.60",
       "license": "MIT",
-      "sourceLocator": "Git tag v2.0.59",
+      "sourceLocator": "Git tag v2.0.60",
       "noticeLocator": "LICENSE"
     },
     {
@@ -504,7 +504,7 @@
       "sha256": "8820a12e07bb3dc45f5b4286acf6918827fba4c265767e7f1cc8f07215c84b6a",
       "origin": "TetoTV source build of media-kit Android helper at 42054e5d479f39ccbb0ae604862e2bcaf59b74c2",
       "license": "MIT",
-      "sourceLocator": "TetoTV-v2.0.59-native-playback-sources.zip: sources/media-kit-android-helper-42054e5d479f39ccbb0ae604862e2bcaf59b74c2.zip",
+      "sourceLocator": "TetoTV-v2.0.60-native-playback-sources.zip: sources/media-kit-android-helper-42054e5d479f39ccbb0ae604862e2bcaf59b74c2.zip",
       "noticeLocator": "assets/legal/native/MEDIA_KIT_ANDROID_HELPER_LICENSE.txt; assets/legal/native/NATIVE_PLAYBACK_NOTICE.txt"
     },
     {
@@ -513,7 +513,7 @@
       "sha256": "d5a220fdf41edde10f161f86addc846ae9cb18137ea48e4db541cd703fec5092",
       "origin": "TetoTV source build of the pinned mpv and FFmpeg native playback stack",
       "license": "LGPL-3.0-or-later (conservative combined classification) plus component terms",
-      "sourceLocator": "TetoTV-v2.0.59-native-playback-sources.zip and tool/native/build_native_playback.sh",
+      "sourceLocator": "TetoTV-v2.0.60-native-playback-sources.zip and tool/native/build_native_playback.sh",
       "noticeLocator": "assets/legal/native/NATIVE_PLAYBACK_NOTICE.txt and its referenced exact license assets"
     },
     {
@@ -531,7 +531,7 @@
       "sha256": "ba0a19d2730969b8e6107db1847888ea8d3b8cafd14a535a3259dd04f8b28d60",
       "origin": "TetoTV source build of the pinned libtorrent4j and libtorrent-rasterbar stack",
       "license": "Mixed MIT, BSD, Boost-1.0, Apache-2.0, and MPL-2.0 component terms",
-      "sourceLocator": "TetoTV-v2.0.59-native-playback-sources.zip and tool/native/build_native_playback.sh",
+      "sourceLocator": "TetoTV-v2.0.60-native-playback-sources.zip and tool/native/build_native_playback.sh",
       "noticeLocator": "assets/legal/native/DIRECT_TORRENT_NATIVE_NOTICE.txt and its referenced exact license assets"
     }
   ],


### PR DESCRIPTION
## Summary
- restore the Developer release-history picker when companion release tags exist
- synchronize AniList/MAL public Watch Party identities for every entry path
- align notification typography and rounded-square profile geometry
- restore the refreshed TV keyboards to their compact lower-screen height
- prepare Beta 2.0.60+410037 release metadata

## Verification
- flutter test: 1,958 passed, 17 platform-only skipped
- flutter analyze --no-fatal-infos
- focused runtime audit: 113 passed
- APK identity/signature/native BOM verification passed
- native source-bundle and release-payload verification passed