### PR TITLE
Fix TV runtime issues and prepare Beta 2.0.61

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 
 <p align="center">
   <a href="https://github.com/LindersOSX/TetoTV-Beta/releases/latest"><strong>Download Beta</strong></a>
-  · <a href="docs/RELEASE_NOTES_2.0.60.md">What's new</a>
+  · <a href="docs/RELEASE_NOTES_2.0.61.md">What's new</a>
   · <a href="https://github.com/LindersOSX/TetoTV-Beta/issues/new">Report an issue</a>
   · <a href="https://discord.gg/juC6k7d4WY">Discord</a>
   · <a href="https://www.youtube.com/@TetoTVApp">YouTube</a>
@@ -94,10 +94,10 @@ TetoTV runs directly on the Android device with no companion server required for
 | Channel | Version | Best for |
 | --- | --- | --- |
 | Public | Not published | Source and release-readiness documents are available, but no Public APK is currently offered |
-| Beta | [2.0.60](docs/RELEASE_NOTES_2.0.60.md) | Runtime fixes and compact controller keyboards |
+| Beta | [2.0.61](docs/RELEASE_NOTES_2.0.61.md) | TV keyboard, release-history, and Watch Party avatar fixes |
 
 > [!WARNING]
-> Beta 2.0.60 uses the repository's explicit unreviewed-Beta exception. Its native-library and corresponding-source material did not receive independent license review, and automated integrity checks are not a legal compliance determination. Read the [complete Beta disclosure](docs/RELEASE_NOTES_2.0.60.md). This exception does not apply to a future Public release.
+> Beta 2.0.61 uses the repository's explicit unreviewed-Beta exception. Its native-library and corresponding-source material did not receive independent license review, and automated integrity checks are not a legal compliance determination. Read the [complete Beta disclosure](docs/RELEASE_NOTES_2.0.61.md). This exception does not apply to a future Public release.
 
 The Public updater repository intentionally has no release while the Public build is held for review. Existing Beta installations continue to update from the Beta repository. Android never permits an in-place install of an APK with a lower build code; Developer Mode does not bypass that platform rule.
 

--- a/docs/BUILD_WINDOWS.md
+++ b/docs/BUILD_WINDOWS.md
@@ -220,39 +220,39 @@ APK containing both supported application ABIs.
 Public and Beta updates use anonymous GitHub requests. No Beta key, GitHub
 token, update-proxy URL, or update-specific Dart define is required. Every
 published APK uses the production signing identity. No Public APK is currently
-published. Beta 2.0.60 uses Android build code `410037`. Flutter reuses
+published. Beta 2.0.61 uses Android build code `410038`. Flutter reuses
 `app-release.apk`, so copy and rename the Beta artifact immediately after the
 build:
 
 ```powershell
-New-Item -ItemType Directory -Force .\build\fire-tv\v2.0.60 | Out-Null
+New-Item -ItemType Directory -Force .\build\fire-tv\v2.0.61 | Out-Null
 
-# Beta 2.0.60
+# Beta 2.0.61
 flutter build apk --release --target-platform android-arm,android-arm64 `
-  --build-name 2.0.60 --build-number 410037 --no-tree-shake-icons
+  --build-name 2.0.61 --build-number 410038 --no-tree-shake-icons
 Copy-Item .\build\app\outputs\flutter-apk\app-release.apk `
-  .\build\fire-tv\v2.0.60\TetoTV-v2.0.60-universal.apk
+  .\build\fire-tv\v2.0.61\TetoTV-v2.0.61-universal.apk
 
 .\tool\release\verify_release_apk.ps1 `
   -Channel Beta `
-  -ApkPath .\build\fire-tv\v2.0.60\TetoTV-v2.0.60-universal.apk
+  -ApkPath .\build\fire-tv\v2.0.61\TetoTV-v2.0.61-universal.apk
 
 .\tool\release\verify_native_redistribution.ps1 `
   -RequireResolvedBinaries `
   -ResolvedBinaryDirectory .\build\native-playback\outputs `
-  -StageBundle -ReleaseTag v2.0.60
+  -StageBundle -ReleaseTag v2.0.61
 
 .\tool\release\new_release_checksums.ps1 `
-  -ApkPath .\build\fire-tv\v2.0.60\TetoTV-v2.0.60-universal.apk `
-  -NativeSourcePath .\build\release-compliance\v2.0.60\TetoTV-v2.0.60-native-playback-sources.zip `
-  -OutputPath .\build\fire-tv\v2.0.60\SHA256SUMS
+  -ApkPath .\build\fire-tv\v2.0.61\TetoTV-v2.0.61-universal.apk `
+  -NativeSourcePath .\build\release-compliance\v2.0.61\TetoTV-v2.0.61-native-playback-sources.zip `
+  -OutputPath .\build\fire-tv\v2.0.61\SHA256SUMS
 
 .\tool\release\verify_release_payloads.ps1 `
   -Channel Beta `
-  -ApkPath .\build\fire-tv\v2.0.60\TetoTV-v2.0.60-universal.apk `
-  -NativeSourcePath .\build\release-compliance\v2.0.60\TetoTV-v2.0.60-native-playback-sources.zip `
-  -ChecksumsPath .\build\fire-tv\v2.0.60\SHA256SUMS `
-  -ReleaseNotesPath .\docs\RELEASE_NOTES_2.0.60.md
+  -ApkPath .\build\fire-tv\v2.0.61\TetoTV-v2.0.61-universal.apk `
+  -NativeSourcePath .\build\release-compliance\v2.0.61\TetoTV-v2.0.61-native-playback-sources.zip `
+  -ChecksumsPath .\build\fire-tv\v2.0.61\SHA256SUMS `
+  -ReleaseNotesPath .\docs\RELEASE_NOTES_2.0.61.md
 ```
 
 The final payload check requires all five exact, source-built native JARs

--- a/docs/RELEASE_NOTES_2.0.61.md
+++ b/docs/RELEASE_NOTES_2.0.61.md
@@ -1,0 +1,29 @@
+# TetoTV 2.0.61 Beta
+
+> [!WARNING]
+> No independent native-license review: This Beta has not received independent native-library licensing review. Automated checks verify the APK, native-source bundle, notices, pinned inputs, and checksums, but do not establish legal compliance or reproducible builds.
+
+This Beta fixes controller-keyboard behavior, developer release-history navigation, cross-tracker Watch Party avatars, and the top-right profile focus treatment.
+
+## What's changed
+
+- Pressing Back on a TV remote while TetoTV's built-in keyboard is open now closes only the keyboard instead of passing the same Back action through to the app.
+- On TV, the numeric controller keypad is centered at the bottom and 50% narrower than its previous fitting width; the full QWERTY keyboard is centered at the bottom and 30% narrower. Phone and other narrow-screen keyboard sizing is unchanged.
+- Developer Mode release history now scrolls and focuses every release row. Android still blocks installing an APK with a lower build code, so Android-blocked downgrades remain non-installable.
+- Late AniList and MyAnimeList Watch Party avatar updates now refresh across participants instead of remaining as initials. This client behavior requires the matching protocol-5 Watch Party broker to be deployed with the Beta.
+- The compact top-right profile avatar now uses a direct themed focus ring and glow without the extra black contrast keyline.
+- AI-assisted development disclosure: AI tools assisted with implementation, documentation, tests, and review. The project owner directed the work, validated the changes, and remains responsible for this release.
+
+## Release assets
+
+- `TetoTV-v2.0.61-universal.apk`
+- `TetoTV-v2.0.61-native-playback-sources.zip`
+- `SHA256SUMS`
+
+## Beta notes
+
+- This is a Beta-channel build with Android build code `410038`.
+- No Public APK is being published with this release.
+- Android does not permit an in-place install over an APK with a higher build code. A future Public counterpart must use build code `410038` or newer for data-preserving channel switching.
+
+<!-- tetotv-android-version-code: 410038 -->

--- a/docs/UPDATE_CHANNELS.md
+++ b/docs/UPDATE_CHANNELS.md
@@ -35,11 +35,11 @@ Beta reads completed 2.x releases from:
 https://api.github.com/repos/LindersOSX/TetoTV-Beta/releases/latest
 ```
 
-The current Beta source build is `v2.0.60` with Android build code `410037`.
+The current Beta source build is `v2.0.61` with Android build code `410038`.
 Its release title is:
 
 ```text
-TetoTV 2.0.60 Beta - Android TV / Google TV / Fire TV
+TetoTV 2.0.61 Beta - Android TV / Google TV / Fire TV
 ```
 
 Publish it as a normal, non-draft, non-prerelease GitHub release so
@@ -72,7 +72,7 @@ proxy.
 Release notes must include the exact asset names and this build-code marker:
 
 ```html
-<!-- tetotv-android-version-code: 410037 -->
+<!-- tetotv-android-version-code: 410038 -->
 ```
 
 When build-code metadata is present, the updater rejects a known lower build
@@ -94,10 +94,10 @@ These rules apply equally on phones, Android TV, Google TV, and Fire TV.
 
 ## Switching and rollback
 
-The current Beta uses build code `410037`. No Public counterpart is available.
+The current Beta uses build code `410038`. No Public counterpart is available.
 An older Public install can move to this Beta when Android accepts the higher
 build code, but it cannot move back in place until a future Public build uses
-code `410037` or higher. Uninstalling first permits an older APK but deletes
+code `410038` or higher. Uninstalling first permits an older APK but deletes
 local application data. Developer Mode and in-app settings cannot override
 this Android rule.
 

--- a/lib/core/legal/bundled_licenses.dart
+++ b/lib/core/legal/bundled_licenses.dart
@@ -44,9 +44,7 @@ const _bundledNotices = <_BundledNotice>[
   _BundledNotice([
     'gas-preprocessor ac18363 (build tool only)',
   ], 'assets/legal/native/GAS_PREPROCESSOR_NOTICE.txt'),
-  _BundledNotice([
-    'mpv 78d4374',
-  ], 'assets/legal/native/MPV_COPYRIGHT.txt'),
+  _BundledNotice(['mpv 78d4374'], 'assets/legal/native/MPV_COPYRIGHT.txt'),
   _BundledNotice([
     'mpv 78d4374 (LGPL terms)',
   ], 'assets/legal/native/MPV_LICENSE_LGPL.txt'),
@@ -56,19 +54,13 @@ const _bundledNotices = <_BundledNotice>[
   _BundledNotice([
     'FFmpeg 6.0 (LGPL-3.0-or-later terms)',
   ], 'assets/legal/native/LGPL-3.0.txt'),
-  _BundledNotice([
-    'Mbed TLS 3.4.0',
-  ], 'assets/legal/native/MBEDTLS_LICENSE.txt'),
+  _BundledNotice(['Mbed TLS 3.4.0'], 'assets/legal/native/MBEDTLS_LICENSE.txt'),
   _BundledNotice(['dav1d 1.2.0'], 'assets/legal/native/DAV1D_COPYING.txt'),
   _BundledNotice([
     'libxml2 2.10.3',
   ], 'assets/legal/native/LIBXML2_COPYRIGHT.txt'),
-  _BundledNotice([
-    'FreeType 2.13.0',
-  ], 'assets/legal/native/FREETYPE_FTL.txt'),
-  _BundledNotice([
-    'FriBidi 1.0.12',
-  ], 'assets/legal/native/FRIBIDI_COPYING.txt'),
+  _BundledNotice(['FreeType 2.13.0'], 'assets/legal/native/FREETYPE_FTL.txt'),
+  _BundledNotice(['FriBidi 1.0.12'], 'assets/legal/native/FRIBIDI_COPYING.txt'),
   _BundledNotice([
     'HarfBuzz 7.2.0',
   ], 'assets/legal/native/HARFBUZZ_COPYING.txt'),

--- a/lib/core/tv/tv_focusable.dart
+++ b/lib/core/tv/tv_focusable.dart
@@ -16,6 +16,8 @@ class TvFocusable extends StatefulWidget {
     this.autofocus = false,
     this.borderRadius = const BorderRadius.all(Radius.circular(14)),
     this.focusScale = 1.045,
+    this.showFocusContrastKeyline = true,
+    this.enabled = true,
     this.focusNode,
     this.onFocusChanged,
     this.onLongPress,
@@ -28,6 +30,19 @@ class TvFocusable extends StatefulWidget {
   final bool autofocus;
   final BorderRadius borderRadius;
   final double focusScale;
+
+  /// Keeps the dark contrast keyline used around ordinary TV controls.
+  ///
+  /// Artwork-led controls such as the profile avatar can disable it so their
+  /// theme-colored ring flows directly into the focus glow.
+  final bool showFocusContrastKeyline;
+
+  /// Whether activation, pointer feedback, and actionable semantics are on.
+  ///
+  /// Disabled controls can remain focusable when their parent needs D-pad
+  /// traversal for reading or scrolling, but they never click or invoke an
+  /// empty action.
+  final bool enabled;
   final FocusNode? focusNode;
   final ValueChanged<bool>? onFocusChanged;
   final VoidCallback? onLongPress;
@@ -56,7 +71,7 @@ class _TvFocusableState extends State<TvFocusable> {
   FocusNode get _focusNode => widget.focusNode ?? _fallbackFocusNode;
 
   void _activate(VoidCallback? action) {
-    if (action == null) return;
+    if (!widget.enabled || action == null) return;
     if (_clickSoundsEnabled) {
       unawaited(SystemSound.play(SystemSoundType.click));
     }
@@ -197,6 +212,7 @@ class _TvFocusableState extends State<TvFocusable> {
     final highlighted = _focused || _hovered || _pressed;
     return Semantics(
       button: true,
+      enabled: widget.enabled,
       child: Focus(
         canRequestFocus: false,
         onKeyEvent: _handleRemoteActivation,
@@ -226,17 +242,21 @@ class _TvFocusableState extends State<TvFocusable> {
                   ),
             },
             child: MouseRegion(
-              cursor: SystemMouseCursors.click,
+              cursor: widget.enabled
+                  ? SystemMouseCursors.click
+                  : MouseCursor.defer,
               child: GestureDetector(
                 behavior: HitTestBehavior.opaque,
-                onTapDown: (_) => _handlePress(true),
-                onTapCancel: () => _handlePress(false),
-                onTapUp: (_) => _handlePress(false),
-                onTap: () {
-                  _focusNode.requestFocus();
-                  _activate(widget.onPressed);
-                },
-                onLongPress: widget.onLongPress == null
+                onTapDown: widget.enabled ? (_) => _handlePress(true) : null,
+                onTapCancel: widget.enabled ? () => _handlePress(false) : null,
+                onTapUp: widget.enabled ? (_) => _handlePress(false) : null,
+                onTap: widget.enabled
+                    ? () {
+                        _focusNode.requestFocus();
+                        _activate(widget.onPressed);
+                      }
+                    : null,
+                onLongPress: !widget.enabled || widget.onLongPress == null
                     ? null
                     : () => _activate(widget.onLongPress),
                 child: AnimatedScale(
@@ -249,14 +269,14 @@ class _TvFocusableState extends State<TvFocusable> {
                       borderRadius: widget.borderRadius,
                       boxShadow: highlighted
                           ? [
-                              // The dark outer keyline keeps the Teto-red ring
-                              // distinct from primary red buttons; the red glow
-                              // remains visible on black and pale artwork.
-                              BoxShadow(
-                                color: palette.focusInnerKeyline,
-                                blurRadius: 0,
-                                spreadRadius: 2,
-                              ),
+                              if (widget.showFocusContrastKeyline)
+                                // The dark outer keyline keeps the focus ring
+                                // distinct from ordinary filled controls.
+                                BoxShadow(
+                                  color: palette.focusInnerKeyline,
+                                  blurRadius: 0,
+                                  spreadRadius: 2,
+                                ),
                               BoxShadow(
                                 color: palette.focusGlow,
                                 blurRadius: 11,
@@ -280,26 +300,27 @@ class _TvFocusableState extends State<TvFocusable> {
                         fit: StackFit.passthrough,
                         children: [
                           widget.child,
-                          Positioned.fill(
-                            child: IgnorePointer(
-                              child: AnimatedOpacity(
-                                opacity: highlighted ? 1 : 0,
-                                duration: const Duration(milliseconds: 80),
-                                child: Padding(
-                                  padding: const EdgeInsets.all(3),
-                                  child: DecoratedBox(
-                                    decoration: BoxDecoration(
-                                      borderRadius: widget.borderRadius,
-                                      border: Border.all(
-                                        color: palette.focusInnerKeyline,
-                                        width: 1,
+                          if (widget.showFocusContrastKeyline)
+                            Positioned.fill(
+                              child: IgnorePointer(
+                                child: AnimatedOpacity(
+                                  opacity: highlighted ? 1 : 0,
+                                  duration: const Duration(milliseconds: 80),
+                                  child: Padding(
+                                    padding: const EdgeInsets.all(3),
+                                    child: DecoratedBox(
+                                      decoration: BoxDecoration(
+                                        borderRadius: widget.borderRadius,
+                                        border: Border.all(
+                                          color: palette.focusInnerKeyline,
+                                          width: 1,
+                                        ),
                                       ),
                                     ),
                                   ),
                                 ),
                               ),
                             ),
-                          ),
                         ],
                       ),
                     ),

--- a/lib/core/widgets/tv_text_input.dart
+++ b/lib/core/widgets/tv_text_input.dart
@@ -1,4 +1,5 @@
 import 'package:anime_tv/core/theme/app_theme.dart';
+import 'package:anime_tv/core/layout/adaptive_layout.dart';
 import 'package:anime_tv/core/tv/tv_focusable.dart';
 import 'package:anime_tv/core/tv/tv_navigation.dart';
 import 'package:anime_tv/features/settings/application/settings_preferences_controller.dart';
@@ -226,6 +227,7 @@ class _TvTextInputState extends ConsumerState<TvTextInput>
           inputFormatters: widget.inputFormatters,
           maxLength: widget.maxLength,
           numericOnly: widget.numericOnly,
+          reduceWidthForTelevision: ref.read(isTelevisionProvider),
           autofillSuggestions: widget.autofillSuggestions,
         ),
       );
@@ -573,6 +575,7 @@ class TvKeyboardDialog extends StatefulWidget {
     this.inputFormatters = const <TextInputFormatter>[],
     this.maxLength,
     this.numericOnly = false,
+    this.reduceWidthForTelevision = true,
     this.autofillSuggestions = const [],
     super.key,
   });
@@ -583,6 +586,7 @@ class TvKeyboardDialog extends StatefulWidget {
   final List<TextInputFormatter> inputFormatters;
   final int? maxLength;
   final bool numericOnly;
+  final bool reduceWidthForTelevision;
   final List<String> autofillSuggestions;
 
   @override
@@ -712,17 +716,26 @@ class _TvKeyboardDialogState extends State<TvKeyboardDialog> {
   }
 
   KeyEventResult _handlePhysicalKeyboard(FocusNode _, KeyEvent event) {
+    final isBackEvent =
+        event.logicalKey == LogicalKeyboardKey.escape ||
+        event.logicalKey == LogicalKeyboardKey.goBack ||
+        event.logicalKey == LogicalKeyboardKey.browserBack;
+    if (isBackEvent) {
+      // A TV remote sends Back as a down/up pair. Popping the dialog on key
+      // down used to expose the underlying route before key up arrived, so
+      // that second event could immediately back out of (or close) the app.
+      // Keep the dialog alive through key down/repeat, then dismiss it while
+      // consuming key up as part of the same remote press.
+      if (event is KeyUpEvent) {
+        Navigator.of(context).pop();
+      }
+      return KeyEventResult.handled;
+    }
     if (event is! KeyDownEvent && event is! KeyRepeatEvent) {
       return KeyEventResult.ignored;
     }
     if (event.logicalKey == LogicalKeyboardKey.backspace) {
       _backspace();
-      return KeyEventResult.handled;
-    }
-    if (event.logicalKey == LogicalKeyboardKey.escape ||
-        event.logicalKey == LogicalKeyboardKey.goBack ||
-        event.logicalKey == LogicalKeyboardKey.browserBack) {
-      Navigator.of(context).pop();
       return KeyEventResult.handled;
     }
     if (event.logicalKey == LogicalKeyboardKey.enter ||
@@ -770,9 +783,21 @@ class _TvKeyboardDialogState extends State<TvKeyboardDialog> {
       0.0,
       double.infinity,
     );
-    final desiredWidth = widget.numericOnly ? 820.0 : 1160.0;
-    final panelWidth = desiredWidth.clamp(0.0, maximumPanelWidth).toDouble();
-    final widthScale = (panelWidth / desiredWidth).clamp(.64, 1.0);
+    final fullWidth = widget.numericOnly ? 820.0 : 1160.0;
+    final formerPanelWidth = fullWidth.clamp(0.0, maximumPanelWidth).toDouble();
+    // Preserve the existing phone layout, but keep TV keyboards centered and
+    // purposefully narrower than the panel that would previously have fit in
+    // this exact viewport. This keeps the requested reduction consistent on
+    // 720p/960dp TV layouts instead of applying it only to very wide screens.
+    final tvWidthFactor = widget.numericOnly ? .50 : .70;
+    final reduceTvWidth = widget.reduceWidthForTelevision && !narrow;
+    final reducedNominalWidth = reduceTvWidth
+        ? fullWidth * tvWidthFactor
+        : fullWidth;
+    final panelWidth = reduceTvWidth
+        ? formerPanelWidth * tvWidthFactor
+        : formerPanelWidth;
+    final widthScale = (panelWidth / reducedNominalWidth).clamp(.64, 1.0);
     final heightTarget = availableHeight < 500
         ? (widget.numericOnly ? 720.0 : 620.0)
         : (widget.numericOnly ? 640.0 : 525.0);

--- a/lib/features/home/presentation/main_navigation_bar.dart
+++ b/lib/features/home/presentation/main_navigation_bar.dart
@@ -1566,6 +1566,10 @@ class _ProfileMenuButton extends StatelessWidget {
               ? _profileTriggerBorderRadius
               : _profileAvatarBorderRadius,
           focusScale: compactAvatar ? 1.01 : 1.02,
+          // The avatar already has the theme-colored outline. Let its focus
+          // glow meet that outline directly instead of inserting the generic
+          // black TV-control keyline around it.
+          showFocusContrastKeyline: !compactAvatar,
           child: Container(
             key: ValueKey('main-nav-profile-$slug'),
             padding: EdgeInsets.symmetric(

--- a/lib/features/settings/presentation/accounts_screen.dart
+++ b/lib/features/settings/presentation/accounts_screen.dart
@@ -5537,12 +5537,14 @@ class _SettingsOption<T> {
     required this.label,
     this.detail,
     this.enabled = true,
+    this.focusableWhenDisabled = false,
   });
 
   final T value;
   final String label;
   final String? detail;
   final bool enabled;
+  final bool focusableWhenDisabled;
 }
 
 Future<T?> _showSettingsSelectionDialog<T>({
@@ -5553,8 +5555,99 @@ Future<T?> _showSettingsSelectionDialog<T>({
 }) => showDialog<T>(
   context: context,
   barrierDismissible: true,
-  builder: (context) {
+  builder: (context) =>
+      _SettingsSelectionDialog<T>(label: label, value: value, options: options),
+);
+
+class _SettingsSelectionDialog<T> extends StatefulWidget {
+  const _SettingsSelectionDialog({
+    required this.label,
+    required this.value,
+    required this.options,
+  });
+
+  final String label;
+  final T value;
+  final List<_SettingsOption<T>> options;
+
+  @override
+  State<_SettingsSelectionDialog<T>> createState() =>
+      _SettingsSelectionDialogState<T>();
+}
+
+class _SettingsSelectionDialogState<T>
+    extends State<_SettingsSelectionDialog<T>> {
+  late final List<FocusNode> _optionFocusNodes;
+
+  bool _canFocus(int index) {
+    final option = widget.options[index];
+    return option.enabled || option.focusableWhenDisabled;
+  }
+
+  @override
+  void initState() {
+    super.initState();
+    _optionFocusNodes = List.generate(
+      widget.options.length,
+      (index) =>
+          FocusNode(debugLabel: 'settings.selection.${widget.label}.$index'),
+    );
+  }
+
+  @override
+  void dispose() {
+    for (final node in _optionFocusNodes) {
+      node.dispose();
+    }
+    super.dispose();
+  }
+
+  int? _nextFocusableIndex(int index, int offset) {
+    for (
+      var candidate = index + offset;
+      candidate >= 0 && candidate < widget.options.length;
+      candidate += offset
+    ) {
+      if (_canFocus(candidate)) return candidate;
+    }
+    return null;
+  }
+
+  KeyEventResult _handleOptionKey(int index, KeyEvent event) {
+    final offset = switch (event.logicalKey) {
+      LogicalKeyboardKey.arrowUp => -1,
+      LogicalKeyboardKey.arrowDown => 1,
+      _ => 0,
+    };
+    if (offset == 0) return KeyEventResult.ignored;
+    if (event is KeyDownEvent || event is KeyRepeatEvent) {
+      final targetIndex = _nextFocusableIndex(index, offset);
+      if (targetIndex != null) {
+        requestTvFocusAndReveal(
+          _optionFocusNodes[targetIndex],
+          towardEnd: offset > 0,
+          duration: const Duration(milliseconds: 90),
+        );
+      }
+    }
+    // Keep vertical traversal inside the modal. Consuming key-up as well
+    // avoids a remote packet leaking into the settings screen underneath.
+    return KeyEventResult.handled;
+  }
+
+  @override
+  Widget build(BuildContext context) {
     final tvScale = _usesTvSettingsScale(context);
+    final selectedIndex = widget.options.indexWhere(
+      (option) =>
+          option.value == widget.value &&
+          (option.enabled || option.focusableWhenDisabled),
+    );
+    final firstFocusableIndex = selectedIndex >= 0
+        ? selectedIndex
+        : widget.options.indexWhere(
+            (option) => option.enabled || option.focusableWhenDisabled,
+          );
     return Dialog(
       backgroundColor: Colors.transparent,
       child: Container(
@@ -5576,7 +5669,7 @@ Future<T?> _showSettingsSelectionDialog<T>({
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
               Text(
-                label,
+                widget.label,
                 style: Theme.of(context).textTheme.titleLarge?.copyWith(
                   fontSize: tvScale ? 18 : null,
                   fontWeight: FontWeight.w800,
@@ -5584,75 +5677,25 @@ Future<T?> _showSettingsSelectionDialog<T>({
               ),
               SizedBox(height: tvScale ? 7 : 14),
               Flexible(
-                child: ListView.separated(
-                  shrinkWrap: true,
-                  itemCount: options.length,
-                  separatorBuilder: (_, _) => SizedBox(height: tvScale ? 4 : 8),
-                  itemBuilder: (context, index) {
-                    final option = options[index];
-                    final optionControl = TvFocusable(
-                      autofocus: option.enabled && option.value == value,
-                      onPressed: () => Navigator.of(context).pop(option.value),
-                      borderRadius: BorderRadius.circular(9),
-                      child: Container(
-                        width: double.infinity,
-                        padding: EdgeInsets.symmetric(
-                          horizontal: tvScale ? 9 : 16,
-                          vertical: tvScale ? 6 : 13,
+                child: SingleChildScrollView(
+                  child: Column(
+                    children: [
+                      for (
+                        var index = 0;
+                        index < widget.options.length;
+                        index++
+                      ) ...[
+                        _buildOption(
+                          context,
+                          index,
+                          autofocus: index == firstFocusableIndex,
+                          tvScale: tvScale,
                         ),
-                        decoration: BoxDecoration(
-                          color: option.value == value
-                              ? context.appPalette.accent.withValues(alpha: .28)
-                              : context.appPalette.surfaceRaised,
-                          borderRadius: BorderRadius.circular(9),
-                        ),
-                        child: Row(
-                          children: [
-                            Icon(
-                              option.value == value
-                                  ? Icons.radio_button_checked_rounded
-                                  : Icons.radio_button_off_rounded,
-                              color: option.value == value
-                                  ? context.appPalette.accentBright
-                                  : context.appPalette.mutedText,
-                            ),
-                            SizedBox(width: tvScale ? 7 : 12),
-                            Expanded(
-                              child: Column(
-                                crossAxisAlignment: CrossAxisAlignment.start,
-                                children: [
-                                  Text(
-                                    option.label,
-                                    style: TextStyle(
-                                      color: _settingsPrimaryText(context),
-                                      fontWeight: FontWeight.w900,
-                                    ),
-                                  ),
-                                  if (option.detail case final detail?) ...[
-                                    const SizedBox(height: 2),
-                                    Text(
-                                      detail,
-                                      style: TextStyle(
-                                        color: context.appPalette.mutedText,
-                                        fontSize: tvScale ? 12 : 11,
-                                      ),
-                                    ),
-                                  ],
-                                ],
-                              ),
-                            ),
-                          ],
-                        ),
-                      ),
-                    );
-                    if (option.enabled) return optionControl;
-                    return ExcludeFocus(
-                      excluding: true,
-                      child: IgnorePointer(
-                        child: Opacity(opacity: .45, child: optionControl),
-                      ),
-                    );
-                  },
+                        if (index != widget.options.length - 1)
+                          SizedBox(height: tvScale ? 4 : 8),
+                      ],
+                    ],
+                  ),
                 ),
               ),
             ],
@@ -5660,8 +5703,87 @@ Future<T?> _showSettingsSelectionDialog<T>({
         ),
       ),
     );
-  },
-);
+  }
+
+  Widget _buildOption(
+    BuildContext context,
+    int index, {
+    required bool autofocus,
+    required bool tvScale,
+  }) {
+    final option = widget.options[index];
+    final canFocus = _canFocus(index);
+    final optionContent = Opacity(
+      opacity: option.enabled ? 1 : .45,
+      child: Container(
+        width: double.infinity,
+        padding: EdgeInsets.symmetric(
+          horizontal: tvScale ? 9 : 16,
+          vertical: tvScale ? 6 : 13,
+        ),
+        decoration: BoxDecoration(
+          color: option.value == widget.value
+              ? context.appPalette.accent.withValues(alpha: .28)
+              : context.appPalette.surfaceRaised,
+          borderRadius: BorderRadius.circular(9),
+        ),
+        child: Row(
+          children: [
+            Icon(
+              option.value == widget.value
+                  ? Icons.radio_button_checked_rounded
+                  : Icons.radio_button_off_rounded,
+              color: option.value == widget.value
+                  ? context.appPalette.accentBright
+                  : context.appPalette.mutedText,
+            ),
+            SizedBox(width: tvScale ? 7 : 12),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    option.label,
+                    style: TextStyle(
+                      color: _settingsPrimaryText(context),
+                      fontWeight: FontWeight.w900,
+                    ),
+                  ),
+                  if (option.detail case final detail?) ...[
+                    const SizedBox(height: 2),
+                    Text(
+                      detail,
+                      style: TextStyle(
+                        color: context.appPalette.mutedText,
+                        fontSize: tvScale ? 12 : 11,
+                      ),
+                    ),
+                  ],
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+    final optionControl = TvFocusable(
+      focusNode: _optionFocusNodes[index],
+      autofocus: autofocus,
+      enabled: option.enabled,
+      onKeyEvent: (_, event) => _handleOptionKey(index, event),
+      onPressed: option.enabled
+          ? () => Navigator.of(context).pop(option.value)
+          : () {},
+      borderRadius: BorderRadius.circular(9),
+      child: optionContent,
+    );
+    if (canFocus) return optionControl;
+    return ExcludeFocus(
+      excluding: true,
+      child: IgnorePointer(child: optionControl),
+    );
+  }
+}
 
 class _SettingsSelection<T> extends StatelessWidget {
   const _SettingsSelection({
@@ -7321,6 +7443,7 @@ class _DeveloperUpdatePanel extends StatelessWidget {
               currentVersion: state.currentVersion,
               releaseVersionCode: release.androidVersionCode,
             ),
+            focusableWhenDisabled: true,
           ),
       ],
     );
@@ -7387,6 +7510,7 @@ class _DeveloperUpdatePanel extends StatelessWidget {
                       currentVersion: state.currentVersion,
                       releaseVersionCode: release.androidVersionCode,
                     ),
+                    focusableWhenDisabled: true,
                   ),
               ],
               onSelected: onReleaseSelected,

--- a/lib/features/watch_together/application/watch_party_controller.dart
+++ b/lib/features/watch_together/application/watch_party_controller.dart
@@ -29,8 +29,9 @@ final watchPartyClientProvider = Provider<WatchPartyClient>((ref) {
 
 final watchPartyControllerProvider =
     StateNotifierProvider<WatchPartyController, WatchPartyState>((ref) {
-      return WatchPartyController(
-        ref.watch(watchPartyClientProvider),
+      final client = ref.watch(watchPartyClientProvider);
+      final controller = WatchPartyController(
+        client,
         diagnostics: (message, details) =>
             TetoTvDatabase.instance.recordDiagnosticEvent(
               category: 'watch-party',
@@ -38,10 +39,34 @@ final watchPartyControllerProvider =
               details: details,
             ),
       );
+      ref.listen<WatchPartyPublicIdentity?>(watchPartyPublicIdentityProvider, (
+        previous,
+        identity,
+      ) {
+        if (_samePublicIdentity(previous, identity)) return;
+        unawaited(controller.refreshPublicIdentity(identity));
+      });
+      return controller;
     });
+
+bool _samePublicIdentity(
+  WatchPartyPublicIdentity? left,
+  WatchPartyPublicIdentity? right,
+) =>
+    left?.displayName == right?.displayName &&
+    left?.avatarUrl == right?.avatarUrl;
 
 typedef WatchPartyDiagnosticsSink =
     Future<void> Function(String message, Map<String, Object?> details);
+typedef WatchPartyIdentityRetryDelay = Future<void> Function(Duration delay);
+
+const _watchPartyIdentityRetryDelays = <Duration>[
+  Duration(milliseconds: 250),
+  Duration(milliseconds: 750),
+];
+
+Future<void> _defaultWatchPartyIdentityRetryDelay(Duration delay) =>
+    Future<void>.delayed(delay);
 
 enum WatchPartyConnection { disconnected, connecting, connected, reconnecting }
 
@@ -145,11 +170,17 @@ class WatchPartyState {
 const _unset = Object();
 
 class WatchPartyController extends StateNotifier<WatchPartyState> {
-  WatchPartyController(this._client, {this.diagnostics})
-    : super(const WatchPartyState());
+  WatchPartyController(
+    this._client, {
+    this.diagnostics,
+    WatchPartyIdentityRetryDelay? identityRetryDelay,
+  }) : _identityRetryDelay =
+           identityRetryDelay ?? _defaultWatchPartyIdentityRetryDelay,
+       super(const WatchPartyState());
 
   final WatchPartyClient _client;
   final WatchPartyDiagnosticsSink? diagnostics;
+  final WatchPartyIdentityRetryDelay _identityRetryDelay;
   Timer? _pollTimer;
   StreamSubscription<WatchPartyPlaybackSample>? _playbackSubscription;
   WatchPartyPlaybackPort? _playbackPort;
@@ -176,6 +207,8 @@ class WatchPartyController extends StateNotifier<WatchPartyState> {
   int _lastEventSequence = 0;
   int _localNoticeSequence = 1 << 30;
   bool _membershipActionInFlight = false;
+  bool _identityRefreshInFlight = false;
+  ({WatchPartyPublicIdentity? identity})? _pendingPublicIdentityUpdate;
   String? _pendingGuestSourceKey;
   int _pendingGuestSourceAfterAttachmentGeneration = -1;
   bool _pendingGuestAllowsDifferentSource = false;
@@ -193,6 +226,7 @@ class WatchPartyController extends StateNotifier<WatchPartyState> {
     await _sendLeaveBestEffort(previousSession);
     if (_disposed || generation != _generation) return false;
     try {
+      final requestedIdentity = _client.publicIdentity;
       final created = await _client.create();
       if (generation != _generation) return false;
       final snapshot = await _client.snapshot(created.session);
@@ -209,6 +243,10 @@ class WatchPartyController extends StateNotifier<WatchPartyState> {
         'role': 'host',
         'participant_count': snapshot.participantCount,
       });
+      final currentIdentity = _client.publicIdentity;
+      if (!_samePublicIdentity(requestedIdentity, currentIdentity)) {
+        unawaited(refreshPublicIdentity(currentIdentity));
+      }
       _schedulePoll(generation, immediate: false);
       if (_lastSample != null) unawaited(_publishHostSample(force: true));
       return true;
@@ -241,6 +279,7 @@ class WatchPartyController extends StateNotifier<WatchPartyState> {
     await _sendLeaveBestEffort(previousSession);
     if (_disposed || generation != _generation) return false;
     try {
+      final requestedIdentity = _client.publicIdentity;
       final joined = await _client.join(normalizedCode);
       if (generation != _generation) return false;
       state = state.copyWith(
@@ -258,6 +297,10 @@ class WatchPartyController extends StateNotifier<WatchPartyState> {
         'participant_count': joined.snapshot.participantCount,
         'host_media_available': joined.snapshot.media != null,
       });
+      final currentIdentity = _client.publicIdentity;
+      if (!_samePublicIdentity(requestedIdentity, currentIdentity)) {
+        unawaited(refreshPublicIdentity(currentIdentity));
+      }
       _schedulePoll(generation, immediate: false);
       if (_playbackPort case final port?) {
         final sample = _lastSample;
@@ -302,6 +345,89 @@ class WatchPartyController extends StateNotifier<WatchPartyState> {
     await _sendLeaveBestEffort(previousSession);
     if (_disposed || departureGeneration != _generation) return;
   }
+
+  /// Refreshes the room roster when a tracker profile finishes loading after
+  /// room entry, or clears it when that profile is removed. Failures are
+  /// deliberately non-fatal: playback and polling remain connected, and a
+  /// later identity change can retry the refresh.
+  Future<void> refreshPublicIdentity(WatchPartyPublicIdentity? identity) async {
+    if (_disposed) return;
+    _pendingPublicIdentityUpdate = (identity: identity);
+    if (_identityRefreshInFlight) return;
+    _identityRefreshInFlight = true;
+    try {
+      while (!_disposed) {
+        final pendingUpdate = _pendingPublicIdentityUpdate;
+        if (pendingUpdate == null) break;
+        _pendingPublicIdentityUpdate = null;
+        final pending = pendingUpdate.identity;
+        final session = state.session;
+        final generation = _generation;
+        if (session == null) continue;
+        var attempts = 0;
+        while (_identityRefreshContextIsCurrent(session, generation)) {
+          attempts += 1;
+          try {
+            final snapshot = await _client.updatePublicIdentity(
+              session: session,
+              identity: pending,
+            );
+            if (!_identityRefreshContextIsCurrent(session, generation)) break;
+            await _acceptPolledSnapshot(session, snapshot);
+            _recordDiagnostics('Watch Party public identity refreshed', {
+              'event': 'public_identity_refreshed',
+              'role': session.role.name,
+              'avatar_shared': pending?.avatarUrl != null,
+              'attempt_count': attempts,
+            });
+            break;
+          } on WatchPartyClientException catch (error) {
+            if (!_identityRefreshContextIsCurrent(session, generation)) break;
+            final replacementQueued = _pendingPublicIdentityUpdate != null;
+            final retryIndex = attempts - 1;
+            final canRetry =
+                !replacementQueued &&
+                _publicIdentityRefreshIsTransient(error) &&
+                retryIndex < _watchPartyIdentityRetryDelays.length;
+            if (!canRetry) {
+              // Old brokers return a permanent 404/405 for this append-only
+              // operation. Do not disconnect the room or retry those errors.
+              if (!replacementQueued) {
+                _recordDiagnostics(
+                  'Watch Party public identity refresh failed',
+                  {
+                    'event': 'public_identity_refresh_failed',
+                    'role': session.role.name,
+                    'avatar_shared': pending?.avatarUrl != null,
+                    'error_code': error.code,
+                    'attempt_count': attempts,
+                  },
+                );
+              }
+              break;
+            }
+            await _identityRetryDelay(
+              _watchPartyIdentityRetryDelays[retryIndex],
+            );
+            if (!_identityRefreshContextIsCurrent(session, generation) ||
+                _pendingPublicIdentityUpdate != null) {
+              break;
+            }
+          }
+        }
+      }
+    } finally {
+      _identityRefreshInFlight = false;
+    }
+  }
+
+  bool _identityRefreshContextIsCurrent(
+    WatchPartySession session,
+    int generation,
+  ) =>
+      !_disposed &&
+      generation == _generation &&
+      state.session?.token == session.token;
 
   Future<bool> transferHost(WatchPartyParticipant participant) =>
       _runMembershipAction(participant, transfer: true);
@@ -1359,6 +1485,7 @@ class WatchPartyController extends StateNotifier<WatchPartyState> {
   WatchPartySession? _disconnectLocally() {
     _pollTimer?.cancel();
     _pollTimer = null;
+    _pendingPublicIdentityUpdate = null;
     final session = state.session;
     _guestReady = false;
     _guestReadySession = null;
@@ -1451,6 +1578,14 @@ String watchPartyFriendlyError(WatchPartyClientException error) =>
       'timeout' || 'network_unavailable' =>
         'Watch Party cannot reach the room service right now.',
       _ => 'Watch Party could not complete that request.',
+    };
+
+bool _publicIdentityRefreshIsTransient(WatchPartyClientException error) =>
+    error.code == 'timeout' ||
+    error.code == 'network_unavailable' ||
+    switch (error.statusCode) {
+      final status? => status >= 500 && status <= 599,
+      null => false,
     };
 
 bool _watchPartySnapshotIsOlder(

--- a/lib/features/watch_together/application/watch_party_public_identity_provider.dart
+++ b/lib/features/watch_together/application/watch_party_public_identity_provider.dart
@@ -26,16 +26,54 @@ WatchPartyPublicIdentity? watchPartyPublicIdentityForProfiles({
   required Map<TrackingProvider, TrackingAccountProfile> trackerProfiles,
   required TrackingProvider preferredTracker,
 }) {
+  final preferredProfile = _preferredOrDeterministicTrackerProfile(
+    trackerProfiles,
+    preferredTracker,
+  );
   if (activeLocalProfile case final local?) {
-    return WatchPartyPublicIdentity.tryCreate(displayName: local.displayName);
+    final localNameKey = _publicIdentityNameKey(local.displayName);
+    TrackingAccountProfile? matchingProfile;
+    final selected = trackerProfiles[preferredTracker];
+    if (selected != null &&
+        _publicIdentityNameKey(selected.username) == localNameKey) {
+      matchingProfile = selected;
+    } else {
+      for (final provider in TrackingProvider.values) {
+        final candidate = trackerProfiles[provider];
+        if (candidate != null &&
+            _publicIdentityNameKey(candidate.username) == localNameKey) {
+          matchingProfile = candidate;
+          break;
+        }
+      }
+    }
+    return WatchPartyPublicIdentity.tryCreate(
+      displayName: local.displayName,
+      // Do not associate an unrelated shared-device persona with a tracker
+      // picture. A case-insensitive normalized name match establishes that
+      // the local selection represents the same public tracker persona.
+      avatarUrl: matchingProfile?.avatarUrl,
+    );
   }
-  var profile = trackerProfiles[preferredTracker];
-  if (profile == null && trackerProfiles.isNotEmpty) {
-    profile = trackerProfiles.values.first;
-  }
-  if (profile == null) return null;
+  if (preferredProfile == null) return null;
   return WatchPartyPublicIdentity.tryCreate(
-    displayName: profile.username,
-    avatarUrl: profile.avatarUrl,
+    displayName: preferredProfile.username,
+    avatarUrl: preferredProfile.avatarUrl,
   );
 }
+
+TrackingAccountProfile? _preferredOrDeterministicTrackerProfile(
+  Map<TrackingProvider, TrackingAccountProfile> profiles,
+  TrackingProvider preferredTracker,
+) {
+  final preferred = profiles[preferredTracker];
+  if (preferred != null) return preferred;
+  for (final provider in TrackingProvider.values) {
+    final candidate = profiles[provider];
+    if (candidate != null) return candidate;
+  }
+  return null;
+}
+
+String _publicIdentityNameKey(String value) =>
+    value.trim().replaceAll(RegExp(r'\s+'), ' ').toLowerCase();

--- a/lib/features/watch_together/data/watch_party_client.dart
+++ b/lib/features/watch_together/data/watch_party_client.dart
@@ -3,10 +3,15 @@ import 'package:dio/dio.dart';
 import 'package:flutter/foundation.dart';
 
 class WatchPartyClientException implements Exception {
-  const WatchPartyClientException(this.code, {this.retryAfter});
+  const WatchPartyClientException(
+    this.code, {
+    this.retryAfter,
+    this.statusCode,
+  });
 
   final String code;
   final Duration? retryAfter;
+  final int? statusCode;
 
   @override
   String toString() => code;
@@ -61,6 +66,11 @@ class WatchPartyClient {
   @visibleForTesting
   WatchPartyPublicIdentity? get publicIdentityForTesting => _publicIdentity;
 
+  /// The current public room identity, if tracker/local profile loading has
+  /// completed. This is intentionally the already-sanitized public model and
+  /// never exposes account credentials or tracker identifiers.
+  WatchPartyPublicIdentity? get publicIdentity => _publicIdentity;
+
   Future<bool> health() async {
     final response = await _request(
       'GET',
@@ -68,7 +78,7 @@ class WatchPartyClient {
       authenticated: false,
     );
     final protocol = (response['protocol'] as num?)?.toInt() ?? 0;
-    return response['status'] == 'ok' && protocol >= 1 && protocol <= 4;
+    return response['status'] == 'ok' && protocol >= 1 && protocol <= 5;
   }
 
   Future<WatchPartyCreated> create() async {
@@ -170,6 +180,26 @@ class WatchPartyClient {
         session.roomCode,
       );
 
+  /// Publishes an identity that became available after room entry.
+  ///
+  /// Tracker profiles load asynchronously during app startup. A room can be
+  /// created or joined before that work finishes, so create/join alone cannot
+  /// be the only time an avatar is sent to the broker.
+  Future<WatchPartySnapshot> updatePublicIdentity({
+    required WatchPartySession session,
+    required WatchPartyPublicIdentity? identity,
+  }) async => _snapshotForRoom(
+    await _request(
+      'POST',
+      '/v1/watch-parties/${session.roomCode}/identity',
+      token: session.token,
+      // A null identity explicitly clears public tracker data when a user
+      // signs out or removes the selected profile while the room is active.
+      data: <String, Object?>{'identity': identity?.toJson()},
+    ),
+    session.roomCode,
+  );
+
   Future<WatchPartySnapshot> updateState({
     required WatchPartySession session,
     required int baseRevision,
@@ -233,34 +263,17 @@ class WatchPartyClient {
   Future<WatchPartySnapshot> setReady({
     required WatchPartySession session,
     required bool ready,
-  }) async {
-    final identity = _publicIdentity;
-    Map<String, Object?> value;
-    try {
-      value = await _request(
-        'POST',
-        '/v1/watch-parties/${session.roomCode}/ready',
-        token: session.token,
-        data: <String, Object>{
-          'ready': ready,
-          if (identity != null) 'identity': identity.toJson(),
-        },
-      );
-    } on WatchPartyClientException catch (error) {
-      if (identity == null ||
-          error.code != 'invalid_ready_state' &&
-              error.code != 'invalid_payload') {
-        rethrow;
-      }
-      value = await _request(
-        'POST',
-        '/v1/watch-parties/${session.roomCode}/ready',
-        token: session.token,
-        data: <String, Object>{'ready': ready},
-      );
-    }
-    return _snapshotForRoom(value, session.roomCode);
-  }
+  }) async => _snapshotForRoom(
+    await _request(
+      'POST',
+      '/v1/watch-parties/${session.roomCode}/ready',
+      token: session.token,
+      // Identity has its own serialized endpoint. Keeping readiness free of
+      // identity prevents a slow Ready(A) request from overwriting a newer B.
+      data: <String, Object>{'ready': ready},
+    ),
+    session.roomCode,
+  );
 
   Future<void> leave(WatchPartySession session) async {
     await _request(
@@ -349,6 +362,7 @@ class WatchPartyClient {
         retryAfter: retrySeconds == null
             ? null
             : Duration(seconds: retrySeconds),
+        statusCode: status,
       );
     }
     if (value == null) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: 'none'
 # Public and Beta artifacts built from the same source use one monotonically
 # increasing Android versionCode. The project default carries the Beta display
 # version; the Public universal APK overrides the build name to the 1.x line.
-version: 2.0.60+410037
+version: 2.0.61+410038
 
 environment:
   sdk: ^3.12.2

--- a/test/accounts_focus_test.dart
+++ b/test/accounts_focus_test.dart
@@ -245,9 +245,7 @@ void main() {
         matching: find.byType(TvFocusable),
       );
       final titleLanguageFocusable = find.descendant(
-        of: find.byKey(
-          const ValueKey('settings-appearance-title-language'),
-        ),
+        of: find.byKey(const ValueKey('settings-appearance-title-language')),
         matching: find.byType(TvFocusable),
       );
       final themeStudioRect = tester.getRect(themeStudioFocusable);
@@ -3299,76 +3297,75 @@ void main() {
     expect(tester.takeException(), isNull);
   });
 
-  testWidgets(
-    'device keyboard stays closed while D-pad reaches Debrid results',
-    (tester) async {
-      FlutterSecureStorage.setMockInitialValues({
-        'input_use_built_in_keyboard': 'false',
-      });
-      tester.view.physicalSize = const Size(1280, 720);
-      tester.view.devicePixelRatio = 1;
-      addTearDown(tester.view.resetPhysicalSize);
-      addTearDown(tester.view.resetDevicePixelRatio);
+  testWidgets('device keyboard stays closed while D-pad reaches Debrid results', (
+    tester,
+  ) async {
+    FlutterSecureStorage.setMockInitialValues({
+      'input_use_built_in_keyboard': 'false',
+    });
+    tester.view.physicalSize = const Size(1280, 720);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
 
-      await tester.pumpWidget(
-        const ProviderScope(child: MaterialApp(home: AccountsScreen())),
-      );
+    await tester.pumpWidget(
+      const ProviderScope(child: MaterialApp(home: AccountsScreen())),
+    );
+    await tester.pumpAndSettle();
+
+    await selectSettingsArea(tester, 'services');
+    for (final key in [
+      LogicalKeyboardKey.arrowDown,
+      LogicalKeyboardKey.arrowDown,
+      LogicalKeyboardKey.enter,
+      LogicalKeyboardKey.arrowDown,
+      LogicalKeyboardKey.enter,
+      LogicalKeyboardKey.arrowDown,
+      LogicalKeyboardKey.arrowDown,
+    ]) {
+      await tester.sendKeyEvent(key);
       await tester.pumpAndSettle();
+    }
 
-      await selectSettingsArea(tester, 'services');
-      for (final key in [
-        LogicalKeyboardKey.arrowDown,
-        LogicalKeyboardKey.arrowDown,
-        LogicalKeyboardKey.enter,
-        LogicalKeyboardKey.arrowDown,
-        LogicalKeyboardKey.enter,
-        LogicalKeyboardKey.arrowDown,
-        LogicalKeyboardKey.arrowDown,
-      ]) {
-        await tester.sendKeyEvent(key);
-        await tester.pumpAndSettle();
-      }
+    expect(
+      FocusManager.instance.primaryFocus?.debugLabel,
+      'accounts.torbox.token',
+    );
+    expect(tester.testTextInput.isVisible, isFalse);
 
-      expect(
-        FocusManager.instance.primaryFocus?.debugLabel,
-        'accounts.torbox.token',
-      );
-      expect(tester.testTextInput.isVisible, isFalse);
+    for (var index = 0; index < 7; index++) {
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
+      await tester.pumpAndSettle();
+    }
+    expect(
+      FocusManager.instance.primaryFocus?.debugLabel,
+      'accounts.streaming.debrid-sort',
+    );
+    expect(tester.testTextInput.isVisible, isFalse);
 
-      for (var index = 0; index < 7; index++) {
-        await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
-        await tester.pumpAndSettle();
-      }
-      expect(
-        FocusManager.instance.primaryFocus?.debugLabel,
-        'accounts.streaming.debrid-sort',
-      );
-      expect(tester.testTextInput.isVisible, isFalse);
-
-      for (var index = 0; index < 6; index++) {
-        await tester.sendKeyEvent(LogicalKeyboardKey.arrowUp);
-        await tester.pumpAndSettle();
-      }
-      expect(
-        FocusManager.instance.primaryFocus?.debugLabel,
-        'accounts.torbox.save',
-        reason:
-            'UP from Sources & stream order should enter the final visible Debrid row.',
-      );
+    for (var index = 0; index < 6; index++) {
       await tester.sendKeyEvent(LogicalKeyboardKey.arrowUp);
       await tester.pumpAndSettle();
-      expect(
-        FocusManager.instance.primaryFocus?.debugLabel,
-        'accounts.torbox.token',
-      );
-      expect(tester.testTextInput.isVisible, isFalse);
+    }
+    expect(
+      FocusManager.instance.primaryFocus?.debugLabel,
+      'accounts.torbox.save',
+      reason:
+          'UP from Sources & stream order should enter the final visible Debrid row.',
+    );
+    await tester.sendKeyEvent(LogicalKeyboardKey.arrowUp);
+    await tester.pumpAndSettle();
+    expect(
+      FocusManager.instance.primaryFocus?.debugLabel,
+      'accounts.torbox.token',
+    );
+    expect(tester.testTextInput.isVisible, isFalse);
 
-      await tester.sendKeyEvent(LogicalKeyboardKey.select);
-      await tester.pump();
-      expect(tester.testTextInput.isVisible, isTrue);
-      expect(tester.takeException(), isNull);
-    },
-  );
+    await tester.sendKeyEvent(LogicalKeyboardKey.select);
+    await tester.pump();
+    expect(tester.testTextInput.isVisible, isTrue);
+    expect(tester.takeException(), isNull);
+  });
 }
 
 class _ConnectedRealDebridController extends RealDebridSettingsController {

--- a/test/anime_details_watch_party_action_test.dart
+++ b/test/anime_details_watch_party_action_test.dart
@@ -478,6 +478,7 @@ class _DetailsWatchPartyClient extends WatchPartyClient {
   var createCalls = 0;
   var leaveCalls = 0;
   Completer<void>? createGate;
+  @override
   WatchPartyPublicIdentity? publicIdentity;
   List<WatchPartyParticipant> participants = const [
     WatchPartyParticipant(

--- a/test/app_update_release_date_ui_test.dart
+++ b/test/app_update_release_date_ui_test.dart
@@ -1,5 +1,6 @@
 import 'dart:io';
 
+import 'package:anime_tv/core/tv/tv_focusable.dart';
 import 'package:anime_tv/features/settings/application/app_update_controller.dart';
 import 'package:anime_tv/features/settings/presentation/accounts_screen.dart';
 import 'package:flutter/material.dart';
@@ -182,6 +183,76 @@ void main() {
     );
     expect(tester.takeException(), isNull);
   });
+
+  testWidgets(
+    'release history D-pad focus scrolls through blocked older releases',
+    (tester) async {
+      final releases = List.generate(
+        15,
+        (index) =>
+            _release('2.0.${20 - index}', androidVersionCode: 410020 - index),
+      );
+      await _pumpSystemUpdates(
+        tester,
+        AppUpdateState(
+          phase: AppUpdatePhase.upToDate,
+          currentVersion: '2.0.20+410020',
+          latestVersion: releases.first.version,
+          release: releases.first,
+          updateChannel: AppUpdateChannel.beta,
+          developerMode: true,
+          releaseHistory: releases,
+        ),
+      );
+
+      final installedRelease = find.text('2.0.20 Beta');
+      await tester.ensureVisible(installedRelease);
+      await tester.pumpAndSettle();
+      await tester.tap(installedRelease);
+      await tester.pumpAndSettle();
+
+      expect(
+        FocusManager.instance.primaryFocus?.debugLabel,
+        'settings.selection.Choose a compatible signed release.0',
+      );
+      for (var index = 1; index < releases.length; index++) {
+        await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
+        await tester.pumpAndSettle();
+      }
+
+      expect(
+        FocusManager.instance.primaryFocus?.debugLabel,
+        'settings.selection.Choose a compatible signed release.14',
+      );
+      final dialogScrollable = find.descendant(
+        of: find.byType(Dialog),
+        matching: find.byType(Scrollable),
+      );
+      expect(dialogScrollable, findsOneWidget);
+      final scrollState = tester.state<ScrollableState>(dialogScrollable);
+      expect(scrollState.position.pixels, greaterThan(0));
+
+      final lastRelease = find.text('2.0.6 Beta');
+      expect(lastRelease, findsOneWidget);
+      final blockedReleaseControl = tester.widget<TvFocusable>(
+        find.ancestor(of: lastRelease, matching: find.byType(TvFocusable)),
+      );
+      expect(blockedReleaseControl.enabled, isFalse);
+      final releaseRect = tester.getRect(lastRelease);
+      final scrollRect = tester.getRect(dialogScrollable);
+      expect(releaseRect.top, greaterThanOrEqualTo(scrollRect.top));
+      expect(releaseRect.bottom, lessThanOrEqualTo(scrollRect.bottom));
+
+      await tester.sendKeyEvent(LogicalKeyboardKey.enter);
+      await tester.pumpAndSettle();
+      expect(
+        find.text('Choose a compatible signed release'),
+        findsWidgets,
+        reason: 'A focused blocked downgrade must remain non-selectable.',
+      );
+      expect(tester.takeException(), isNull);
+    },
+  );
 }
 
 Future<void> _pumpSystemUpdates(

--- a/test/local_profiles_test.dart
+++ b/test/local_profiles_test.dart
@@ -134,7 +134,7 @@ void main() {
     );
   });
 
-  test('Watch Party uses active local name without a tracker or avatar', () {
+  test('Watch Party shares an avatar only for the same local persona', () {
     final localIdentity = watchPartyPublicIdentityForProfiles(
       activeLocalProfile: const LocalProfile(
         id: 'localprofile000001',
@@ -151,6 +151,27 @@ void main() {
       preferredTracker: TrackingProvider.anilist,
     );
     expect(localIdentity?.toJson(), {'display_name': 'Living Room'});
+
+    final matchingLocalIdentity = watchPartyPublicIdentityForProfiles(
+      activeLocalProfile: const LocalProfile(
+        id: 'localprofile000002',
+        displayName: '  tracker   USER ',
+      ),
+      trackerProfiles: const {
+        TrackingProvider.anilist: TrackingAccountProfile(
+          provider: TrackingProvider.anilist,
+          username: 'Tracker User',
+          avatarUrl:
+              'https://s4.anilist.co/file/anilistcdn/user/avatar/large/b1.jpg',
+        ),
+      },
+      preferredTracker: TrackingProvider.anilist,
+    );
+    expect(matchingLocalIdentity?.toJson(), {
+      'display_name': 'tracker USER',
+      'avatar_url':
+          'https://s4.anilist.co/file/anilistcdn/user/avatar/large/b1.jpg',
+    });
 
     final trackerIdentity = watchPartyPublicIdentityForProfiles(
       activeLocalProfile: null,

--- a/test/my_list_screen_test.dart
+++ b/test/my_list_screen_test.dart
@@ -365,6 +365,7 @@ void main() {
       find.descendant(of: profileSwitcher, matching: find.byType(TvFocusable)),
     );
     expect(profileFocusable.borderRadius, BorderRadius.circular(13));
+    expect(profileFocusable.showFocusContrastKeyline, isFalse);
     expect(find.byKey(const ValueKey('main-nav-settings')), findsOneWidget);
     expect(find.text('TetoFan'), findsNothing);
     expect(find.text('MALFan'), findsNothing);

--- a/test/tv_focusable_test.dart
+++ b/test/tv_focusable_test.dart
@@ -40,6 +40,104 @@ void main() {
     );
   });
 
+  testWidgets('artwork focus can glow without a dark contrast keyline', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: AppTheme.dark,
+        home: Scaffold(
+          body: TvFocusable(
+            autofocus: true,
+            showFocusContrastKeyline: false,
+            onPressed: () {},
+            child: const SizedBox(width: 52, height: 52),
+          ),
+        ),
+      ),
+    );
+    await tester.pump();
+
+    final animated = tester.widget<AnimatedContainer>(
+      find.byType(AnimatedContainer),
+    );
+    final decoration = animated.decoration! as BoxDecoration;
+    final foreground = animated.foregroundDecoration! as BoxDecoration;
+    expect(decoration.boxShadow, hasLength(1));
+    expect(decoration.boxShadow!.single.color, AppColors.focusGlow);
+    expect(foreground.border!.top.color, AppColors.focusRing);
+    final darkKeylines = tester
+        .widgetList<DecoratedBox>(
+          find.descendant(
+            of: find.byType(TvFocusable),
+            matching: find.byType(DecoratedBox),
+          ),
+        )
+        .where((box) {
+          final boxDecoration = box.decoration;
+          return boxDecoration is BoxDecoration &&
+              boxDecoration.border?.top.color == AppColors.focusInnerKeyline;
+        });
+    expect(darkKeylines, isEmpty);
+  });
+
+  testWidgets(
+    'disabled TV control stays focusable without actions or click feedback',
+    (tester) async {
+      final platformCalls = <MethodCall>[];
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(SystemChannels.platform, (call) async {
+            platformCalls.add(call);
+            return null;
+          });
+      addTearDown(
+        () => TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+            .setMockMethodCallHandler(SystemChannels.platform, null),
+      );
+      var calls = 0;
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: TvFocusable(
+              autofocus: true,
+              enabled: false,
+              onPressed: () => calls++,
+              child: const SizedBox(width: 100, height: 60),
+            ),
+          ),
+        ),
+      );
+      await tester.pump();
+      platformCalls.clear();
+
+      final semantics = tester.widget<Semantics>(
+        find
+            .descendant(
+              of: find.byType(TvFocusable),
+              matching: find.byType(Semantics),
+            )
+            .first,
+      );
+      final gesture = tester.widget<GestureDetector>(
+        find.descendant(
+          of: find.byType(TvFocusable),
+          matching: find.byType(GestureDetector),
+        ),
+      );
+      expect(semantics.properties.enabled, isFalse);
+      expect(gesture.onTap, isNull);
+      expect(FocusManager.instance.primaryFocus?.hasFocus, isTrue);
+
+      await tester.sendKeyEvent(LogicalKeyboardKey.select);
+      await tester.pump();
+      expect(calls, 0);
+      expect(
+        platformCalls.where((call) => call.method == 'SystemSound.play'),
+        isEmpty,
+      );
+    },
+  );
+
   testWidgets('mouse hover receives the same Teto-red focus treatment', (
     tester,
   ) async {

--- a/test/tv_text_input_test.dart
+++ b/test/tv_text_input_test.dart
@@ -1,4 +1,5 @@
 import 'package:anime_tv/core/widgets/tv_text_input.dart';
+import 'package:anime_tv/core/layout/adaptive_layout.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -112,6 +113,16 @@ void main() {
 
     final keyboardPanel = find.byKey(const ValueKey('tv-keyboard-panel'));
     final keyboardRect = tester.getRect(keyboardPanel);
+    expect(
+      keyboardRect.width,
+      inInclusiveRange(790, 825),
+      reason: 'the wide TV QWERTY keyboard is about thirty percent narrower',
+    );
+    expect(
+      keyboardRect.center.dx,
+      closeTo(640, .5),
+      reason: 'the TV QWERTY keyboard stays horizontally centered',
+    );
     expect(
       keyboardRect.height,
       lessThanOrEqualTo(210),
@@ -254,6 +265,16 @@ void main() {
       find.byKey(const ValueKey('tv-keyboard-panel')),
     );
     expect(
+      numericPanelRect.width,
+      inInclusiveRange(400, 420),
+      reason: 'the wide TV number pad is about half its former width',
+    );
+    expect(
+      numericPanelRect.center.dx,
+      closeTo(640, .5),
+      reason: 'the TV number pad stays horizontally centered',
+    );
+    expect(
       numericPanelRect.height,
       lessThanOrEqualTo(225),
       reason: 'the room-code keyboard must keep the compact TV footprint',
@@ -317,5 +338,176 @@ void main() {
     await tester.tap(find.byType(EditableText));
     await tester.pumpAndSettle();
     expect(find.byType(TvKeyboardDialog), findsNothing);
+  });
+
+  testWidgets('remote Back dismisses only the TV keyboard dialog', (
+    tester,
+  ) async {
+    FlutterSecureStorage.setMockInitialValues({
+      'input_use_built_in_keyboard': 'true',
+    });
+    final controller = TextEditingController();
+    addTearDown(controller.dispose);
+    var underlyingBackEvents = 0;
+
+    await tester.pumpWidget(
+      ProviderScope(
+        child: MaterialApp(
+          home: Focus(
+            autofocus: true,
+            onKeyEvent: (_, event) {
+              if (event.logicalKey == LogicalKeyboardKey.goBack) {
+                underlyingBackEvents += 1;
+              }
+              return KeyEventResult.ignored;
+            },
+            child: Scaffold(
+              body: TvTextInput(controller: controller, labelText: 'Search'),
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Search'));
+    await tester.pumpAndSettle();
+    expect(find.byType(TvKeyboardDialog), findsOneWidget);
+
+    await tester.sendKeyDownEvent(
+      LogicalKeyboardKey.goBack,
+      physicalKey: PhysicalKeyboardKey.escape,
+    );
+    await tester.pump();
+    expect(
+      find.byType(TvKeyboardDialog),
+      findsOneWidget,
+      reason: 'the route underneath must not be exposed before key up',
+    );
+    expect(underlyingBackEvents, 0);
+
+    await tester.sendKeyUpEvent(
+      LogicalKeyboardKey.goBack,
+      physicalKey: PhysicalKeyboardKey.escape,
+    );
+    await tester.pumpAndSettle();
+    expect(find.byType(TvKeyboardDialog), findsNothing);
+    expect(
+      underlyingBackEvents,
+      0,
+      reason: 'the complete remote Back press belongs to the keyboard',
+    );
+  });
+
+  testWidgets('QWERTY reduction follows the former width on a 960dp TV', (
+    tester,
+  ) async {
+    tester.view.physicalSize = const Size(960, 540);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(() {
+      tester.view.resetPhysicalSize();
+      tester.view.resetDevicePixelRatio();
+    });
+    FlutterSecureStorage.setMockInitialValues({
+      'input_use_built_in_keyboard': 'true',
+    });
+    final controller = TextEditingController();
+    addTearDown(controller.dispose);
+
+    await tester.pumpWidget(
+      ProviderScope(
+        child: MaterialApp(
+          home: Scaffold(
+            body: TvTextInput(controller: controller, labelText: 'Search'),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Search'));
+    await tester.pumpAndSettle();
+
+    final panel = tester.getRect(
+      find.byKey(const ValueKey('tv-keyboard-panel')),
+    );
+    // The former panel filled 920dp after 20dp side insets; 70% is 644dp.
+    expect(panel.width, closeTo(644, .5));
+    expect(panel.center.dx, closeTo(480, .5));
+  });
+
+  testWidgets('landscape phone keeps the former keyboard width', (
+    tester,
+  ) async {
+    tester.view.physicalSize = const Size(960, 540);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(() {
+      tester.view.resetPhysicalSize();
+      tester.view.resetDevicePixelRatio();
+    });
+    FlutterSecureStorage.setMockInitialValues({
+      'input_use_built_in_keyboard': 'true',
+    });
+    final controller = TextEditingController();
+    addTearDown(controller.dispose);
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [isTelevisionProvider.overrideWith((_) => false)],
+        child: MaterialApp(
+          home: Scaffold(
+            body: TvTextInput(controller: controller, labelText: 'Search'),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Search'));
+    await tester.pumpAndSettle();
+
+    final panel = tester.getRect(
+      find.byKey(const ValueKey('tv-keyboard-panel')),
+    );
+    expect(panel.width, closeTo(920, .5));
+    expect(panel.center.dx, closeTo(480, .5));
+  });
+
+  testWidgets('number-pad reduction follows the former width on a 720dp TV', (
+    tester,
+  ) async {
+    tester.view.physicalSize = const Size(720, 540);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(() {
+      tester.view.resetPhysicalSize();
+      tester.view.resetDevicePixelRatio();
+    });
+    FlutterSecureStorage.setMockInitialValues({
+      'input_use_built_in_keyboard': 'true',
+    });
+    final controller = TextEditingController();
+    addTearDown(controller.dispose);
+
+    await tester.pumpWidget(
+      ProviderScope(
+        child: MaterialApp(
+          home: Scaffold(
+            body: TvTextInput(
+              controller: controller,
+              labelText: 'Room code',
+              numericOnly: true,
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Room code'));
+    await tester.pumpAndSettle();
+
+    final panel = tester.getRect(
+      find.byKey(const ValueKey('tv-keyboard-panel')),
+    );
+    // The former panel filled 680dp after 20dp side insets; half is 340dp.
+    expect(panel.width, closeTo(340, .5));
+    expect(panel.center.dx, closeTo(360, .5));
   });
 }

--- a/test/watch_party_controller_test.dart
+++ b/test/watch_party_controller_test.dart
@@ -38,6 +38,205 @@ void main() {
     expect(controller.state.message, contains('eight-digit'));
   });
 
+  test(
+    'late tracker identity refresh keeps only the newest queued avatar',
+    () async {
+      final firstStarted = Completer<void>();
+      final firstGate = Completer<void>();
+      final client = _FakeWatchPartyClient()
+        ..identityRefreshStarted = firstStarted
+        ..identityRefreshGate = firstGate;
+      final controller = WatchPartyController(client);
+      addTearDown(controller.dispose);
+      expect(await controller.create(), isTrue);
+
+      final first = WatchPartyPublicIdentity.tryCreate(
+        displayName: 'AniList Viewer',
+        avatarUrl: 'https://img.anili.st/user/123/avatar.png',
+      )!;
+      final newest = WatchPartyPublicIdentity.tryCreate(
+        displayName: 'MAL Viewer',
+        avatarUrl:
+            'https://api-cdn.myanimelist.net/images/userimages/456/avatar.jpg?t=1725123456',
+      )!;
+      final refresh = controller.refreshPublicIdentity(first);
+      await firstStarted.future;
+      await controller.refreshPublicIdentity(newest);
+      firstGate.complete();
+      await refresh;
+
+      expect(client.refreshedIdentities.map((item) => item!.toJson()), [
+        {
+          'display_name': 'AniList Viewer',
+          'avatar_url': 'https://img.anili.st/user/123/avatar.png',
+        },
+        {
+          'display_name': 'MAL Viewer',
+          'avatar_url':
+              'https://api-cdn.myanimelist.net/images/userimages/456/avatar.jpg',
+        },
+      ]);
+    },
+  );
+
+  test('queued tracker logout clears a late avatar refresh', () async {
+    final firstStarted = Completer<void>();
+    final firstGate = Completer<void>();
+    final client = _FakeWatchPartyClient()
+      ..identityRefreshStarted = firstStarted
+      ..identityRefreshGate = firstGate;
+    final controller = WatchPartyController(client);
+    addTearDown(controller.dispose);
+    expect(await controller.create(), isTrue);
+
+    final identity = WatchPartyPublicIdentity.tryCreate(
+      displayName: 'AniList Viewer',
+      avatarUrl: 'https://img.anili.st/user/123/avatar.png',
+    )!;
+    final refresh = controller.refreshPublicIdentity(identity);
+    await firstStarted.future;
+    await controller.refreshPublicIdentity(null);
+    firstGate.complete();
+    await refresh;
+
+    expect(client.refreshedIdentities, [identity, null]);
+  });
+
+  test('late identity refresh retries timeout and server failures', () async {
+    final delays = <Duration>[];
+    final client = _FakeWatchPartyClient()
+      ..identityRefreshErrors.addAll(const [
+        WatchPartyClientException('timeout'),
+        WatchPartyClientException('server_error', statusCode: 503),
+      ]);
+    final controller = WatchPartyController(
+      client,
+      identityRetryDelay: (delay) async => delays.add(delay),
+    );
+    addTearDown(controller.dispose);
+    expect(await controller.create(), isTrue);
+    final identity = WatchPartyPublicIdentity.tryCreate(
+      displayName: 'Retry Viewer',
+      avatarUrl: 'https://img.anili.st/user/123/avatar.png',
+    )!;
+
+    await controller.refreshPublicIdentity(identity);
+
+    expect(client.refreshedIdentities, [identity, identity, identity]);
+    expect(delays, const [
+      Duration(milliseconds: 250),
+      Duration(milliseconds: 750),
+    ]);
+  });
+
+  test('unsupported old broker identity route is not retried', () async {
+    final delays = <Duration>[];
+    final client = _FakeWatchPartyClient()
+      ..identityRefreshErrors.add(
+        const WatchPartyClientException('not_found', statusCode: 404),
+      );
+    final controller = WatchPartyController(
+      client,
+      identityRetryDelay: (delay) async => delays.add(delay),
+    );
+    addTearDown(controller.dispose);
+    expect(await controller.create(), isTrue);
+    final identity = WatchPartyPublicIdentity.tryCreate(
+      displayName: 'Old Broker Viewer',
+    )!;
+
+    await controller.refreshPublicIdentity(identity);
+
+    expect(client.refreshedIdentities, [identity]);
+    expect(delays, isEmpty);
+    expect(controller.state.isActive, isTrue);
+  });
+
+  test(
+    'newest identity replaces a stale refresh during retry backoff',
+    () async {
+      final delayStarted = Completer<void>();
+      final delayGate = Completer<void>();
+      final client = _FakeWatchPartyClient()
+        ..identityRefreshErrors.add(
+          const WatchPartyClientException('network_unavailable'),
+        );
+      final controller = WatchPartyController(
+        client,
+        identityRetryDelay: (_) {
+          delayStarted.complete();
+          return delayGate.future;
+        },
+      );
+      addTearDown(controller.dispose);
+      expect(await controller.create(), isTrue);
+      final stale = WatchPartyPublicIdentity.tryCreate(displayName: 'Stale')!;
+      final newest = WatchPartyPublicIdentity.tryCreate(displayName: 'Newest')!;
+
+      final refresh = controller.refreshPublicIdentity(stale);
+      await delayStarted.future;
+      await controller.refreshPublicIdentity(newest);
+      delayGate.complete();
+      await refresh;
+
+      expect(client.refreshedIdentities, [stale, newest]);
+    },
+  );
+
+  test('leaving the room cancels a pending identity retry', () async {
+    final delayStarted = Completer<void>();
+    final delayGate = Completer<void>();
+    final client = _FakeWatchPartyClient()
+      ..identityRefreshErrors.add(const WatchPartyClientException('timeout'));
+    final controller = WatchPartyController(
+      client,
+      identityRetryDelay: (_) {
+        delayStarted.complete();
+        return delayGate.future;
+      },
+    );
+    addTearDown(controller.dispose);
+    expect(await controller.create(), isTrue);
+    final identity = WatchPartyPublicIdentity.tryCreate(
+      displayName: 'Leaving Viewer',
+    )!;
+
+    final refresh = controller.refreshPublicIdentity(identity);
+    await delayStarted.future;
+    await controller.leave();
+    delayGate.complete();
+    await refresh;
+
+    expect(client.refreshedIdentities, [identity]);
+    expect(controller.state.session, isNull);
+  });
+
+  test('disposing the controller cancels a pending identity retry', () async {
+    final delayStarted = Completer<void>();
+    final delayGate = Completer<void>();
+    final client = _FakeWatchPartyClient()
+      ..identityRefreshErrors.add(const WatchPartyClientException('timeout'));
+    final controller = WatchPartyController(
+      client,
+      identityRetryDelay: (_) {
+        delayStarted.complete();
+        return delayGate.future;
+      },
+    );
+    expect(await controller.create(), isTrue);
+    final identity = WatchPartyPublicIdentity.tryCreate(
+      displayName: 'Disposed Viewer',
+    )!;
+
+    final refresh = controller.refreshPublicIdentity(identity);
+    await delayStarted.future;
+    controller.dispose();
+    delayGate.complete();
+    await refresh;
+
+    expect(client.refreshedIdentities, [identity]);
+  });
+
   test('client requires one root HTTPS origin', () {
     for (final value in const [
       'http://tetotv.example',
@@ -52,6 +251,32 @@ void main() {
       );
     }
   });
+
+  test(
+    'client accepts the append-only protocol-v5 broker health response',
+    () async {
+      final dio = Dio(BaseOptions(baseUrl: 'https://tetotv.example'))
+        ..interceptors.add(
+          InterceptorsWrapper(
+            onRequest: (options, handler) => handler.resolve(
+              Response<Object?>(
+                requestOptions: options,
+                statusCode: 200,
+                data: const {'status': 'ok', 'protocol': 5},
+              ),
+            ),
+          ),
+        );
+
+      expect(
+        await WatchPartyClient(
+          baseUrl: 'https://tetotv.example',
+          dio: dio,
+        ).health(),
+        isTrue,
+      );
+    },
+  );
 
   test('only an attached guest yields playback authority to the host', () {
     final guestLobby = WatchPartyState(
@@ -2125,6 +2350,10 @@ class _FakeWatchPartyClient extends WatchPartyClient {
   Completer<void>? leaveStarted;
   Completer<void>? leaveGate;
   int leaveCalls = 0;
+  final refreshedIdentities = <WatchPartyPublicIdentity?>[];
+  final identityRefreshErrors = <WatchPartyClientException>[];
+  Completer<void>? identityRefreshStarted;
+  Completer<void>? identityRefreshGate;
 
   @override
   Future<WatchPartyCreated> create() async =>
@@ -2147,6 +2376,23 @@ class _FakeWatchPartyClient extends WatchPartyClient {
     if (started != null && !started.isCompleted) started.complete();
     await snapshotGate?.future;
     return value;
+  }
+
+  @override
+  Future<WatchPartySnapshot> updatePublicIdentity({
+    required WatchPartySession session,
+    required WatchPartyPublicIdentity? identity,
+  }) async {
+    refreshedIdentities.add(identity);
+    final started = identityRefreshStarted;
+    if (started != null && !started.isCompleted) started.complete();
+    if (identityRefreshErrors.isNotEmpty) {
+      throw identityRefreshErrors.removeAt(0);
+    }
+    final gate = identityRefreshGate;
+    identityRefreshGate = null;
+    await gate?.future;
+    return session.role == WatchPartyRole.host ? hostSnapshot : joinSnapshot;
   }
 
   @override

--- a/test/watch_party_player_dialog_test.dart
+++ b/test/watch_party_player_dialog_test.dart
@@ -225,6 +225,7 @@ class _HudWatchPartyClient extends WatchPartyClient {
   var includeGuest = true;
   var snapshotRole = WatchPartyRole.host;
   var revision = 0;
+  @override
   WatchPartyPublicIdentity? publicIdentity;
 
   @override

--- a/test/watch_party_public_roster_test.dart
+++ b/test/watch_party_public_roster_test.dart
@@ -1,6 +1,8 @@
+import 'dart:async';
 import 'dart:convert';
 
 import 'package:anime_tv/features/auth/domain/tracking_provider.dart';
+import 'package:anime_tv/features/settings/application/local_profiles_controller.dart';
 import 'package:anime_tv/features/settings/application/tracking_accounts_controller.dart';
 import 'package:anime_tv/features/watch_together/application/watch_party_controller.dart';
 import 'package:anime_tv/features/watch_together/application/watch_party_public_identity_provider.dart';
@@ -98,6 +100,60 @@ void main() {
         displayName: List<String>.filled(49, 'x').join(),
       ),
       isNull,
+    );
+  });
+
+  test('matching local persona keeps the preferred tracker public avatar', () {
+    final identity = watchPartyPublicIdentityForProfiles(
+      activeLocalProfile: const LocalProfile(
+        id: 'local-profile-1',
+        displayName: '  shared   VIEWER  ',
+      ),
+      trackerProfiles: const <TrackingProvider, TrackingAccountProfile>{
+        TrackingProvider.anilist: TrackingAccountProfile(
+          provider: TrackingProvider.anilist,
+          username: 'Shared Viewer',
+          avatarUrl: 'https://img.anili.st/user/123/avatar.png',
+        ),
+        TrackingProvider.myAnimeList: TrackingAccountProfile(
+          provider: TrackingProvider.myAnimeList,
+          username: 'shared viewer',
+          avatarUrl:
+              'https://api-cdn.myanimelist.net/images/userimages/456/avatar.jpg',
+        ),
+      },
+      preferredTracker: TrackingProvider.myAnimeList,
+    );
+
+    expect(identity?.toJson(), {
+      'display_name': 'shared VIEWER',
+      'avatar_url':
+          'https://api-cdn.myanimelist.net/images/userimages/456/avatar.jpg',
+    });
+
+    final deterministicFallback = watchPartyPublicIdentityForProfiles(
+      activeLocalProfile: const LocalProfile(
+        id: 'local-profile-2',
+        displayName: 'Shared Viewer',
+      ),
+      trackerProfiles: const <TrackingProvider, TrackingAccountProfile>{
+        TrackingProvider.anilist: TrackingAccountProfile(
+          provider: TrackingProvider.anilist,
+          username: 'Different AniList User',
+          avatarUrl: 'https://img.anili.st/user/999/avatar.png',
+        ),
+        TrackingProvider.myAnimeList: TrackingAccountProfile(
+          provider: TrackingProvider.myAnimeList,
+          username: 'shared viewer',
+          avatarUrl:
+              'https://cdn.myanimelist.net/images/userimages/456/avatar.jpg',
+        ),
+      },
+      preferredTracker: TrackingProvider.anilist,
+    );
+    expect(
+      deterministicFallback?.avatarUrl,
+      'https://cdn.myanimelist.net/images/userimages/456/avatar.jpg',
     );
   });
 
@@ -272,16 +328,12 @@ void main() {
               requests.add(options);
               final attempt = (attempts[options.path] ?? 0) + 1;
               attempts[options.path] = attempt;
-              if (attempt == 1) {
+              if (attempt == 1 && !options.path.endsWith('/ready')) {
                 handler.resolve(
                   Response<Object?>(
                     requestOptions: options,
                     statusCode: 400,
-                    data: {
-                      'error': options.path.endsWith('/ready')
-                          ? 'invalid_ready_state'
-                          : 'invalid_payload',
-                    },
+                    data: const {'error': 'invalid_payload'},
                   ),
                 );
                 return;
@@ -323,8 +375,8 @@ void main() {
       final joined = await client.join('23456789');
       await client.setReady(session: joined.session, ready: true);
 
-      expect(requests, hasLength(6));
-      for (var index = 0; index < requests.length; index += 2) {
+      expect(requests, hasLength(5));
+      for (var index = 0; index < 4; index += 2) {
         final first = requests[index].data as Map;
         final fallback = requests[index + 1].data as Map;
         expect(first['identity'], {
@@ -340,6 +392,188 @@ void main() {
         expect(serialized, isNot(contains('oauth')));
         expect(serialized, isNot(contains('token')));
       }
+      expect(requests.last.path, endsWith('/ready'));
+      expect(requests.last.data, {'ready': true});
+    },
+  );
+
+  test('in-flight Ready cannot carry an identity older than refresh', () async {
+    final readyStarted = Completer<void>();
+    RequestInterceptorHandler? heldReadyHandler;
+    RequestOptions? readyRequest;
+    RequestOptions? identityRequest;
+    final dio = Dio(BaseOptions(baseUrl: 'https://tetotv.example'))
+      ..interceptors.add(
+        InterceptorsWrapper(
+          onRequest: (options, handler) {
+            if (options.path.endsWith('/ready')) {
+              readyRequest = options;
+              heldReadyHandler = handler;
+              readyStarted.complete();
+              return;
+            }
+            identityRequest = options;
+            handler.resolve(
+              Response<Object?>(
+                requestOptions: options,
+                statusCode: 200,
+                data: _snapshotJson(),
+              ),
+            );
+          },
+        ),
+      );
+    final client = WatchPartyClient(
+      baseUrl: 'https://tetotv.example',
+      dio: dio,
+    );
+    final session = WatchPartySession(
+      roomCode: '23456789',
+      token: List<String>.filled(48, 'b').join(),
+      role: WatchPartyRole.guest,
+      expiresAt: DateTime.utc(2030),
+      watchUrl: Uri.parse('https://tetotv.example/watch?room=23456789'),
+    );
+    client.setPublicIdentity(
+      WatchPartyPublicIdentity.tryCreate(displayName: 'Identity A'),
+    );
+
+    final ready = client.setReady(session: session, ready: true);
+    await readyStarted.future;
+    final identityB = WatchPartyPublicIdentity.tryCreate(
+      displayName: 'Identity B',
+      avatarUrl: 'https://img.anili.st/user/123/avatar.png',
+    )!;
+    client.setPublicIdentity(identityB);
+    await client.updatePublicIdentity(session: session, identity: identityB);
+
+    expect(readyRequest?.data, {'ready': true});
+    expect(identityRequest?.data, {
+      'identity': {
+        'display_name': 'Identity B',
+        'avatar_url': 'https://img.anili.st/user/123/avatar.png',
+      },
+    });
+    final handler = heldReadyHandler;
+    expect(handler, isNotNull);
+    handler!.resolve(
+      Response<Object?>(
+        requestOptions: readyRequest!,
+        statusCode: 200,
+        data: _snapshotJson(),
+      ),
+    );
+    await ready;
+  });
+
+  test('client refreshes a late cross-tracker public avatar in the room', () async {
+    RequestOptions? recorded;
+    final dio = Dio(BaseOptions(baseUrl: 'https://tetotv.example'))
+      ..interceptors.add(
+        InterceptorsWrapper(
+          onRequest: (options, handler) {
+            recorded = options;
+            handler.resolve(
+              Response<Object?>(
+                requestOptions: options,
+                statusCode: 200,
+                data: {
+                  ..._snapshotJson(),
+                  'participants': [
+                    {
+                      'display_name': 'AniList Host',
+                      'participant_id': 'abcdefghijklmnop',
+                      'avatar_url': 'https://img.anili.st/user/123/avatar.png',
+                      'role': 'host',
+                      'ready': true,
+                    },
+                    {
+                      'display_name': 'MAL Guest',
+                      'participant_id': 'qrstuvwxyzABCDEF',
+                      'avatar_url':
+                          'https://api-cdn.myanimelist.net/images/userimages/456/avatar.jpg',
+                      'role': 'guest',
+                      'ready': false,
+                    },
+                  ],
+                },
+              ),
+            );
+          },
+        ),
+      );
+    final client = WatchPartyClient(
+      baseUrl: 'https://tetotv.example',
+      dio: dio,
+    );
+    final identity = WatchPartyPublicIdentity.tryCreate(
+      displayName: 'MAL Guest',
+      avatarUrl:
+          'https://api-cdn.myanimelist.net/images/userimages/456/avatar.jpg?t=1725123456',
+    )!;
+    final snapshot = await client.updatePublicIdentity(
+      session: WatchPartySession(
+        roomCode: '23456789',
+        token: List<String>.filled(48, 'b').join(),
+        role: WatchPartyRole.guest,
+        expiresAt: DateTime.utc(2030),
+        watchUrl: Uri.parse('https://tetotv.example/watch?room=23456789'),
+      ),
+      identity: identity,
+    );
+
+    expect(recorded?.method, 'POST');
+    expect(recorded?.path, '/v1/watch-parties/23456789/identity');
+    expect(recorded?.headers['Authorization'], startsWith('Bearer '));
+    expect(recorded?.data, {
+      'identity': {
+        'display_name': 'MAL Guest',
+        'avatar_url':
+            'https://api-cdn.myanimelist.net/images/userimages/456/avatar.jpg',
+      },
+    });
+    expect(snapshot.participants.map((item) => item.avatarUrl), [
+      'https://img.anili.st/user/123/avatar.png',
+      'https://api-cdn.myanimelist.net/images/userimages/456/avatar.jpg',
+    ]);
+  });
+
+  test(
+    'client sends an explicit null identity when tracker data is removed',
+    () async {
+      RequestOptions? recorded;
+      final dio = Dio(BaseOptions(baseUrl: 'https://tetotv.example'))
+        ..interceptors.add(
+          InterceptorsWrapper(
+            onRequest: (options, handler) {
+              recorded = options;
+              handler.resolve(
+                Response<Object?>(
+                  requestOptions: options,
+                  statusCode: 200,
+                  data: _snapshotJson(),
+                ),
+              );
+            },
+          ),
+        );
+      final client = WatchPartyClient(
+        baseUrl: 'https://tetotv.example',
+        dio: dio,
+      );
+
+      await client.updatePublicIdentity(
+        session: WatchPartySession(
+          roomCode: '23456789',
+          token: List<String>.filled(48, 'b').join(),
+          role: WatchPartyRole.guest,
+          expiresAt: DateTime.utc(2030),
+          watchUrl: Uri.parse('https://tetotv.example/watch?room=23456789'),
+        ),
+        identity: null,
+      );
+
+      expect(recorded?.data, {'identity': null});
     },
   );
 }

--- a/tool/release/native_playback_manifest.json
+++ b/tool/release/native_playback_manifest.json
@@ -375,10 +375,10 @@
     {
       "path": "lib/arm64-v8a/libapp.so",
       "size": 12387216,
-      "sha256": "cc3b6b3a257cde3d5d5797771d0b2a3152d7a5ffe5c653a5a580d480424a82d2",
-      "origin": "TetoTV Flutter application AOT 2.0.60",
+      "sha256": "4c4beb32d6d67a8467cb4df379cf185cdce90b8d8c47d30a2419ff5b294a70e2",
+      "origin": "TetoTV Flutter application AOT 2.0.61",
       "license": "MIT",
-      "sourceLocator": "Git tag v2.0.60",
+      "sourceLocator": "Git tag v2.0.61",
       "noticeLocator": "LICENSE"
     },
     {
@@ -423,7 +423,7 @@
       "sha256": "dc05f53278b2733094f12aeaed54c080329309762ce49e6de4118e4bfb0fff55",
       "origin": "TetoTV source build of media-kit Android helper at 42054e5d479f39ccbb0ae604862e2bcaf59b74c2",
       "license": "MIT",
-      "sourceLocator": "TetoTV-v2.0.60-native-playback-sources.zip: sources/media-kit-android-helper-42054e5d479f39ccbb0ae604862e2bcaf59b74c2.zip",
+      "sourceLocator": "TetoTV-v2.0.61-native-playback-sources.zip: sources/media-kit-android-helper-42054e5d479f39ccbb0ae604862e2bcaf59b74c2.zip",
       "noticeLocator": "assets/legal/native/MEDIA_KIT_ANDROID_HELPER_LICENSE.txt; assets/legal/native/NATIVE_PLAYBACK_NOTICE.txt"
     },
     {
@@ -432,7 +432,7 @@
       "sha256": "a7399d0be70844e5ee94cc5b1acc1516571113c50561fe0a5d05b49101c53ef2",
       "origin": "TetoTV source build of the pinned mpv and FFmpeg native playback stack",
       "license": "LGPL-3.0-or-later (conservative combined classification) plus component terms",
-      "sourceLocator": "TetoTV-v2.0.60-native-playback-sources.zip and tool/native/build_native_playback.sh",
+      "sourceLocator": "TetoTV-v2.0.61-native-playback-sources.zip and tool/native/build_native_playback.sh",
       "noticeLocator": "assets/legal/native/NATIVE_PLAYBACK_NOTICE.txt and its referenced exact license assets"
     },
     {
@@ -450,16 +450,16 @@
       "sha256": "263ba714570fb3acfc308cce52776b00506ec8809d225617e52352336144cfa2",
       "origin": "TetoTV source build of the pinned libtorrent4j and libtorrent-rasterbar stack",
       "license": "Mixed MIT, BSD, Boost-1.0, Apache-2.0, and MPL-2.0 component terms",
-      "sourceLocator": "TetoTV-v2.0.60-native-playback-sources.zip and tool/native/build_native_playback.sh",
+      "sourceLocator": "TetoTV-v2.0.61-native-playback-sources.zip and tool/native/build_native_playback.sh",
       "noticeLocator": "assets/legal/native/DIRECT_TORRENT_NATIVE_NOTICE.txt and its referenced exact license assets"
     },
     {
       "path": "lib/armeabi-v7a/libapp.so",
       "size": 13533772,
-      "sha256": "e1e9b0045dc609eb434eb01233edde017b3fc49ddb564bd062c4a81010adb953",
-      "origin": "TetoTV Flutter application AOT 2.0.60",
+      "sha256": "107440008624ef4a9fabd0983e770d0b6810c7891833ef79a4636647d1462761",
+      "origin": "TetoTV Flutter application AOT 2.0.61",
       "license": "MIT",
-      "sourceLocator": "Git tag v2.0.60",
+      "sourceLocator": "Git tag v2.0.61",
       "noticeLocator": "LICENSE"
     },
     {
@@ -504,7 +504,7 @@
       "sha256": "8820a12e07bb3dc45f5b4286acf6918827fba4c265767e7f1cc8f07215c84b6a",
       "origin": "TetoTV source build of media-kit Android helper at 42054e5d479f39ccbb0ae604862e2bcaf59b74c2",
       "license": "MIT",
-      "sourceLocator": "TetoTV-v2.0.60-native-playback-sources.zip: sources/media-kit-android-helper-42054e5d479f39ccbb0ae604862e2bcaf59b74c2.zip",
+      "sourceLocator": "TetoTV-v2.0.61-native-playback-sources.zip: sources/media-kit-android-helper-42054e5d479f39ccbb0ae604862e2bcaf59b74c2.zip",
       "noticeLocator": "assets/legal/native/MEDIA_KIT_ANDROID_HELPER_LICENSE.txt; assets/legal/native/NATIVE_PLAYBACK_NOTICE.txt"
     },
     {
@@ -513,7 +513,7 @@
       "sha256": "d5a220fdf41edde10f161f86addc846ae9cb18137ea48e4db541cd703fec5092",
       "origin": "TetoTV source build of the pinned mpv and FFmpeg native playback stack",
       "license": "LGPL-3.0-or-later (conservative combined classification) plus component terms",
-      "sourceLocator": "TetoTV-v2.0.60-native-playback-sources.zip and tool/native/build_native_playback.sh",
+      "sourceLocator": "TetoTV-v2.0.61-native-playback-sources.zip and tool/native/build_native_playback.sh",
       "noticeLocator": "assets/legal/native/NATIVE_PLAYBACK_NOTICE.txt and its referenced exact license assets"
     },
     {
@@ -531,7 +531,7 @@
       "sha256": "ba0a19d2730969b8e6107db1847888ea8d3b8cafd14a535a3259dd04f8b28d60",
       "origin": "TetoTV source build of the pinned libtorrent4j and libtorrent-rasterbar stack",
       "license": "Mixed MIT, BSD, Boost-1.0, Apache-2.0, and MPL-2.0 component terms",
-      "sourceLocator": "TetoTV-v2.0.60-native-playback-sources.zip and tool/native/build_native_playback.sh",
+      "sourceLocator": "TetoTV-v2.0.61-native-playback-sources.zip and tool/native/build_native_playback.sh",
       "noticeLocator": "assets/legal/native/DIRECT_TORRENT_NATIVE_NOTICE.txt and its referenced exact license assets"
     }
   ],


### PR DESCRIPTION
Fixes the reported TV keyboard behavior and sizing, developer release-history navigation, late cross-provider Watch Party avatars, and compact profile focus treatment.

Includes protocol-v5 Watch Party identity refresh with transient retries, privacy-safe local persona handling, full regression coverage, and Beta 2.0.61 release metadata.

Validation: Flutter full suite, flutter analyze, formatting, release APK verification, broker full suite, TypeScript check/build, and independent focused re-audit.