### PR TITLE
Release Beta 2.0.66

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 
 <p align="center">
   <a href="https://github.com/LindersOSX/TetoTV-Beta/releases/latest"><strong>Download Beta</strong></a>
-  · <a href="docs/RELEASE_NOTES_2.0.65.md">What's new</a>
+  · <a href="docs/RELEASE_NOTES_2.0.66.md">What's new</a>
   · <a href="https://github.com/LindersOSX/TetoTV-Beta/issues/new">Report an issue</a>
   · <a href="https://discord.gg/juC6k7d4WY">Discord</a>
   · <a href="https://www.youtube.com/@TetoTVApp">YouTube</a>
@@ -96,10 +96,10 @@ TetoTV runs directly on the Android device with no companion server required for
 | Channel | Version | Best for |
 | --- | --- | --- |
 | Public | Not published | Source and release-readiness documents are available, but no Public APK is currently offered |
-| Beta | [2.0.65](docs/RELEASE_NOTES_2.0.65.md) | Smoother playback recovery, dependable Recently released results, safer calendar outage handling, and secure SIMKL account linking |
+| Beta | [2.0.66](docs/RELEASE_NOTES_2.0.66.md) | More reliable TorBox pairing, device-aware stream compatibility, paged episode browsing, and persistent update notifications |
 
 > [!WARNING]
-> Beta 2.0.65 uses the repository's explicit unreviewed-Beta exception. Its native-library and corresponding-source material did not receive independent license review, and automated integrity checks are not a legal compliance determination. Read the [complete Beta disclosure](docs/RELEASE_NOTES_2.0.65.md). This exception does not apply to a future Public release.
+> Beta 2.0.66 uses the repository's explicit unreviewed-Beta exception. Its native-library and corresponding-source material did not receive independent license review, and automated integrity checks are not a legal compliance determination. Read the [complete Beta disclosure](docs/RELEASE_NOTES_2.0.66.md). This exception does not apply to a future Public release.
 
 The Public updater repository intentionally has no release while the Public build is held for review. Existing Beta installations continue to update from the Beta repository. Android never permits an in-place install of an APK with a lower build code; Developer Mode does not bypass that platform rule.
 

--- a/docs/BUILD_WINDOWS.md
+++ b/docs/BUILD_WINDOWS.md
@@ -220,39 +220,39 @@ APK containing both supported application ABIs.
 Public and Beta updates use anonymous GitHub requests. No Beta key, GitHub
 token, update-proxy URL, or update-specific Dart define is required. Every
 published APK uses the production signing identity. No Public APK is currently
-published. Beta 2.0.65 uses Android build code `410042`. Flutter reuses
+published. Beta 2.0.66 uses Android build code `410043`. Flutter reuses
 `app-release.apk`, so copy and rename the Beta artifact immediately after the
 build:
 
 ```powershell
-New-Item -ItemType Directory -Force .\build\fire-tv\v2.0.65 | Out-Null
+New-Item -ItemType Directory -Force .\build\fire-tv\v2.0.66 | Out-Null
 
-# Beta 2.0.65
+# Beta 2.0.66
 flutter build apk --release --target-platform android-arm,android-arm64 `
-  --build-name 2.0.65 --build-number 410042 --no-tree-shake-icons
+  --build-name 2.0.66 --build-number 410043 --no-tree-shake-icons
 Copy-Item .\build\app\outputs\flutter-apk\app-release.apk `
-  .\build\fire-tv\v2.0.65\TetoTV-v2.0.65-universal.apk
+  .\build\fire-tv\v2.0.66\TetoTV-v2.0.66-universal.apk
 
 .\tool\release\verify_release_apk.ps1 `
   -Channel Beta `
-  -ApkPath .\build\fire-tv\v2.0.65\TetoTV-v2.0.65-universal.apk
+  -ApkPath .\build\fire-tv\v2.0.66\TetoTV-v2.0.66-universal.apk
 
 .\tool\release\verify_native_redistribution.ps1 `
   -RequireResolvedBinaries `
   -ResolvedBinaryDirectory .\build\native-playback\outputs `
-  -StageBundle -ReleaseTag v2.0.65
+  -StageBundle -ReleaseTag v2.0.66
 
 .\tool\release\new_release_checksums.ps1 `
-  -ApkPath .\build\fire-tv\v2.0.65\TetoTV-v2.0.65-universal.apk `
-  -NativeSourcePath .\build\release-compliance\v2.0.65\TetoTV-v2.0.65-native-playback-sources.zip `
-  -OutputPath .\build\fire-tv\v2.0.65\SHA256SUMS
+  -ApkPath .\build\fire-tv\v2.0.66\TetoTV-v2.0.66-universal.apk `
+  -NativeSourcePath .\build\release-compliance\v2.0.66\TetoTV-v2.0.66-native-playback-sources.zip `
+  -OutputPath .\build\fire-tv\v2.0.66\SHA256SUMS
 
 .\tool\release\verify_release_payloads.ps1 `
   -Channel Beta `
-  -ApkPath .\build\fire-tv\v2.0.65\TetoTV-v2.0.65-universal.apk `
-  -NativeSourcePath .\build\release-compliance\v2.0.65\TetoTV-v2.0.65-native-playback-sources.zip `
-  -ChecksumsPath .\build\fire-tv\v2.0.65\SHA256SUMS `
-  -ReleaseNotesPath .\docs\RELEASE_NOTES_2.0.65.md `
+  -ApkPath .\build\fire-tv\v2.0.66\TetoTV-v2.0.66-universal.apk `
+  -NativeSourcePath .\build\release-compliance\v2.0.66\TetoTV-v2.0.66-native-playback-sources.zip `
+  -ChecksumsPath .\build\fire-tv\v2.0.66\SHA256SUMS `
+  -ReleaseNotesPath .\docs\RELEASE_NOTES_2.0.66.md `
   -ResolvedBinaryDirectory .\build\native-playback\outputs
 ```
 

--- a/docs/RELEASE_NOTES_2.0.66.md
+++ b/docs/RELEASE_NOTES_2.0.66.md
@@ -1,0 +1,31 @@
+# TetoTV 2.0.66 Beta
+
+> [!WARNING]
+> No independent native-license review: This Beta has not received independent native-library licensing review. Automated checks verify the APK, native-source bundle, notices, pinned inputs, and checksums, but do not establish legal compliance or reproducible builds.
+
+This Beta improves TorBox linking, filters incompatible streams for each device, adds faster episode browsing, and introduces a persistent app-update inbox.
+
+## What's changed
+
+- TorBox device linking now survives temporary DNS or network failures and remains active while the user switches to a phone browser to approve the code, instead of timing out or failing the pairing screen prematurely.
+- Stream results now use the Android device's actual hardware-decoder inventory. A stream is hidden only when its advertised codec and resolution are proven unsupported on that device; unknown codec or device data remains visible. This prevents AV1 streams from appearing on an AVC-only TV while preserving uncertain results.
+- Pressing Down from the episode selector now opens a TV-friendly paged browser with series artwork, runtime, clear page controls, direct episode-number entry, and polished handling for episodes or entire series that have not aired yet. Releasing titles also show the next known air date or countdown when AniList provides it.
+- A notification bell beside the profile picture now keeps app-update notices until they are read. The inbox shows release details and current download state, with actions to check, retry, download, or install an update.
+- Automatic update checks no longer open Android's installer without user intent; completed downloads wait in the notification panel until the user chooses to install.
+- Temporary SIMKL availability problems are classified correctly and no longer create misleading anonymous crash reports.
+- AI-assisted development disclosure: AI tools assisted with implementation, documentation, tests, and review. The project owner directed the work, validated the changes, and remains responsible for this release.
+
+## Release assets
+
+- `TetoTV-v2.0.66-universal.apk` — install this file on a supported Android device.
+- `TetoTV-v2.0.66-native-playback-sources.zip` — native playback source and license material for developers and compliance review; normal users do not need it.
+- `SHA256SUMS` — integrity hashes for the two files above.
+
+## Beta notes
+
+- This is a Beta-channel build with Android build code `410043`.
+- No Public APK is being published with this release.
+- Codec compatibility is evaluated locally per device. Known-incompatible results are hidden, while missing or ambiguous capability data safely leaves results available.
+- Android does not permit an in-place install over an APK with a higher build code. A future Public counterpart must use build code `410043` or newer for data-preserving channel switching.
+
+<!-- tetotv-android-version-code: 410043 -->

--- a/docs/UPDATE_CHANNELS.md
+++ b/docs/UPDATE_CHANNELS.md
@@ -35,11 +35,11 @@ Beta reads completed 2.x releases from:
 https://api.github.com/repos/LindersOSX/TetoTV-Beta/releases/latest
 ```
 
-The current Beta source build is `v2.0.65` with Android build code `410042`.
+The current Beta source build is `v2.0.66` with Android build code `410043`.
 Its release title is:
 
 ```text
-TetoTV 2.0.65 Beta - Android TV / Google TV / Fire TV
+TetoTV 2.0.66 Beta - Android TV / Google TV / Fire TV
 ```
 
 Publish it as a normal, non-draft, non-prerelease GitHub release so
@@ -72,7 +72,7 @@ proxy.
 Release notes must include the exact asset names and this build-code marker:
 
 ```html
-<!-- tetotv-android-version-code: 410042 -->
+<!-- tetotv-android-version-code: 410043 -->
 ```
 
 When build-code metadata is present, the updater rejects a known lower build
@@ -94,10 +94,10 @@ These rules apply equally on phones, Android TV, Google TV, and Fire TV.
 
 ## Switching and rollback
 
-The current Beta uses build code `410042`. No Public counterpart is available.
+The current Beta uses build code `410043`. No Public counterpart is available.
 An older Public install can move to this Beta when Android accepts the higher
 build code, but it cannot move back in place until a future Public build uses
-code `410042` or higher. Uninstalling first permits an older APK but deletes
+code `410043` or higher. Uninstalling first permits an older APK but deletes
 local application data. Developer Mode and in-app settings cannot override
 this Android rule.
 

--- a/lib/core/diagnostics/anonymous_crash_reporter.dart
+++ b/lib/core/diagnostics/anonymous_crash_reporter.dart
@@ -413,6 +413,7 @@ bool _isUnexpectedHandledError(Object error) {
       type == 'webprovidersearchcancelled' ||
       type == 'webstreampreflightfailure' ||
       type == 'catalogtrackingvalidationerror' ||
+      type == 'simklbrokernotconfigured' ||
       type == '_discordauthenticationabandoned') {
     return false;
   }

--- a/lib/core/notifications/app_notification.dart
+++ b/lib/core/notifications/app_notification.dart
@@ -1,0 +1,54 @@
+enum AppNotificationKind { appUpdate }
+
+enum AppNotificationAction { openAppUpdates }
+
+/// A durable, local-only notification shown by TetoTV's in-app inbox.
+///
+/// Update notices deliberately store a constrained action instead of an
+/// arbitrary URL. This keeps persisted data from becoming a navigation or
+/// deep-link injection surface.
+class AppNotification {
+  const AppNotification({
+    required this.id,
+    required this.kind,
+    required this.title,
+    required this.body,
+    required this.action,
+    required this.createdAtUtc,
+    this.readAtUtc,
+    this.targetVersion,
+    this.targetVersionCode,
+    this.targetChannel,
+  });
+
+  final String id;
+  final AppNotificationKind kind;
+  final String title;
+  final String body;
+  final AppNotificationAction action;
+  final DateTime createdAtUtc;
+  final DateTime? readAtUtc;
+  final String? targetVersion;
+  final int? targetVersionCode;
+  final String? targetChannel;
+
+  bool get isRead => readAtUtc != null;
+
+  String get actionRoute => switch (action) {
+    AppNotificationAction.openAppUpdates =>
+      '/settings/accounts?section=app-updates',
+  };
+
+  AppNotification copyWith({DateTime? readAtUtc}) => AppNotification(
+    id: id,
+    kind: kind,
+    title: title,
+    body: body,
+    action: action,
+    createdAtUtc: createdAtUtc,
+    readAtUtc: readAtUtc ?? this.readAtUtc,
+    targetVersion: targetVersion,
+    targetVersionCode: targetVersionCode,
+    targetChannel: targetChannel,
+  );
+}

--- a/lib/core/notifications/app_notification.dart
+++ b/lib/core/notifications/app_notification.dart
@@ -34,11 +34,6 @@ class AppNotification {
 
   bool get isRead => readAtUtc != null;
 
-  String get actionRoute => switch (action) {
-    AppNotificationAction.openAppUpdates =>
-      '/settings/accounts?section=app-updates',
-  };
-
   AppNotification copyWith({DateTime? readAtUtc}) => AppNotification(
     id: id,
     kind: kind,

--- a/lib/core/notifications/app_notification_controller.dart
+++ b/lib/core/notifications/app_notification_controller.dart
@@ -1,0 +1,221 @@
+import 'dart:async';
+
+import 'package:anime_tv/core/notifications/app_notification.dart';
+import 'package:anime_tv/core/notifications/app_notification_store.dart';
+import 'package:anime_tv/core/storage/storage_providers.dart';
+import 'package:anime_tv/features/settings/application/app_update_controller.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+final appNotificationControllerProvider =
+    StateNotifierProvider<AppNotificationController, AppNotificationState>((
+      ref,
+    ) {
+      final controller = AppNotificationController(
+        AppNotificationStore(ref.watch(tetoTvDatabaseProvider)),
+      );
+      unawaited(controller.load());
+      ref.listen<AppUpdateState>(
+        appUpdateControllerProvider,
+        (_, next) => unawaited(controller.syncAppUpdate(next)),
+        fireImmediately: true,
+      );
+      return controller;
+    });
+
+class AppNotificationState {
+  const AppNotificationState({
+    this.loaded = false,
+    this.items = const [],
+    this.errorMessage,
+  });
+
+  final bool loaded;
+  final List<AppNotification> items;
+  final String? errorMessage;
+
+  int get unreadCount => items.where((item) => !item.isRead).length;
+
+  AppNotificationState copyWith({
+    bool? loaded,
+    List<AppNotification>? items,
+    String? errorMessage,
+    bool clearError = false,
+  }) => AppNotificationState(
+    loaded: loaded ?? this.loaded,
+    items: items ?? this.items,
+    errorMessage: clearError ? null : errorMessage ?? this.errorMessage,
+  );
+}
+
+typedef AppNotificationClock = DateTime Function();
+
+class AppNotificationController extends StateNotifier<AppNotificationState> {
+  AppNotificationController(this._store, {this._clock = _utcNow})
+    : super(const AppNotificationState());
+
+  final AppNotificationStore _store;
+  final AppNotificationClock _clock;
+  Future<void> _pendingMutation = Future.value();
+
+  Future<void> load() => _enqueue(() async {
+    await _reload();
+  });
+
+  /// Reconciles the inbox with the validated state produced by the updater.
+  ///
+  /// The call is serialized and fully caught so a database problem can never
+  /// bubble through an updater listener and break the update itself.
+  Future<void> syncAppUpdate(AppUpdateState update) => _enqueue(() async {
+    if (!update.loaded) return;
+    if (!state.loaded) await _reload();
+
+    final obsolete = state.items
+        .where((item) => _isInstalledUpdate(item, update.currentVersion))
+        .map((item) => item.id);
+    await _store.deleteIds(obsolete);
+
+    if (update.phase == AppUpdatePhase.upToDate) {
+      await _store.deleteAppUpdatesForChannel(update.updateChannel.name);
+    } else if (_canCreateUpdateNotification(update)) {
+      final notification = _notificationFor(update, _clock().toUtc());
+      await _store.deleteIds(
+        state.items
+            .where(
+              (item) =>
+                  item.kind == AppNotificationKind.appUpdate &&
+                  item.targetChannel == update.updateChannel.name &&
+                  item.id != notification.id,
+            )
+            .map((item) => item.id),
+      );
+      await _store.upsert(notification);
+    }
+    await _reload();
+  });
+
+  Future<void> markRead(String id) => _enqueue(() async {
+    await _store.markRead(id, _clock().toUtc());
+    await _reload();
+  });
+
+  Future<void> markAllRead() => _enqueue(() async {
+    await _store.markAllRead(_clock().toUtc());
+    await _reload();
+  });
+
+  Future<void> _reload() async {
+    final items = await _store.load();
+    if (!mounted) return;
+    state = state.copyWith(loaded: true, items: items, clearError: true);
+  }
+
+  Future<void> _enqueue(Future<void> Function() operation) {
+    final next = _pendingMutation.then((_) async {
+      try {
+        await operation();
+      } catch (_) {
+        if (mounted) {
+          state = state.copyWith(
+            loaded: true,
+            errorMessage: 'Could not update notifications.',
+          );
+        }
+      }
+    });
+    _pendingMutation = next;
+    return next;
+  }
+}
+
+bool _canCreateUpdateNotification(AppUpdateState update) {
+  final release = update.release;
+  if (release == null) return false;
+  final relevantPhase = switch (update.phase) {
+    AppUpdatePhase.available ||
+    AppUpdatePhase.downloading ||
+    AppUpdatePhase.ready ||
+    AppUpdatePhase.installing => true,
+    _ => false,
+  };
+  return relevantPhase &&
+      shouldOfferAppRelease(
+        currentVersion: update.currentVersion,
+        releaseVersion: release.version,
+        channel: update.updateChannel,
+        releaseVersionCode: release.androidVersionCode,
+      );
+}
+
+AppNotification _notificationFor(AppUpdateState update, DateTime createdAtUtc) {
+  final release = update.release!;
+  final channel = update.updateChannel;
+  final targetVersion = normalizeAppVersion(release.version);
+  final identity = release.androidVersionCode == null
+      ? targetVersion
+      : '$targetVersion@${release.androidVersionCode}';
+  return AppNotification(
+    id: 'app-update:${channel.name}:$identity',
+    kind: AppNotificationKind.appUpdate,
+    title: 'TetoTV ${channel.versionLabel(targetVersion)} is available',
+    body: _releaseNotesSummary(release.notes, channel),
+    action: AppNotificationAction.openAppUpdates,
+    createdAtUtc: createdAtUtc,
+    targetVersion: targetVersion,
+    targetVersionCode: release.androidVersionCode,
+    targetChannel: channel.name,
+  );
+}
+
+bool _isInstalledUpdate(AppNotification item, String currentVersion) {
+  if (item.kind != AppNotificationKind.appUpdate ||
+      item.targetVersion == null ||
+      item.targetChannel == null ||
+      currentVersion == 'unknown') {
+    return false;
+  }
+  AppUpdateChannel? channel;
+  for (final candidate in AppUpdateChannel.values) {
+    if (candidate.name == item.targetChannel) {
+      channel = candidate;
+      break;
+    }
+  }
+  if (channel == null ||
+      appVersionMajor(currentVersion) != channel.releaseMajor) {
+    return false;
+  }
+  return !shouldOfferAppRelease(
+    currentVersion: currentVersion,
+    releaseVersion: item.targetVersion!,
+    channel: channel,
+    releaseVersionCode: item.targetVersionCode,
+  );
+}
+
+DateTime _utcNow() => DateTime.now().toUtc();
+
+String _releaseNotesSummary(String notes, AppUpdateChannel channel) {
+  var plainText = notes
+      .replaceAll(RegExp(r'```[\s\S]*?```'), ' ')
+      .replaceAll(RegExp(r'!\[[^\]]*\]\([^)]*\)'), ' ')
+      .replaceAllMapped(
+        RegExp(r'\[([^\]]+)\]\([^)]*\)'),
+        (match) => match.group(1) ?? '',
+      )
+      .replaceAll(RegExp(r'<[^>]*>'), ' ')
+      .replaceAll(RegExp(r'https?://\S+', caseSensitive: false), ' ')
+      .replaceAll(RegExp(r'[#>*_`~|]+'), ' ')
+      .replaceAll(RegExp(r'\s+'), ' ')
+      .trim();
+  if (plainText.isEmpty) {
+    return 'A new ${channel.displayName} update is ready to install from TetoTV settings.';
+  }
+  const maximumLength = 480;
+  if (plainText.length <= maximumLength) return plainText;
+  plainText = plainText.substring(0, maximumLength - 1).trimRight();
+  final lastSpace = plainText.lastIndexOf(' ');
+  if (lastSpace >= maximumLength ~/ 2) {
+    plainText = plainText.substring(0, lastSpace);
+  }
+  return '$plainText…';
+}

--- a/lib/core/notifications/app_notification_controller.dart
+++ b/lib/core/notifications/app_notification_controller.dart
@@ -14,9 +14,24 @@ final appNotificationControllerProvider =
         AppNotificationStore(ref.watch(tetoTvDatabaseProvider)),
       );
       unawaited(controller.load());
-      ref.listen<AppUpdateState>(
-        appUpdateControllerProvider,
-        (_, next) => unawaited(controller.syncAppUpdate(next)),
+      // Download progress can update the updater state once per percentage.
+      // Reconcile only when notification-relevant identity/state changes so a
+      // large APK does not enqueue a hundred redundant SQLite transactions.
+      ref.listen(
+        appUpdateControllerProvider.select(
+          (state) => (
+            loaded: state.loaded,
+            phase: state.phase,
+            currentVersion: state.currentVersion,
+            releaseVersion: state.release?.version,
+            releaseVersionCode: state.release?.androidVersionCode,
+            releaseNotes: state.release?.notes,
+            channel: state.updateChannel,
+          ),
+        ),
+        (_, _) => unawaited(
+          controller.syncAppUpdate(ref.read(appUpdateControllerProvider)),
+        ),
         fireImmediately: true,
       );
       return controller;
@@ -68,6 +83,11 @@ class AppNotificationController extends StateNotifier<AppNotificationState> {
   Future<void> syncAppUpdate(AppUpdateState update) => _enqueue(() async {
     if (!update.loaded) return;
     if (!state.loaded) await _reload();
+
+    // Only the selected channel can be checked or installed. Keeping a notice
+    // from the previous channel would give it a button that cannot act on the
+    // release it describes, so discard it as soon as the preference changes.
+    await _store.deleteAppUpdatesOutsideChannel(update.updateChannel.name);
 
     final obsolete = state.items
         .where((item) => _isInstalledUpdate(item, update.currentVersion))

--- a/lib/core/notifications/app_notification_store.dart
+++ b/lib/core/notifications/app_notification_store.dart
@@ -1,0 +1,140 @@
+import 'package:anime_tv/core/notifications/app_notification.dart';
+import 'package:anime_tv/core/storage/tetotv_database.dart';
+
+class AppNotificationStore {
+  const AppNotificationStore(this._database);
+
+  final TetoTvDatabase _database;
+
+  Future<List<AppNotification>> load() async {
+    final database = await _database.database;
+    final rows = await database.query(
+      'app_notifications',
+      orderBy: 'created_at DESC, id ASC',
+    );
+    return rows.map(_notificationFromRow).toList(growable: false);
+  }
+
+  /// Creates or refreshes a notification without making a previously-read
+  /// item unread again.
+  Future<void> upsert(AppNotification notification) async {
+    final database = await _database.database;
+    await database.transaction((transaction) async {
+      final existing = await transaction.query(
+        'app_notifications',
+        columns: const ['id'],
+        where: 'id = ?',
+        whereArgs: [notification.id],
+        limit: 1,
+      );
+      final values = _notificationToRow(notification);
+      if (existing.isEmpty) {
+        await transaction.insert('app_notifications', values);
+        return;
+      }
+      values
+        ..remove('created_at')
+        ..remove('read_at');
+      await transaction.update(
+        'app_notifications',
+        values,
+        where: 'id = ?',
+        whereArgs: [notification.id],
+      );
+    });
+  }
+
+  Future<void> markRead(String id, DateTime readAtUtc) async {
+    final database = await _database.database;
+    await database.update(
+      'app_notifications',
+      {'read_at': readAtUtc.toUtc().millisecondsSinceEpoch},
+      where: 'id = ? AND read_at IS NULL',
+      whereArgs: [id],
+    );
+  }
+
+  Future<void> markAllRead(DateTime readAtUtc) async {
+    final database = await _database.database;
+    await database.update('app_notifications', {
+      'read_at': readAtUtc.toUtc().millisecondsSinceEpoch,
+    }, where: 'read_at IS NULL');
+  }
+
+  Future<void> deleteIds(Iterable<String> ids) async {
+    final normalized = ids.toSet().toList(growable: false);
+    if (normalized.isEmpty) return;
+    final database = await _database.database;
+    await database.transaction((transaction) async {
+      for (final id in normalized) {
+        await transaction.delete(
+          'app_notifications',
+          where: 'id = ?',
+          whereArgs: [id],
+        );
+      }
+    });
+  }
+
+  Future<void> deleteAppUpdatesForChannel(String channel) async {
+    final database = await _database.database;
+    await database.delete(
+      'app_notifications',
+      where: 'kind = ? AND target_channel = ?',
+      whereArgs: ['app_update', channel],
+    );
+  }
+}
+
+Map<String, Object?> _notificationToRow(AppNotification notification) => {
+  'id': notification.id,
+  'kind': _kindName(notification.kind),
+  'title': notification.title,
+  'body': notification.body,
+  'action': _actionName(notification.action),
+  'target_version': notification.targetVersion,
+  'target_version_code': notification.targetVersionCode,
+  'target_channel': notification.targetChannel,
+  'created_at': notification.createdAtUtc.toUtc().millisecondsSinceEpoch,
+  'read_at': notification.readAtUtc?.toUtc().millisecondsSinceEpoch,
+};
+
+AppNotification _notificationFromRow(Map<String, Object?> row) {
+  final kind = switch (row['kind']) {
+    'app_update' => AppNotificationKind.appUpdate,
+    _ => throw const FormatException('Unknown app notification kind.'),
+  };
+  final action = switch (row['action']) {
+    'open_app_updates' => AppNotificationAction.openAppUpdates,
+    _ => throw const FormatException('Unknown app notification action.'),
+  };
+  return AppNotification(
+    id: row['id']! as String,
+    kind: kind,
+    title: row['title']! as String,
+    body: row['body']! as String,
+    action: action,
+    targetVersion: row['target_version'] as String?,
+    targetVersionCode: row['target_version_code'] as int?,
+    targetChannel: row['target_channel'] as String?,
+    createdAtUtc: DateTime.fromMillisecondsSinceEpoch(
+      row['created_at']! as int,
+      isUtc: true,
+    ),
+    readAtUtc: switch (row['read_at']) {
+      final int value => DateTime.fromMillisecondsSinceEpoch(
+        value,
+        isUtc: true,
+      ),
+      _ => null,
+    },
+  );
+}
+
+String _kindName(AppNotificationKind kind) => switch (kind) {
+  AppNotificationKind.appUpdate => 'app_update',
+};
+
+String _actionName(AppNotificationAction action) => switch (action) {
+  AppNotificationAction.openAppUpdates => 'open_app_updates',
+};

--- a/lib/core/notifications/app_notification_store.dart
+++ b/lib/core/notifications/app_notification_store.dart
@@ -46,19 +46,28 @@ class AppNotificationStore {
 
   Future<void> markRead(String id, DateTime readAtUtc) async {
     final database = await _database.database;
-    await database.update(
-      'app_notifications',
-      {'read_at': readAtUtc.toUtc().millisecondsSinceEpoch},
-      where: 'id = ? AND read_at IS NULL',
-      whereArgs: [id],
+    final timestamp = readAtUtc.toUtc().millisecondsSinceEpoch;
+    await database.rawUpdate(
+      '''
+        UPDATE app_notifications
+        SET read_at = CASE WHEN created_at > ? THEN created_at ELSE ? END
+        WHERE id = ? AND read_at IS NULL
+      ''',
+      [timestamp, timestamp, id],
     );
   }
 
   Future<void> markAllRead(DateTime readAtUtc) async {
     final database = await _database.database;
-    await database.update('app_notifications', {
-      'read_at': readAtUtc.toUtc().millisecondsSinceEpoch,
-    }, where: 'read_at IS NULL');
+    final timestamp = readAtUtc.toUtc().millisecondsSinceEpoch;
+    await database.rawUpdate(
+      '''
+        UPDATE app_notifications
+        SET read_at = CASE WHEN created_at > ? THEN created_at ELSE ? END
+        WHERE read_at IS NULL
+      ''',
+      [timestamp, timestamp],
+    );
   }
 
   Future<void> deleteIds(Iterable<String> ids) async {
@@ -81,6 +90,15 @@ class AppNotificationStore {
     await database.delete(
       'app_notifications',
       where: 'kind = ? AND target_channel = ?',
+      whereArgs: ['app_update', channel],
+    );
+  }
+
+  Future<void> deleteAppUpdatesOutsideChannel(String channel) async {
+    final database = await _database.database;
+    await database.delete(
+      'app_notifications',
+      where: 'kind = ? AND target_channel != ?',
       whereArgs: ['app_update', channel],
     );
   }

--- a/lib/core/storage/tetotv_database.dart
+++ b/lib/core/storage/tetotv_database.dart
@@ -9,7 +9,7 @@ import 'package:sqflite/sqflite.dart';
 /// The SQLite table survives process death; it is never uploaded unless the
 /// user presses the diagnostic-report share button.
 const diagnosticHistoryWindow = Duration(hours: 48);
-const tetoTvDatabaseSchemaVersion = 10;
+const tetoTvDatabaseSchemaVersion = 11;
 // Provider searches and playback startup can each emit a burst of events.
 // Retain enough history for a complete search plus the playback which follows
 // it; 240 entries allowed title-artwork noise to evict the evidence needed to
@@ -540,6 +540,7 @@ class TetoTvDatabase {
         await _createReliabilityTables(db);
         await createOfflineDownloadTables(db);
         await createMangaTables(db);
+        await createAppNotificationsTable(db);
       },
       onUpgrade: upgradeTetoTvDatabaseSchema,
     );
@@ -1199,6 +1200,44 @@ Future<void> upgradeTetoTvDatabaseSchema(
   if (oldVersion < 10 && newVersion >= 10) {
     await createMangaTables(db);
   }
+  if (oldVersion < 11 && newVersion >= 11) {
+    await createAppNotificationsTable(db);
+  }
+}
+
+/// Creates the local in-app notification inbox.
+///
+/// Actions are an allowlisted enum rather than arbitrary URLs so a corrupted
+/// database row cannot turn a notification into an unsafe deep link.
+Future<void> createAppNotificationsTable(DatabaseExecutor db) async {
+  await db.execute('''
+    CREATE TABLE IF NOT EXISTS app_notifications (
+      id TEXT PRIMARY KEY,
+      kind TEXT NOT NULL,
+      title TEXT NOT NULL,
+      body TEXT NOT NULL,
+      action TEXT NOT NULL,
+      target_version TEXT,
+      target_version_code INTEGER,
+      target_channel TEXT,
+      created_at INTEGER NOT NULL,
+      read_at INTEGER,
+      CHECK(length(id) BETWEEN 1 AND 192),
+      CHECK(kind IN ('app_update')),
+      CHECK(length(title) BETWEEN 1 AND 256),
+      CHECK(length(body) BETWEEN 1 AND 512),
+      CHECK(action IN ('open_app_updates')),
+      CHECK(target_version IS NULL OR length(target_version) BETWEEN 1 AND 64),
+      CHECK(target_version_code IS NULL OR target_version_code > 0),
+      CHECK(target_channel IS NULL OR target_channel IN ('public', 'beta')),
+      CHECK(created_at >= 0),
+      CHECK(read_at IS NULL OR read_at >= 0)
+    )
+  ''');
+  await db.execute('''
+    CREATE INDEX IF NOT EXISTS app_notifications_unread_created
+    ON app_notifications(read_at, created_at DESC)
+  ''');
 }
 
 /// Creates the developer-only manga catalog, reading-progress, and offline

--- a/lib/features/auth/data/torbox_device_auth_client.dart
+++ b/lib/features/auth/data/torbox_device_auth_client.dart
@@ -1,10 +1,15 @@
 import 'package:dio/dio.dart';
 
 class TorBoxDeviceAuthException implements Exception {
-  const TorBoxDeviceAuthException(this.message, {this.code});
+  const TorBoxDeviceAuthException(
+    this.message, {
+    this.code,
+    this.retryable = false,
+  });
 
   final String message;
   final String? code;
+  final bool retryable;
 
   @override
   String toString() => message;
@@ -91,56 +96,126 @@ class TorBoxDeviceAuthClient {
   final Dio _dio;
 
   Future<TorBoxDeviceSession> start() async {
-    final response = await _dio.get<Map<String, dynamic>>(
-      '/user/auth/device/start',
-      queryParameters: const {'app': 'TetoTV'},
-    );
-    final body = response.data ?? const <String, dynamic>{};
-    final data = body['data'];
-    if (body['success'] != true || data is! Map<String, dynamic>) {
-      throw StateError(
-        body['detail']?.toString() ??
-            'TorBox could not start device authorization.',
+    try {
+      final response = await _dio.get<Map<String, dynamic>>(
+        '/user/auth/device/start',
+        queryParameters: const {'app': 'TetoTV'},
       );
+      final body = response.data ?? const <String, dynamic>{};
+      final data = body['data'];
+      if (body['success'] != true || data is! Map<String, dynamic>) {
+        throw TorBoxDeviceAuthException(
+          body['detail']?.toString() ??
+              'TorBox could not start device authorization.',
+          code: body['error']?.toString(),
+        );
+      }
+      return TorBoxDeviceSession.fromJson(data);
+    } on TorBoxDeviceAuthException {
+      rethrow;
+    } on DioException catch (error) {
+      throw _torBoxTransportFailure(error);
     }
-    return TorBoxDeviceSession.fromJson(data);
   }
 
   Future<String?> poll(TorBoxDeviceSession session) async {
     if (DateTime.now().isAfter(session.expiresAt)) {
-      throw StateError('The TorBox authorization code expired.');
+      throw const TorBoxDeviceAuthException(
+        'The TorBox authorization code expired. Get a new code and try again.',
+        code: 'AUTHORIZATION_EXPIRED',
+      );
     }
-    final response = await _dio.post<Map<String, dynamic>>(
-      '/user/auth/device/token',
-      data: {'device_code': session.deviceCode},
-      options: Options(
-        contentType: Headers.jsonContentType,
-        validateStatus: (status) => status != null && status < 500,
-      ),
-    );
-    final body = response.data ?? const <String, dynamic>{};
-    if (response.statusCode == 200 && body['success'] == true) {
-      final data = body['data'];
-      final token = data is Map<String, dynamic>
-          ? data['access_token']?.toString()
-          : null;
-      if (token == null || token.isEmpty) {
-        throw const FormatException(
-          'TorBox approved the device without returning an API token.',
+    try {
+      final response = await _dio.post<Map<String, dynamic>>(
+        '/user/auth/device/token',
+        data: {'device_code': session.deviceCode},
+        options: Options(
+          contentType: Headers.jsonContentType,
+          validateStatus: (status) => status != null && status < 500,
+        ),
+      );
+      final body = response.data ?? const <String, dynamic>{};
+      if (response.statusCode == 200 && body['success'] == true) {
+        final data = body['data'];
+        final token = data is Map<String, dynamic>
+            ? data['access_token']?.toString()
+            : null;
+        if (token == null || token.isEmpty) {
+          throw const FormatException(
+            'TorBox approved the device without returning an API token.',
+          );
+        }
+        return token;
+      }
+      final code = body['error']?.toString().trim().toUpperCase();
+      // TorBox documents DEVICE_CODE_NOT_USED as the normal pending response.
+      if (response.statusCode == 400 && code == 'DEVICE_CODE_NOT_USED') {
+        return null;
+      }
+      if (_torBoxTransientResponse(response.statusCode, code)) {
+        throw TorBoxDeviceAuthException(
+          'TorBox is temporarily unreachable. TetoTV will keep retrying this code.',
+          code: code ?? '${response.statusCode ?? ''}',
+          retryable: true,
         );
       }
-      return token;
+      if (code == 'ITEM_NOT_FOUND') {
+        throw const TorBoxDeviceAuthException(
+          'The TorBox authorization code expired. Get a new code and try again.',
+          code: 'ITEM_NOT_FOUND',
+        );
+      }
+      if (code == 'PLAN_RESTRICTED_FEATURE') {
+        throw const TorBoxDeviceAuthException(
+          'TorBox device linking requires an active paid TorBox plan.',
+          code: 'PLAN_RESTRICTED_FEATURE',
+        );
+      }
+      throw TorBoxDeviceAuthException(
+        body['detail']?.toString() ?? 'TorBox device authorization failed.',
+        code: code,
+      );
+    } on TorBoxDeviceAuthException {
+      rethrow;
+    } on DioException catch (error) {
+      throw _torBoxTransportFailure(error);
     }
-    final code = body['error']?.toString().trim().toUpperCase();
-    // TorBox documents DEVICE_CODE_NOT_USED as the normal pending response.
-    // Other 400 responses (expired/invalid code, free-plan rejection, etc.)
-    // are terminal and must not be hidden behind ten minutes of polling.
-    if (response.statusCode == 400 && code == 'DEVICE_CODE_NOT_USED') {
-      return null;
-    }
-    throw TorBoxDeviceAuthException(
-      body['detail']?.toString() ?? 'TorBox device authorization failed.',
-      code: code,
-    );
   }
+}
+
+const _torBoxTransientCodes = {
+  'DATABASE_ERROR',
+  'DOWNLOAD_SERVER_ERROR',
+  'NO_SERVERS_AVAILABLE_ERROR',
+  'TOO_MANY_REQUESTS',
+  'UNKNOWN_ERROR',
+};
+
+bool _torBoxTransientResponse(int? status, String? code) {
+  return status == 408 ||
+      status == 425 ||
+      status == 429 ||
+      (status != null && status >= 500) ||
+      _torBoxTransientCodes.contains(code);
+}
+
+TorBoxDeviceAuthException _torBoxTransportFailure(DioException error) {
+  final status = error.response?.statusCode;
+  final retryable =
+      _torBoxTransientResponse(status, null) ||
+      switch (error.type) {
+        DioExceptionType.connectionTimeout ||
+        DioExceptionType.sendTimeout ||
+        DioExceptionType.receiveTimeout ||
+        DioExceptionType.connectionError ||
+        DioExceptionType.unknown => true,
+        _ => false,
+      };
+  return TorBoxDeviceAuthException(
+    retryable
+        ? 'TorBox is temporarily unreachable. TetoTV will keep retrying this code.'
+        : 'TorBox could not complete device authorization. Try again.',
+    code: status == null ? 'NETWORK_ERROR' : '$status',
+    retryable: retryable,
+  );
 }

--- a/lib/features/auth/presentation/torbox_pairing_screen.dart
+++ b/lib/features/auth/presentation/torbox_pairing_screen.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:anime_tv/core/storage/tetotv_database.dart';
 import 'package:anime_tv/core/theme/app_theme.dart';
 import 'package:anime_tv/core/widgets/copyable_code_interaction.dart';
 import 'package:anime_tv/core/widgets/copyable_qr_interaction.dart';
@@ -11,50 +12,130 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:qr_flutter/qr_flutter.dart';
 
+typedef TorBoxPairingDiagnosticRecorder =
+    Future<void> Function(Map<String, Object?> details);
+
 class TorBoxPairingScreen extends ConsumerStatefulWidget {
-  const TorBoxPairingScreen({super.key, this.client});
+  const TorBoxPairingScreen({super.key, this.client, this.diagnosticRecorder});
 
   @visibleForTesting
   final TorBoxDeviceAuthClient? client;
+
+  @visibleForTesting
+  final TorBoxPairingDiagnosticRecorder? diagnosticRecorder;
 
   @override
   ConsumerState<TorBoxPairingScreen> createState() =>
       _TorBoxPairingScreenState();
 }
 
-class _TorBoxPairingScreenState extends ConsumerState<TorBoxPairingScreen> {
+class _TorBoxPairingScreenState extends ConsumerState<TorBoxPairingScreen>
+    with WidgetsBindingObserver {
   late final TorBoxDeviceAuthClient _client;
+  late final TorBoxPairingDiagnosticRecorder _diagnosticRecorder;
   TorBoxDeviceSession? _session;
   Timer? _pollTimer;
   bool _polling = false;
   bool _authorized = false;
+  bool _pendingRecorded = false;
   String? _error;
+  String? _temporaryNotice;
+  String? _pendingToken;
+  int _transientFailureCount = 0;
   int _generation = 0;
 
   @override
   void initState() {
     super.initState();
+    WidgetsBinding.instance.addObserver(this);
     _client = widget.client ?? TorBoxDeviceAuthClient();
+    _diagnosticRecorder =
+        widget.diagnosticRecorder ??
+        (details) => TetoTvDatabase.instance.recordDiagnosticEvent(
+          category: 'torbox-pairing',
+          message: 'TorBox pairing stage',
+          details: details,
+        );
     _start();
+  }
+
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    if (state != AppLifecycleState.resumed || !mounted || _authorized) return;
+    final session = _session;
+    if (session == null || _error != null) return;
+    if (_pollTimer?.isActive != true) {
+      _schedulePolling(session, _generation);
+    }
+    // Android can suspend Dart timers while another screen or app is open.
+    // Poll immediately on resume so a TorBox approval is not missed while the
+    // user switches back from the browser.
+    unawaited(_poll(_generation));
+  }
+
+  void _schedulePolling(
+    TorBoxDeviceSession session,
+    int generation, {
+    Duration? delay,
+  }) {
+    _pollTimer?.cancel();
+    _pollTimer = Timer(delay ?? session.interval, () => _poll(generation));
+  }
+
+  void _recordStage(String stage, {String? outcome, int? retry}) {
+    // These values are fixed internal labels. Never add the user/device code,
+    // provider token, authorization URL, exception text, or hostname here.
+    unawaited(
+      _diagnosticRecorder({
+        'flow': 'direct-device',
+        'stage': stage,
+        'outcome': ?outcome,
+        'retry': ?retry?.clamp(1, 99),
+      }),
+    );
+  }
+
+  Duration _transientRetryDelay(Duration providerInterval) {
+    final exponent = (_transientFailureCount - 1).clamp(0, 3);
+    final multiplier = 1 << exponent;
+    final milliseconds = providerInterval.inMilliseconds * multiplier;
+    return Duration(
+      milliseconds: milliseconds.clamp(
+        providerInterval.inMilliseconds,
+        const Duration(seconds: 30).inMilliseconds,
+      ),
+    );
   }
 
   Future<void> _start() async {
     if (!mounted) return;
     final generation = ++_generation;
     _pollTimer?.cancel();
+    _recordStage('start');
     setState(() {
       _session = null;
       _authorized = false;
+      _pendingRecorded = false;
       _error = null;
+      _temporaryNotice = null;
+      _pendingToken = null;
+      _transientFailureCount = 0;
     });
     try {
       final session = await _client.start();
       if (!mounted || generation != _generation) return;
       setState(() => _session = session);
-      _pollTimer = Timer.periodic(session.interval, (_) => _poll(generation));
+      _recordStage('pending');
+      _pendingRecorded = true;
+      _schedulePolling(session, generation);
     } catch (error) {
       if (mounted && generation == _generation) {
-        setState(() => _error = error.toString());
+        _recordStage('terminal', outcome: 'start-failed');
+        setState(
+          () => _error = error is TorBoxDeviceAuthException
+              ? error.message
+              : 'TorBox could not start device authorization. Try again.',
+        );
       }
     }
   }
@@ -68,40 +149,97 @@ class _TorBoxPairingScreenState extends ConsumerState<TorBoxPairingScreen> {
         generation != _generation) {
       return;
     }
-    if (DateTime.now().isAfter(session.expiresAt)) {
+    if (_pendingToken == null && DateTime.now().isAfter(session.expiresAt)) {
       _pollTimer?.cancel();
+      _recordStage('expired', outcome: 'provider-expiry');
       setState(() => _error = 'The TorBox authorization code expired.');
       return;
     }
     _polling = true;
     try {
-      final token = await _client.poll(session);
-      if (token == null || !mounted || generation != _generation) return;
+      final token = _pendingToken ?? await _client.poll(session);
+      if (!mounted || generation != _generation) return;
+      if (token == null) {
+        _transientFailureCount = 0;
+        if (!_pendingRecorded) {
+          _recordStage('pending');
+          _pendingRecorded = true;
+        }
+        if (_temporaryNotice != null) {
+          setState(() => _temporaryNotice = null);
+        }
+        _schedulePolling(session, generation);
+        return;
+      }
+      _pendingToken = token;
       final saved = await ref
           .read(torBoxSettingsControllerProvider.notifier)
           .saveAndValidate(token);
       if (!mounted || generation != _generation) return;
       if (!saved) {
+        final settingsState = ref.read(torBoxSettingsControllerProvider);
+        if (settingsState.retryableError) {
+          throw const TorBoxDeviceAuthException(
+            'TorBox approved this device, but its API is temporarily unreachable. TetoTV will keep retrying.',
+            code: 'provider_temporarily_unavailable',
+            retryable: true,
+          );
+        }
         throw StateError(
-          ref.read(torBoxSettingsControllerProvider).errorMessage ??
+          settingsState.errorMessage ??
               'TorBox could not validate this account.',
         );
       }
       _pollTimer?.cancel();
-      setState(() => _authorized = true);
+      _recordStage('approved');
+      setState(() {
+        _authorized = true;
+        _temporaryNotice = null;
+        _pendingToken = null;
+      });
     } catch (error) {
       if (!mounted || generation != _generation) return;
+      if (error is TorBoxDeviceAuthException && error.retryable) {
+        _transientFailureCount += 1;
+        final retryDelay = _transientRetryDelay(session.interval);
+        _recordStage(
+          'transient-retry',
+          outcome: 'provider-unreachable',
+          retry: _transientFailureCount,
+        );
+        setState(() => _temporaryNotice = error.message);
+        _schedulePolling(session, generation, delay: retryDelay);
+        return;
+      }
       _pollTimer?.cancel();
-      setState(() => _error = error.toString());
+      _recordStage('terminal', outcome: _terminalOutcome(error));
+      setState(
+        () => _error = error is TorBoxDeviceAuthException
+            ? error.message
+            : error.toString(),
+      );
     } finally {
       _polling = false;
     }
+  }
+
+  String _terminalOutcome(Object error) {
+    if (error is TorBoxDeviceAuthException) {
+      return switch (error.code) {
+        'ITEM_NOT_FOUND' || 'AUTHORIZATION_EXPIRED' => 'provider-expired',
+        'PLAN_RESTRICTED_FEATURE' => 'paid-plan-required',
+        _ => 'provider-rejected',
+      };
+    }
+    if (error is FormatException) return 'invalid-provider-response';
+    return 'account-validation-failed';
   }
 
   @override
   void dispose() {
     _generation++;
     _pollTimer?.cancel();
+    WidgetsBinding.instance.removeObserver(this);
     super.dispose();
   }
 
@@ -236,6 +374,21 @@ class _TorBoxPairingScreenState extends ConsumerState<TorBoxPairingScreen> {
                 'Device authorization requires a paid TorBox plan.',
                 style: Theme.of(context).textTheme.bodyMedium,
               ),
+              const SizedBox(height: 10),
+              Text(
+                'If TorBox\'s Continue button does not respond on your phone, '
+                'keep this code open and try Chrome, an incognito tab, another '
+                'browser, or a PC before the code expires. This TV will keep '
+                'retrying. TorBox also recommends disabling VPN, ad blocking, '
+                'and private DNS when its CAPTCHA has trouble.',
+                style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                  color: context.appPalette.mutedText,
+                ),
+              ),
+              if (_temporaryNotice case final notice?) ...[
+                const SizedBox(height: 14),
+                _RetryingNotice(message: notice),
+              ],
             ],
           );
           return Container(
@@ -265,6 +418,40 @@ class _TorBoxPairingScreenState extends ConsumerState<TorBoxPairingScreen> {
                   ),
           );
         },
+      ),
+    );
+  }
+}
+
+class _RetryingNotice extends StatelessWidget {
+  const _RetryingNotice({required this.message});
+
+  final String message;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
+      decoration: BoxDecoration(
+        color: context.appPalette.secondaryAccent.withValues(alpha: .10),
+        borderRadius: BorderRadius.circular(10),
+        border: Border.all(
+          color: context.appPalette.secondaryAccent.withValues(alpha: .45),
+        ),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(
+            Icons.cloud_sync_outlined,
+            size: 18,
+            color: context.appPalette.secondaryAccent,
+          ),
+          const SizedBox(width: 8),
+          Flexible(
+            child: Text(message, style: Theme.of(context).textTheme.bodySmall),
+          ),
+        ],
       ),
     );
   }

--- a/lib/features/catalog/domain/episode_airing_availability.dart
+++ b/lib/features/catalog/domain/episode_airing_availability.dart
@@ -2,6 +2,66 @@ import 'package:anime_tv/features/catalog/domain/anime_summary.dart';
 
 enum EpisodeAiringAvailabilityKind { available, episodeUnaired, seriesUnaired }
 
+/// Builds the short, human-readable countdown used beside a releasing
+/// series' status.
+///
+/// AniList only exposes an exact timestamp for the immediate next episode,
+/// so this deliberately returns `null` when that timestamp is missing,
+/// stale, or belongs to a non-releasing series. The UI must never estimate a
+/// schedule from a show's usual broadcast day.
+String? nextEpisodeAiringCountdownLabel({
+  required AnimeSummary anime,
+  DateTime? now,
+}) {
+  final normalizedStatus = anime.status?.trim().toUpperCase().replaceAll(
+    RegExp(r'[\s-]+'),
+    '_',
+  );
+  if (normalizedStatus != 'RELEASING' &&
+      normalizedStatus != 'AIRING' &&
+      normalizedStatus != 'CURRENTLY_AIRING') {
+    return null;
+  }
+
+  final airingAt = anime.nextAiringAt;
+  final nextEpisode = anime.nextAiringEpisode;
+  if (airingAt == null || nextEpisode == null || nextEpisode <= 0) return null;
+
+  final remaining = airingAt.difference(now ?? DateTime.now());
+  if (remaining <= Duration.zero) return null;
+
+  final minutes = remaining.inMinutes;
+  if (minutes < 60) return 'next episode in less than an hour';
+
+  if (minutes < Duration.minutesPerDay) {
+    final hours = (minutes / Duration.minutesPerHour).ceil();
+    return 'next episode in $hours ${hours == 1 ? 'hour' : 'hours'}';
+  }
+
+  final days = (minutes / Duration.minutesPerDay).ceil();
+  return 'next episode in $days ${days == 1 ? 'day' : 'days'}';
+}
+
+/// Formats a known catalog air date without implying a time of day.
+String episodeAiringDateLabel(DateTime value) {
+  const months = <String>[
+    'January',
+    'February',
+    'March',
+    'April',
+    'May',
+    'June',
+    'July',
+    'August',
+    'September',
+    'October',
+    'November',
+    'December',
+  ];
+  final local = value.toLocal();
+  return '${months[local.month - 1]} ${local.day}, ${local.year}';
+}
+
 class EpisodeAiringAvailability {
   const EpisodeAiringAvailability._({
     required this.kind,

--- a/lib/features/catalog/presentation/anime_details_screen.dart
+++ b/lib/features/catalog/presentation/anime_details_screen.dart
@@ -14,6 +14,7 @@ import 'package:anime_tv/features/catalog/domain/anime_summary.dart';
 import 'package:anime_tv/features/catalog/domain/episode_airing_availability.dart';
 import 'package:anime_tv/features/catalog/domain/filler_episode_lookup.dart';
 import 'package:anime_tv/features/catalog/presentation/anime_title_logo_view.dart';
+import 'package:anime_tv/features/catalog/presentation/episode_browser_dialog.dart';
 import 'package:anime_tv/features/downloads/application/season_download_controller.dart';
 import 'package:anime_tv/features/downloads/domain/season_download_plan.dart';
 import 'package:anime_tv/features/downloads/presentation/season_download_dialog.dart';
@@ -97,6 +98,7 @@ class _DetailsContentState extends ConsumerState<_DetailsContent> {
   bool _initialPrefetchStarted = false;
   bool _initialPrefetchScheduled = false;
   bool _startingWatchParty = false;
+  bool _episodeBrowserOpen = false;
   final FocusNode _watchPartyFocusNode = FocusNode(
     debugLabel: 'episode.watch-together',
   );
@@ -230,6 +232,7 @@ class _DetailsContentState extends ConsumerState<_DetailsContent> {
           knownEpisodes,
         );
     final releaseCheckAt = DateTime.now();
+    final statusText = _animeDetailsStatusText(anime, releaseCheckAt);
     final selectedAvailability = episodeAiringAvailability(
       anime: anime,
       episode: selectedEpisode,
@@ -294,6 +297,14 @@ class _DetailsContentState extends ConsumerState<_DetailsContent> {
       onSelectEpisode: !guestInWatchParty && !isUnreleased
           ? () => unawaited(
               _showEpisodeNumberPicker(
+                selectedEpisode: selectedEpisode,
+                totalEpisodes: knownEpisodes,
+              ),
+            )
+          : null,
+      onBrowseEpisodes: isTelevision && !guestInWatchParty && !isUnreleased
+          ? () => unawaited(
+              _showEpisodeBrowser(
                 selectedEpisode: selectedEpisode,
                 totalEpisodes: knownEpisodes,
               ),
@@ -484,10 +495,10 @@ class _DetailsContentState extends ConsumerState<_DetailsContent> {
                                           context,
                                         ).textTheme.headlineSmall,
                                       ),
-                                      if (anime.status case final status?) ...[
+                                      if (statusText case final status?) ...[
                                         const SizedBox(height: 9),
                                         Text(
-                                          'Status: ${status.replaceAll('_', ' ')}',
+                                          'Status: $status',
                                           style: TextStyle(
                                             color: context.appPalette.mutedText,
                                             fontSize: 11,
@@ -700,10 +711,10 @@ class _DetailsContentState extends ConsumerState<_DetailsContent> {
                                           height: 1.48,
                                         ),
                                   ),
-                                  if (anime.status case final status?) ...[
+                                  if (statusText case final status?) ...[
                                     SizedBox(height: wide ? 20 : 10),
                                     Text(
-                                      'Status:  ${status.replaceAll('_', ' ')}',
+                                      'Status: $status',
                                       style: TextStyle(
                                         color: context.appPalette.accentBright,
                                         fontSize: wide ? 17 : 13,
@@ -887,6 +898,50 @@ class _DetailsContentState extends ConsumerState<_DetailsContent> {
     if (episode == null || episode < 1 || episode > totalEpisodes) return;
     if (_selectedEpisode != episode) {
       setState(() => _selectedEpisode = episode);
+    }
+  }
+
+  Future<void> _showEpisodeBrowser({
+    required int selectedEpisode,
+    required int totalEpisodes,
+  }) async {
+    if (_episodeBrowserOpen) return;
+    FocusNode? restoreFocusNode;
+    for (final node in <FocusNode>[
+      _previousEpisodeFocusNode,
+      _episodePickerFocusNode,
+      _nextEpisodeFocusNode,
+    ]) {
+      if (node.hasFocus) {
+        restoreFocusNode = node;
+        break;
+      }
+    }
+    _episodeBrowserOpen = true;
+    int? episode;
+    try {
+      episode = await showEpisodeBrowserDialog(
+        context,
+        anime: anime,
+        selectedEpisode: selectedEpisode,
+        totalEpisodes: totalEpisodes,
+      );
+    } finally {
+      _episodeBrowserOpen = false;
+    }
+    if (!mounted) return;
+    if (episode != null &&
+        episode >= 1 &&
+        episode <= totalEpisodes &&
+        _selectedEpisode != episode) {
+      setState(() => _selectedEpisode = episode);
+    }
+    if (restoreFocusNode != null) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (mounted && restoreFocusNode!.canRequestFocus) {
+          restoreFocusNode.requestFocus();
+        }
+      });
     }
   }
 
@@ -1635,6 +1690,7 @@ class _EpisodeActions extends StatelessWidget {
     required this.onDecrease,
     required this.onIncrease,
     required this.onSelectEpisode,
+    required this.onBrowseEpisodes,
     required this.onPlayFromBeginning,
     required this.onResume,
     required this.onPlaySelected,
@@ -1666,6 +1722,7 @@ class _EpisodeActions extends StatelessWidget {
   final VoidCallback? onDecrease;
   final VoidCallback? onIncrease;
   final VoidCallback? onSelectEpisode;
+  final VoidCallback? onBrowseEpisodes;
   final VoidCallback? onPlayFromBeginning;
   final VoidCallback? onResume;
   final VoidCallback? onPlaySelected;
@@ -1816,6 +1873,7 @@ class _EpisodeActions extends StatelessWidget {
                   icon: Icons.remove_rounded,
                   label: 'Previous episode',
                   onPressed: onDecrease,
+                  onBrowseEpisodes: onBrowseEpisodes,
                   focusNode: previousEpisodeFocusNode,
                 ),
                 Expanded(
@@ -1824,6 +1882,7 @@ class _EpisodeActions extends StatelessWidget {
                     selectedEpisode: selectedEpisode,
                     totalEpisodes: totalEpisodes,
                     onPressed: onSelectEpisode,
+                    onBrowseEpisodes: onBrowseEpisodes,
                     focusNode: episodePickerFocusNode,
                     large: large,
                   ),
@@ -1833,6 +1892,7 @@ class _EpisodeActions extends StatelessWidget {
                   icon: Icons.add_rounded,
                   label: 'Next episode',
                   onPressed: onIncrease,
+                  onBrowseEpisodes: onBrowseEpisodes,
                   focusNode: nextEpisodeFocusNode,
                 ),
               ],
@@ -1861,7 +1921,7 @@ class _EpisodeAiringNotice extends StatelessWidget {
     final dateLabel = expectedAt == null
         ? null
         : '${isSeries ? 'Expected premiere date' : 'Expected air date'}: '
-              '${_formatAiringDate(expectedAt)}';
+              '${episodeAiringDateLabel(expectedAt)}';
     return Semantics(
       liveRegion: true,
       label: dateLabel == null ? title : '$title $dateLabel',
@@ -1931,23 +1991,20 @@ String _unavailableEpisodeActionLabel(EpisodeAiringAvailability availability) =>
       EpisodeAiringAvailabilityKind.available => 'Start watching',
     };
 
-String _formatAiringDate(DateTime value) {
-  const months = <String>[
-    'January',
-    'February',
-    'March',
-    'April',
-    'May',
-    'June',
-    'July',
-    'August',
-    'September',
-    'October',
-    'November',
-    'December',
-  ];
-  final local = value.toLocal();
-  return '${months[local.month - 1]} ${local.day}, ${local.year}';
+String? _animeDetailsStatusText(AnimeSummary anime, DateTime now) {
+  final rawStatus = anime.status?.trim();
+  if (rawStatus == null || rawStatus.isEmpty) return null;
+  final status = rawStatus
+      .replaceAll(RegExp(r'[\s_-]+'), ' ')
+      .toLowerCase()
+      .split(' ')
+      .where((part) => part.isNotEmpty)
+      .map((part) => '${part[0].toUpperCase()}${part.substring(1)}')
+      .join(' ');
+  final countdown = nextEpisodeAiringCountdownLabel(anime: anime, now: now);
+  final nextAiringAt = anime.nextAiringAt;
+  if (countdown == null || nextAiringAt == null) return status;
+  return '$status · $countdown · ${episodeAiringDateLabel(nextAiringAt)}';
 }
 
 class _EpisodeWatchPartyAction extends StatelessWidget {
@@ -2494,6 +2551,7 @@ class _EpisodeSelectionButton extends StatelessWidget {
     required this.selectedEpisode,
     required this.totalEpisodes,
     required this.onPressed,
+    required this.onBrowseEpisodes,
     required this.focusNode,
     required this.large,
   });
@@ -2501,6 +2559,7 @@ class _EpisodeSelectionButton extends StatelessWidget {
   final int selectedEpisode;
   final int totalEpisodes;
   final VoidCallback? onPressed;
+  final VoidCallback? onBrowseEpisodes;
   final FocusNode focusNode;
   final bool large;
 
@@ -2516,7 +2575,7 @@ class _EpisodeSelectionButton extends StatelessWidget {
         children: [
           Flexible(
             child: Text(
-              'Episode $selectedEpisode of $totalEpisodes',
+              '$selectedEpisode of $totalEpisodes',
               textAlign: TextAlign.center,
               maxLines: 1,
               overflow: TextOverflow.ellipsis,
@@ -2557,6 +2616,15 @@ class _EpisodeSelectionButton extends StatelessWidget {
         focusScale: 1.025,
         borderRadius: BorderRadius.circular(9),
         onPressed: onPressed!,
+        onKeyEvent: (_, event) {
+          if (onBrowseEpisodes == null ||
+              event is! KeyDownEvent ||
+              event.logicalKey != LogicalKeyboardKey.arrowDown) {
+            return KeyEventResult.ignored;
+          }
+          onBrowseEpisodes!();
+          return KeyEventResult.handled;
+        },
         child: content,
       ),
     );
@@ -2569,12 +2637,14 @@ class _EpisodeStepButton extends StatelessWidget {
     required this.icon,
     required this.label,
     required this.onPressed,
+    required this.onBrowseEpisodes,
     required this.focusNode,
   });
 
   final IconData icon;
   final String label;
   final VoidCallback? onPressed;
+  final VoidCallback? onBrowseEpisodes;
   final FocusNode focusNode;
 
   @override
@@ -2601,6 +2671,15 @@ class _EpisodeStepButton extends StatelessWidget {
         focusScale: 1.04,
         borderRadius: BorderRadius.circular(9),
         onPressed: onPressed!,
+        onKeyEvent: (_, event) {
+          if (onBrowseEpisodes == null ||
+              event is! KeyDownEvent ||
+              event.logicalKey != LogicalKeyboardKey.arrowDown) {
+            return KeyEventResult.ignored;
+          }
+          onBrowseEpisodes!();
+          return KeyEventResult.handled;
+        },
         child: content,
       ),
     );

--- a/lib/features/catalog/presentation/episode_browser_dialog.dart
+++ b/lib/features/catalog/presentation/episode_browser_dialog.dart
@@ -1,0 +1,682 @@
+import 'dart:math' as math;
+
+import 'package:anime_tv/core/theme/app_theme.dart';
+import 'package:anime_tv/core/tv/tv_focusable.dart';
+import 'package:anime_tv/core/widgets/network_artwork.dart';
+import 'package:anime_tv/features/catalog/domain/anime_summary.dart';
+import 'package:anime_tv/features/catalog/domain/episode_airing_availability.dart';
+import 'package:flutter/material.dart';
+
+Future<int?> showEpisodeBrowserDialog(
+  BuildContext context, {
+  required AnimeSummary anime,
+  required int selectedEpisode,
+  required int totalEpisodes,
+}) {
+  return showDialog<int>(
+    context: context,
+    barrierColor: Colors.black.withValues(alpha: .72),
+    builder: (_) => EpisodeBrowserDialog(
+      anime: anime,
+      selectedEpisode: selectedEpisode,
+      totalEpisodes: totalEpisodes,
+    ),
+  );
+}
+
+/// A paged episode browser designed for TV remotes and compact screens.
+///
+/// The catalog currently exposes only series-level artwork and runtime. Cards
+/// use those values as honest fallbacks and explicitly say when an episode
+/// synopsis is unavailable instead of presenting the series synopsis as
+/// episode-specific metadata.
+class EpisodeBrowserDialog extends StatefulWidget {
+  const EpisodeBrowserDialog({
+    required this.anime,
+    required this.selectedEpisode,
+    required this.totalEpisodes,
+    this.now,
+    super.key,
+  }) : assert(totalEpisodes > 0),
+       assert(selectedEpisode > 0 && selectedEpisode <= totalEpisodes);
+
+  final AnimeSummary anime;
+  final int selectedEpisode;
+  final int totalEpisodes;
+  final DateTime? now;
+
+  @override
+  State<EpisodeBrowserDialog> createState() => _EpisodeBrowserDialogState();
+}
+
+class _EpisodeBrowserDialogState extends State<EpisodeBrowserDialog> {
+  final Map<int, FocusNode> _episodeFocusNodes = <int, FocusNode>{};
+  int _pageIndex = 0;
+  int? _pageSize;
+
+  FocusNode _focusNodeForEpisode(int episode) => _episodeFocusNodes.putIfAbsent(
+    episode,
+    () => FocusNode(debugLabel: 'episode-browser.$episode'),
+  );
+
+  @override
+  void dispose() {
+    for (final node in _episodeFocusNodes.values) {
+      node.dispose();
+    }
+    super.dispose();
+  }
+
+  void _changePage(int page, {bool focusFirstEpisode = true}) {
+    final pageSize = _pageSize;
+    if (pageSize == null) return;
+    final pageCount = (widget.totalEpisodes / pageSize).ceil();
+    final nextPage = page.clamp(0, pageCount - 1);
+    if (nextPage == _pageIndex) return;
+    setState(() => _pageIndex = nextPage);
+    if (!focusFirstEpisode) return;
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      final firstEpisode = nextPage * pageSize + 1;
+      final node = _focusNodeForEpisode(firstEpisode);
+      if (node.canRequestFocus && node.context != null) node.requestFocus();
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final screen = MediaQuery.sizeOf(context);
+    final width = math.min(screen.width * .94, 1800.0);
+    final height = math.min(screen.height * .88, 900.0);
+    final compact = width < 700 || height < 450;
+    final palette = context.appPalette;
+    final gridDimension = width >= 1450 && height >= 760
+        ? 4
+        : width >= 1050 && height >= 590
+        ? 3
+        : width >= 650 && height >= 430
+        ? 2
+        : 1;
+    final pageSize = gridDimension * gridDimension;
+    final pageCount = (widget.totalEpisodes / pageSize).ceil();
+    if (_pageSize != pageSize) {
+      _pageSize = pageSize;
+      _pageIndex = (widget.selectedEpisode - 1) ~/ pageSize;
+    } else {
+      _pageIndex = _pageIndex.clamp(0, pageCount - 1);
+    }
+
+    return Dialog(
+      key: const ValueKey('episode-browser-dialog'),
+      insetPadding: EdgeInsets.symmetric(
+        horizontal: screen.width < 600 ? 10 : 24,
+        vertical: screen.height < 500 ? 10 : 22,
+      ),
+      backgroundColor: Colors.transparent,
+      child: Container(
+        width: width,
+        height: height,
+        padding: EdgeInsets.fromLTRB(
+          compact ? 14 : 22,
+          compact ? 12 : 18,
+          compact ? 14 : 22,
+          compact ? 12 : 16,
+        ),
+        decoration: BoxDecoration(
+          color: palette.surface.withValues(alpha: .98),
+          borderRadius: BorderRadius.circular(compact ? 16 : 22),
+          border: Border.all(
+            color: palette.accentBright.withValues(alpha: .70),
+            width: 1.4,
+          ),
+          boxShadow: [
+            BoxShadow(
+              color: palette.focusGlow.withValues(alpha: .32),
+              blurRadius: 32,
+              spreadRadius: 2,
+            ),
+          ],
+        ),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            _EpisodeBrowserHeader(
+              selectedEpisode: widget.selectedEpisode,
+              totalEpisodes: widget.totalEpisodes,
+              compact: compact,
+              onClose: () => Navigator.pop(context),
+            ),
+            SizedBox(height: compact ? 10 : 16),
+            Expanded(
+              child: LayoutBuilder(
+                builder: (context, constraints) {
+                  final columns = gridDimension;
+                  final rows = gridDimension;
+                  final firstEpisode = _pageIndex * pageSize + 1;
+                  final lastEpisode = math.min(
+                    firstEpisode + pageSize - 1,
+                    widget.totalEpisodes,
+                  );
+                  final horizontalGap = compact ? 8.0 : 12.0;
+                  final verticalGap = compact ? 8.0 : 12.0;
+                  final cardWidth =
+                      (constraints.maxWidth - horizontalGap * (columns - 1)) /
+                      columns;
+                  final cardHeight =
+                      (constraints.maxHeight - verticalGap * (rows - 1)) / rows;
+
+                  return GridView.builder(
+                    key: ValueKey('episode-browser-page-$_pageIndex'),
+                    physics: const NeverScrollableScrollPhysics(),
+                    padding: EdgeInsets.zero,
+                    gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
+                      crossAxisCount: columns,
+                      crossAxisSpacing: horizontalGap,
+                      mainAxisSpacing: verticalGap,
+                      childAspectRatio: cardWidth / cardHeight,
+                    ),
+                    itemCount: lastEpisode - firstEpisode + 1,
+                    itemBuilder: (context, index) {
+                      final episode = firstEpisode + index;
+                      return _EpisodeBrowserCard(
+                        key: ValueKey('episode-browser-card-$episode'),
+                        anime: widget.anime,
+                        episode: episode,
+                        selected: episode == widget.selectedEpisode,
+                        availability: episodeAiringAvailability(
+                          anime: widget.anime,
+                          episode: episode,
+                          now: widget.now,
+                        ),
+                        autofocus: episode == widget.selectedEpisode,
+                        focusNode: _focusNodeForEpisode(episode),
+                        compact: cardHeight < 175,
+                        onPressed: () => Navigator.pop(context, episode),
+                      );
+                    },
+                  );
+                },
+              ),
+            ),
+            if (pageCount > 1) ...[
+              SizedBox(height: compact ? 10 : 15),
+              _EpisodeBrowserPagination(
+                pageIndex: _pageIndex,
+                pageCount: pageCount,
+                compact: compact,
+                onPageSelected: _changePage,
+              ),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _EpisodeBrowserHeader extends StatelessWidget {
+  const _EpisodeBrowserHeader({
+    required this.selectedEpisode,
+    required this.totalEpisodes,
+    required this.compact,
+    required this.onClose,
+  });
+
+  final int selectedEpisode;
+  final int totalEpisodes;
+  final bool compact;
+  final VoidCallback onClose;
+
+  @override
+  Widget build(BuildContext context) {
+    final palette = context.appPalette;
+    return Row(
+      children: [
+        Container(
+          width: compact ? 4 : 5,
+          height: compact ? 32 : 42,
+          decoration: BoxDecoration(
+            color: palette.accentBright,
+            borderRadius: BorderRadius.circular(99),
+          ),
+        ),
+        SizedBox(width: compact ? 10 : 14),
+        Expanded(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                'Episodes',
+                style: TextStyle(
+                  color: palette.primaryText,
+                  fontSize: compact ? 20 : 28,
+                  height: 1,
+                  fontWeight: FontWeight.w900,
+                ),
+              ),
+              SizedBox(height: compact ? 3 : 5),
+              Text(
+                '$selectedEpisode of $totalEpisodes selected',
+                style: TextStyle(
+                  color: palette.mutedText,
+                  fontSize: compact ? 11 : 13,
+                  fontWeight: FontWeight.w700,
+                ),
+              ),
+            ],
+          ),
+        ),
+        TvFocusable(
+          onPressed: onClose,
+          focusScale: 1.02,
+          borderRadius: BorderRadius.circular(10),
+          child: Container(
+            key: const ValueKey('episode-browser-close'),
+            width: compact ? 42 : 50,
+            height: compact ? 36 : 42,
+            alignment: Alignment.center,
+            decoration: BoxDecoration(
+              color: palette.surfaceRaised,
+              borderRadius: BorderRadius.circular(10),
+              border: Border.all(
+                color: palette.primaryText.withValues(alpha: .14),
+              ),
+            ),
+            child: Icon(Icons.close_rounded, size: compact ? 20 : 24),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _EpisodeBrowserCard extends StatelessWidget {
+  const _EpisodeBrowserCard({
+    required this.anime,
+    required this.episode,
+    required this.selected,
+    required this.availability,
+    required this.autofocus,
+    required this.focusNode,
+    required this.compact,
+    required this.onPressed,
+    super.key,
+  });
+
+  final AnimeSummary anime;
+  final int episode;
+  final bool selected;
+  final EpisodeAiringAvailability availability;
+  final bool autofocus;
+  final FocusNode focusNode;
+  final bool compact;
+  final VoidCallback onPressed;
+
+  @override
+  Widget build(BuildContext context) {
+    final palette = context.appPalette;
+    final expectedAt = availability.expectedAt;
+    final runtime = anime.durationMinutes;
+    final artwork = anime.bannerImageUrl ?? anime.coverImageUrl;
+    final statusLabel = availability.isAvailable
+        ? null
+        : expectedAt == null
+        ? 'UNAIRED'
+        : episodeAiringDateLabel(expectedAt);
+    final semantics = <String>[
+      'Episode $episode',
+      if (runtime != null) '$runtime minutes',
+      if (availability.isAvailable) 'available' else 'not aired yet',
+      if (expectedAt != null) 'expected ${episodeAiringDateLabel(expectedAt)}',
+    ].join(', ');
+
+    return Semantics(
+      label: semantics,
+      button: true,
+      selected: selected,
+      excludeSemantics: true,
+      child: TvFocusable(
+        autofocus: autofocus,
+        focusNode: focusNode,
+        focusScale: 1.018,
+        borderRadius: BorderRadius.circular(compact ? 11 : 14),
+        onPressed: onPressed,
+        child: Container(
+          decoration: BoxDecoration(
+            color: palette.surfaceRaised,
+            borderRadius: BorderRadius.circular(compact ? 11 : 14),
+            border: Border.all(
+              color: selected
+                  ? palette.accentBright.withValues(alpha: .82)
+                  : palette.primaryText.withValues(alpha: .13),
+              width: selected ? 2 : 1,
+            ),
+          ),
+          child: ClipRRect(
+            borderRadius: BorderRadius.circular(compact ? 10 : 13),
+            child: Row(
+              children: [
+                SizedBox(
+                  width: compact ? 112 : 154,
+                  height: double.infinity,
+                  child: Stack(
+                    fit: StackFit.expand,
+                    children: [
+                      NetworkArtwork(
+                        url: artwork,
+                        cacheWidth: compact ? 260 : 380,
+                      ),
+                      const DecoratedBox(
+                        decoration: BoxDecoration(
+                          gradient: LinearGradient(
+                            colors: [Colors.transparent, Color(0xA6000000)],
+                            begin: Alignment.topCenter,
+                            end: Alignment.bottomCenter,
+                          ),
+                        ),
+                      ),
+                      Positioned(
+                        left: compact ? 8 : 10,
+                        bottom: compact ? 7 : 9,
+                        child: Text(
+                          'EP $episode',
+                          style: TextStyle(
+                            color: Colors.white,
+                            fontSize: compact ? 11 : 13,
+                            fontWeight: FontWeight.w900,
+                            letterSpacing: .6,
+                          ),
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+                Expanded(
+                  child: Padding(
+                    padding: EdgeInsets.all(compact ? 9 : 13),
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      mainAxisAlignment: MainAxisAlignment.center,
+                      children: [
+                        Row(
+                          children: [
+                            Expanded(
+                              child: Text(
+                                'Episode $episode',
+                                maxLines: 1,
+                                overflow: TextOverflow.ellipsis,
+                                style: TextStyle(
+                                  color: palette.primaryText,
+                                  fontSize: compact ? 13 : 16,
+                                  fontWeight: FontWeight.w900,
+                                ),
+                              ),
+                            ),
+                            if (selected)
+                              _EpisodeCardBadge(
+                                label: 'SELECTED',
+                                compact: compact,
+                                emphasized: true,
+                              ),
+                          ],
+                        ),
+                        SizedBox(height: compact ? 4 : 7),
+                        Text(
+                          runtime == null
+                              ? 'Runtime unavailable'
+                              : '$runtime min',
+                          style: TextStyle(
+                            color: palette.accentBright,
+                            fontSize: compact ? 10 : 12,
+                            fontWeight: FontWeight.w800,
+                          ),
+                        ),
+                        SizedBox(height: compact ? 4 : 7),
+                        Text(
+                          availability.isAvailable
+                              ? 'Episode synopsis unavailable.'
+                              : 'This episode has not aired yet.',
+                          maxLines: compact ? 2 : 3,
+                          overflow: TextOverflow.ellipsis,
+                          style: TextStyle(
+                            color: palette.mutedText,
+                            fontSize: compact ? 10 : 12,
+                            height: 1.25,
+                            fontWeight: FontWeight.w600,
+                          ),
+                        ),
+                        if (statusLabel != null) ...[
+                          SizedBox(height: compact ? 4 : 7),
+                          _EpisodeCardBadge(
+                            label: statusLabel,
+                            compact: compact,
+                          ),
+                        ],
+                      ],
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _EpisodeCardBadge extends StatelessWidget {
+  const _EpisodeCardBadge({
+    required this.label,
+    required this.compact,
+    this.emphasized = false,
+  });
+
+  final String label;
+  final bool compact;
+  final bool emphasized;
+
+  @override
+  Widget build(BuildContext context) {
+    final palette = context.appPalette;
+    return Container(
+      padding: EdgeInsets.symmetric(
+        horizontal: compact ? 5 : 7,
+        vertical: compact ? 2 : 3,
+      ),
+      decoration: BoxDecoration(
+        color: emphasized
+            ? palette.accent.withValues(alpha: .38)
+            : palette.accent.withValues(alpha: .18),
+        borderRadius: BorderRadius.circular(99),
+        border: Border.all(color: palette.accentBright.withValues(alpha: .56)),
+      ),
+      child: Text(
+        label,
+        maxLines: 1,
+        overflow: TextOverflow.ellipsis,
+        style: TextStyle(
+          color: palette.accentBright,
+          fontSize: compact ? 8 : 9,
+          height: 1,
+          fontWeight: FontWeight.w900,
+          letterSpacing: .5,
+        ),
+      ),
+    );
+  }
+}
+
+class _EpisodeBrowserPagination extends StatelessWidget {
+  const _EpisodeBrowserPagination({
+    required this.pageIndex,
+    required this.pageCount,
+    required this.compact,
+    required this.onPageSelected,
+  });
+
+  final int pageIndex;
+  final int pageCount;
+  final bool compact;
+  final ValueChanged<int> onPageSelected;
+
+  @override
+  Widget build(BuildContext context) {
+    final visiblePages = _visibleEpisodeBrowserPages(
+      pageIndex: pageIndex,
+      pageCount: pageCount,
+      compact: compact,
+    );
+    return Row(
+      key: const ValueKey('episode-browser-pagination'),
+      mainAxisAlignment: MainAxisAlignment.center,
+      children: [
+        _EpisodePageButton(
+          key: const ValueKey('episode-browser-previous-page'),
+          label: 'Previous',
+          icon: Icons.chevron_left_rounded,
+          enabled: pageIndex > 0,
+          compact: compact,
+          onPressed: () => onPageSelected(pageIndex - 1),
+        ),
+        SizedBox(width: compact ? 6 : 10),
+        for (var index = 0; index < visiblePages.length; index++) ...[
+          if (index > 0) SizedBox(width: compact ? 5 : 7),
+          if (visiblePages[index] case final page?)
+            _EpisodePageButton(
+              key: ValueKey('episode-browser-page-button-$page'),
+              label: '${page + 1}',
+              selected: page == pageIndex,
+              compact: compact,
+              onPressed: () => onPageSelected(page),
+            )
+          else
+            Padding(
+              padding: EdgeInsets.symmetric(horizontal: compact ? 1 : 3),
+              child: Text(
+                '…',
+                key: ValueKey('episode-browser-page-ellipsis-$index'),
+                style: TextStyle(
+                  color: context.appPalette.mutedText,
+                  fontSize: compact ? 14 : 17,
+                  fontWeight: FontWeight.w900,
+                ),
+              ),
+            ),
+        ],
+        SizedBox(width: compact ? 6 : 10),
+        _EpisodePageButton(
+          key: const ValueKey('episode-browser-next-page'),
+          label: 'Next',
+          icon: Icons.chevron_right_rounded,
+          iconAfter: true,
+          enabled: pageIndex < pageCount - 1,
+          compact: compact,
+          onPressed: () => onPageSelected(pageIndex + 1),
+        ),
+      ],
+    );
+  }
+}
+
+List<int?> _visibleEpisodeBrowserPages({
+  required int pageIndex,
+  required int pageCount,
+  required bool compact,
+}) {
+  if (pageCount <= (compact ? 5 : 7)) {
+    return <int?>[for (var page = 0; page < pageCount; page++) page];
+  }
+
+  final pages = <int>{0, pageCount - 1};
+  final radius = compact ? 1 : 2;
+  for (var page = pageIndex - radius; page <= pageIndex + radius; page++) {
+    if (page >= 0 && page < pageCount) pages.add(page);
+  }
+  final leadingFill = compact ? 1 : 3;
+  if (pageIndex <= leadingFill) {
+    for (var page = 0; page <= leadingFill; page++) {
+      pages.add(page);
+    }
+  }
+  if (pageIndex >= pageCount - leadingFill - 1) {
+    for (var page = pageCount - leadingFill - 1; page < pageCount; page++) {
+      pages.add(page);
+    }
+  }
+
+  final sorted = pages.toList()..sort();
+  final result = <int?>[];
+  for (final page in sorted) {
+    if (result.isNotEmpty && page - result.last! > 1) result.add(null);
+    result.add(page);
+  }
+  return result;
+}
+
+class _EpisodePageButton extends StatelessWidget {
+  const _EpisodePageButton({
+    required this.label,
+    required this.compact,
+    required this.onPressed,
+    this.icon,
+    this.iconAfter = false,
+    this.enabled = true,
+    this.selected = false,
+    super.key,
+  });
+
+  final String label;
+  final IconData? icon;
+  final bool iconAfter;
+  final bool compact;
+  final bool enabled;
+  final bool selected;
+  final VoidCallback onPressed;
+
+  @override
+  Widget build(BuildContext context) {
+    final palette = context.appPalette;
+    final content = Container(
+      height: compact ? 34 : 40,
+      constraints: BoxConstraints(minWidth: compact ? 34 : 40),
+      padding: EdgeInsets.symmetric(horizontal: compact ? 8 : 12),
+      alignment: Alignment.center,
+      decoration: BoxDecoration(
+        color: selected
+            ? palette.accent.withValues(alpha: .60)
+            : palette.surfaceRaised,
+        borderRadius: BorderRadius.circular(9),
+        border: Border.all(
+          color: selected
+              ? palette.accentBright
+              : palette.primaryText.withValues(alpha: .13),
+        ),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          if (icon != null && !iconAfter) Icon(icon, size: compact ? 17 : 20),
+          if (icon != null && !iconAfter) const SizedBox(width: 3),
+          Text(
+            label,
+            style: TextStyle(
+              color: palette.primaryText,
+              fontSize: compact ? 10 : 12,
+              fontWeight: FontWeight.w900,
+            ),
+          ),
+          if (icon != null && iconAfter) const SizedBox(width: 3),
+          if (icon != null && iconAfter) Icon(icon, size: compact ? 17 : 20),
+        ],
+      ),
+    );
+    if (!enabled) return Opacity(opacity: .34, child: content);
+    return TvFocusable(
+      onPressed: onPressed,
+      focusScale: 1.025,
+      borderRadius: BorderRadius.circular(9),
+      child: content,
+    );
+  }
+}

--- a/lib/features/home/presentation/home_screen.dart
+++ b/lib/features/home/presentation/home_screen.dart
@@ -55,6 +55,7 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
   final _heroMyListFocus = FocusNode(debugLabel: 'home.hero-my-list');
   final _homeNavFocus = FocusNode(debugLabel: 'home.navigation.home');
   final _searchFocus = FocusNode(debugLabel: 'home.header-search');
+  final _notificationFocus = FocusNode(debugLabel: 'home.notifications');
   final _profileFocus = FocusNode(debugLabel: 'home.profile-switcher');
   final _homeSearchController = TextEditingController();
   final _scrollController = ScrollController();
@@ -139,7 +140,11 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
 
   Future<void> _checkForUpdates() async {
     final updater = ref.read(appUpdateControllerProvider.notifier);
-    await updater.checkForUpdates(automatic: true, launchInstaller: true);
+    // Automatic checks may download a verified update in the background, but
+    // opening Android's installer without an explicit user action is jarring
+    // and gives the user no chance to read what changed. The Home notification
+    // bell surfaces the downloaded release and lets the user choose Install.
+    await updater.checkForUpdates(automatic: true, launchInstaller: false);
     if (!mounted) return;
     final notes = await updater.takeInstalledReleaseNotes();
     if (!mounted || notes == null) return;
@@ -183,6 +188,8 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
       _homeNavFocus.requestFocus();
     } else if (_searchFocus.context != null) {
       _searchFocus.requestFocus();
+    } else if (_notificationFocus.context != null) {
+      _notificationFocus.requestFocus();
     } else if (_profileFocus.context != null) {
       _profileFocus.requestFocus();
     } else {
@@ -194,7 +201,10 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
     if (!mounted || !_scrollController.hasClients) return;
     final visibleAtTop = _scrollController.offset <= .5;
     if (visibleAtTop == _headerVisibleAtTop) return;
-    if (!visibleAtTop && (_searchFocus.hasFocus || _profileFocus.hasFocus)) {
+    if (!visibleAtTop &&
+        (_searchFocus.hasFocus ||
+            _notificationFocus.hasFocus ||
+            _profileFocus.hasFocus)) {
       if (_hasVisibleNavigationAction && _homeNavFocus.context != null) {
         // A pointer/remote scroll can hide the fixed header while Search or
         // Profile still owns focus. Move focus somewhere visible without
@@ -222,6 +232,8 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
       if (!mounted) return;
       if (_searchFocus.context != null) {
         _searchFocus.requestFocus();
+      } else if (_notificationFocus.context != null) {
+        _notificationFocus.requestFocus();
       } else if (_profileFocus.context != null) {
         _profileFocus.requestFocus();
       }
@@ -246,7 +258,31 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
     if (!directional) return KeyEventResult.ignored;
     if (event is KeyDownEvent || event is KeyRepeatEvent) {
       if (key == LogicalKeyboardKey.arrowLeft) {
+        if (_notificationFocus.context != null) {
+          _notificationFocus.requestFocus();
+        } else if (_searchFocus.context != null) {
+          _searchFocus.requestFocus();
+        }
+      } else if (key == LogicalKeyboardKey.arrowDown) {
+        _restoreContentFocus();
+      }
+    }
+    return KeyEventResult.handled;
+  }
+
+  KeyEventResult _handleHeaderNotificationKey(FocusNode _, KeyEvent event) {
+    final key = event.logicalKey;
+    final directional =
+        key == LogicalKeyboardKey.arrowLeft ||
+        key == LogicalKeyboardKey.arrowRight ||
+        key == LogicalKeyboardKey.arrowUp ||
+        key == LogicalKeyboardKey.arrowDown;
+    if (!directional) return KeyEventResult.ignored;
+    if (event is KeyDownEvent || event is KeyRepeatEvent) {
+      if (key == LogicalKeyboardKey.arrowLeft) {
         if (_searchFocus.context != null) _searchFocus.requestFocus();
+      } else if (key == LogicalKeyboardKey.arrowRight) {
+        if (_profileFocus.context != null) _profileFocus.requestFocus();
       } else if (key == LogicalKeyboardKey.arrowDown) {
         _restoreContentFocus();
       }
@@ -634,6 +670,7 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
     _heroMyListFocus.dispose();
     _homeNavFocus.dispose();
     _searchFocus.dispose();
+    _notificationFocus.dispose();
     _profileFocus.dispose();
     _homeSearchController.dispose();
     _verticalRepeatGate.reset();
@@ -929,18 +966,25 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
         preferences: preferences,
         searchFocusNode: _searchFocus,
         searchController: _homeSearchController,
+        notificationFocusNode: _notificationFocus,
         profileFocusNode: _profileFocus,
         onSearchSubmitted: _submitHeaderSearch,
         onSearchExitLeft: _focusNavigationChrome,
         onSearchExitRight: () {
-          if (_profileFocus.context != null) _profileFocus.requestFocus();
+          if (_notificationFocus.context != null) {
+            _notificationFocus.requestFocus();
+          }
         },
         onSearchExitDown: _restoreContentFocus,
         onProfileKeyEvent: _handleHeaderProfileKey,
+        onNotificationKeyEvent: _handleHeaderNotificationKey,
         onSearchFocusChanged: (focused) {
           if (focused) unawaited(_restoreSponsoredHero());
         },
         onProfileFocusChanged: (focused) {
+          if (focused) unawaited(_restoreSponsoredHero());
+        },
+        onNotificationFocusChanged: (focused) {
           if (focused) unawaited(_restoreSponsoredHero());
         },
         compactMobile: true,
@@ -1006,20 +1050,25 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
                       preferences: preferences,
                       searchFocusNode: _searchFocus,
                       searchController: _homeSearchController,
+                      notificationFocusNode: _notificationFocus,
                       profileFocusNode: _profileFocus,
                       onSearchSubmitted: _submitHeaderSearch,
                       onSearchExitLeft: _focusNavigationChrome,
                       onSearchExitRight: () {
-                        if (_profileFocus.context != null) {
-                          _profileFocus.requestFocus();
+                        if (_notificationFocus.context != null) {
+                          _notificationFocus.requestFocus();
                         }
                       },
                       onSearchExitDown: _restoreContentFocus,
                       onProfileKeyEvent: _handleHeaderProfileKey,
+                      onNotificationKeyEvent: _handleHeaderNotificationKey,
                       onSearchFocusChanged: (focused) {
                         if (focused) unawaited(_restoreSponsoredHero());
                       },
                       onProfileFocusChanged: (focused) {
+                        if (focused) unawaited(_restoreSponsoredHero());
+                      },
+                      onNotificationFocusChanged: (focused) {
                         if (focused) unawaited(_restoreSponsoredHero());
                       },
                     ),

--- a/lib/features/home/presentation/main_navigation_bar.dart
+++ b/lib/features/home/presentation/main_navigation_bar.dart
@@ -1,6 +1,8 @@
 import 'dart:async';
 
 import 'package:anime_tv/core/theme/app_theme.dart';
+import 'package:anime_tv/core/notifications/app_notification.dart';
+import 'package:anime_tv/core/notifications/app_notification_controller.dart';
 import 'package:anime_tv/core/tv/tv_focusable.dart';
 import 'package:anime_tv/core/tv/tv_shelf_focus.dart';
 import 'package:anime_tv/core/widgets/network_artwork.dart';
@@ -945,13 +947,16 @@ class HomeTopRightHeader extends ConsumerWidget {
     required this.searchFocusNode,
     required this.searchController,
     required this.onSearchSubmitted,
+    this.notificationFocusNode,
     this.profileFocusNode,
     this.onSearchExitLeft,
     this.onSearchExitRight,
     this.onSearchExitDown,
     this.onProfileKeyEvent,
+    this.onNotificationKeyEvent,
     this.onSearchFocusChanged,
     this.onProfileFocusChanged,
+    this.onNotificationFocusChanged,
     this.compactMobile = false,
     super.key,
   });
@@ -960,13 +965,16 @@ class HomeTopRightHeader extends ConsumerWidget {
   final FocusNode searchFocusNode;
   final TextEditingController searchController;
   final ValueChanged<String> onSearchSubmitted;
+  final FocusNode? notificationFocusNode;
   final FocusNode? profileFocusNode;
   final VoidCallback? onSearchExitLeft;
   final VoidCallback? onSearchExitRight;
   final VoidCallback? onSearchExitDown;
   final FocusOnKeyEventCallback? onProfileKeyEvent;
+  final FocusOnKeyEventCallback? onNotificationKeyEvent;
   final ValueChanged<bool>? onSearchFocusChanged;
   final ValueChanged<bool>? onProfileFocusChanged;
+  final ValueChanged<bool>? onNotificationFocusChanged;
   final bool compactMobile;
 
   @override
@@ -1011,8 +1019,15 @@ class HomeTopRightHeader extends ConsumerWidget {
                 ),
               ),
             ),
+            const SizedBox(width: 10),
+            TetoNotificationBell(
+              key: const ValueKey('home-notification-bell'),
+              focusNode: notificationFocusNode,
+              onKeyEvent: onNotificationKeyEvent,
+              onFocusChanged: onNotificationFocusChanged,
+            ),
             if (hasProfile) ...[
-              const SizedBox(width: 10),
+              const SizedBox(width: 6),
               SizedBox(
                 width: 52,
                 child: TetoProfileSwitcher(
@@ -1053,8 +1068,15 @@ class HomeTopRightHeader extends ConsumerWidget {
             onExitDown: onSearchExitDown,
           ),
         ),
+        const SizedBox(width: 12),
+        TetoNotificationBell(
+          key: const ValueKey('home-notification-bell'),
+          focusNode: notificationFocusNode,
+          onKeyEvent: onNotificationKeyEvent,
+          onFocusChanged: onNotificationFocusChanged,
+        ),
         if (hasProfile) ...[
-          const SizedBox(width: 20),
+          const SizedBox(width: 10),
           TetoProfileSwitcher(
             key: const ValueKey('home-profile-switcher'),
             preferences: preferences,
@@ -1067,6 +1089,687 @@ class HomeTopRightHeader extends ConsumerWidget {
       ],
     );
   }
+}
+
+/// Compact entry point for TetoTV's durable, local notification inbox.
+///
+/// The 52dp target is shared by television and touch layouts. The visible
+/// count is capped for stable header geometry while semantics retain the real
+/// unread total.
+class TetoNotificationBell extends ConsumerWidget {
+  const TetoNotificationBell({
+    this.focusNode,
+    this.onKeyEvent,
+    this.onFocusChanged,
+    super.key,
+  });
+
+  final FocusNode? focusNode;
+  final FocusOnKeyEventCallback? onKeyEvent;
+  final ValueChanged<bool>? onFocusChanged;
+
+  Future<void> _openInbox(BuildContext context, WidgetRef ref) async {
+    final box = context.findRenderObject() as RenderBox?;
+    final overlay =
+        Overlay.of(context).context.findRenderObject() as RenderBox?;
+    if (box == null || overlay == null) return;
+    final notificationState = ref.read(appNotificationControllerProvider);
+    final items = List<AppNotification>.unmodifiable(notificationState.items);
+    final unreadCount = notificationState.unreadCount;
+    final topLeft = box.localToGlobal(Offset.zero, ancestor: overlay);
+    final menuWidth = (overlay.size.width - 24).clamp(296.0, 440.0).toDouble();
+    final preferredTop = topLeft.dy + box.size.height + 8;
+    final menuTop = preferredTop
+        .clamp(12.0, (overlay.size.height - 180).clamp(12.0, double.infinity))
+        .toDouble();
+    final menuRight = (overlay.size.width - topLeft.dx - box.size.width)
+        .clamp(
+          12.0,
+          (overlay.size.width - menuWidth - 12).clamp(12.0, double.infinity),
+        )
+        .toDouble();
+
+    // Everything in this snapshot is visible in the inbox. Clear its badge as
+    // soon as the viewer opens it, while keeping the immutable snapshot on
+    // screen so a provider rebuild cannot close or reorder the dialog.
+    if (unreadCount > 0) {
+      unawaited(
+        ref.read(appNotificationControllerProvider.notifier).markAllRead(),
+      );
+    }
+
+    final result = await showGeneralDialog<String>(
+      context: context,
+      barrierDismissible: true,
+      barrierLabel: 'Close notifications',
+      barrierColor: context.appPalette.background.withValues(alpha: .58),
+      transitionDuration: const Duration(milliseconds: 120),
+      pageBuilder: (menuContext, _, _) => _NotificationMenuOverlay(
+        items: items,
+        width: menuWidth,
+        top: menuTop,
+        right: menuRight,
+        maxHeight: (overlay.size.height - menuTop - 12)
+            .clamp(180.0, overlay.size.height - 24)
+            .toDouble(),
+      ),
+      transitionBuilder: (context, animation, _, child) => FadeTransition(
+        opacity: CurvedAnimation(
+          parent: animation,
+          curve: Curves.easeOutCubic,
+          reverseCurve: Curves.easeInCubic,
+        ),
+        child: child,
+      ),
+    );
+    if (!context.mounted || result == null) return;
+    if (result == 'install') {
+      await ref
+          .read(appUpdateControllerProvider.notifier)
+          .installDownloadedUpdate();
+      return;
+    }
+    if (result == 'check') {
+      await ref
+          .read(appUpdateControllerProvider.notifier)
+          .checkForUpdates(automatic: false, launchInstaller: false);
+      return;
+    }
+  }
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final notificationState = ref.watch(appNotificationControllerProvider);
+    final unreadCount = notificationState.unreadCount;
+    final badgeText = unreadCount > 99 ? '99+' : '$unreadCount';
+    final unreadLabel = unreadCount == 1
+        ? '1 unread notification'
+        : '$unreadCount unread notifications';
+    return Semantics(
+      key: const ValueKey('notification-bell-semantics'),
+      button: true,
+      label: 'Notifications, $unreadLabel',
+      excludeSemantics: true,
+      child: SizedBox(
+        width: 52,
+        height: 52,
+        child: Builder(
+          builder: (buttonContext) => TvFocusable(
+            focusNode: focusNode,
+            onKeyEvent: onKeyEvent,
+            onFocusChanged: onFocusChanged,
+            onPressed: () => _openInbox(buttonContext, ref),
+            borderRadius: BorderRadius.circular(13),
+            focusScale: 1.01,
+            child: Stack(
+              clipBehavior: Clip.none,
+              children: [
+                Positioned.fill(
+                  child: Container(
+                    key: const ValueKey('notification-bell-surface'),
+                    alignment: Alignment.center,
+                    margin: const EdgeInsets.all(4),
+                    decoration: BoxDecoration(
+                      color: context.appPalette.surface.withValues(alpha: .92),
+                      borderRadius: BorderRadius.circular(10),
+                      border: Border.all(
+                        color: context.appPalette.primaryText.withValues(
+                          alpha: .11,
+                        ),
+                      ),
+                    ),
+                    child: Icon(
+                      Icons.notifications_rounded,
+                      color: context.appPalette.primaryText,
+                      size: 25,
+                    ),
+                  ),
+                ),
+                if (unreadCount > 0)
+                  Positioned(
+                    key: const ValueKey('notification-unread-badge'),
+                    right: 0,
+                    top: 0,
+                    child: Container(
+                      constraints: const BoxConstraints(
+                        minWidth: 20,
+                        minHeight: 20,
+                      ),
+                      padding: const EdgeInsets.symmetric(horizontal: 5),
+                      alignment: Alignment.center,
+                      decoration: BoxDecoration(
+                        color: const Color(0xFFE53935),
+                        borderRadius: BorderRadius.circular(999),
+                        border: Border.all(color: Colors.black, width: 1.5),
+                      ),
+                      child: Text(
+                        badgeText,
+                        key: const ValueKey('notification-unread-count'),
+                        style: const TextStyle(
+                          color: Colors.white,
+                          fontSize: 10,
+                          fontWeight: FontWeight.w900,
+                          height: 1,
+                        ),
+                      ),
+                    ),
+                  ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _NotificationMenuOverlay extends ConsumerWidget {
+  const _NotificationMenuOverlay({
+    required this.items,
+    required this.width,
+    required this.top,
+    required this.right,
+    required this.maxHeight,
+  });
+
+  final List<AppNotification> items;
+  final double width;
+  final double top;
+  final double right;
+  final double maxHeight;
+
+  KeyEventResult _handleDismissKey(
+    BuildContext context,
+    FocusNode _,
+    KeyEvent event,
+  ) {
+    final key = event.logicalKey;
+    final isLeft = key == LogicalKeyboardKey.arrowLeft;
+    final isBack =
+        key == LogicalKeyboardKey.escape ||
+        key == LogicalKeyboardKey.goBack ||
+        key == LogicalKeyboardKey.browserBack;
+    if (!isLeft && !isBack) return KeyEventResult.ignored;
+    if (isBack) {
+      if (event is KeyUpEvent) Navigator.of(context).pop();
+      return KeyEventResult.handled;
+    }
+    if (event is KeyDownEvent) Navigator.of(context).pop();
+    return KeyEventResult.handled;
+  }
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final updateState = ref.watch(appUpdateControllerProvider);
+    return Stack(
+      children: [
+        Positioned(
+          top: top,
+          right: right,
+          width: width,
+          child: Focus(
+            canRequestFocus: false,
+            onKeyEvent: (node, event) =>
+                _handleDismissKey(context, node, event),
+            child: FocusTraversalGroup(
+              policy: ReadingOrderTraversalPolicy(),
+              child: ConstrainedBox(
+                constraints: BoxConstraints(maxHeight: maxHeight),
+                child: Material(
+                  key: const ValueKey('notification-menu-surface'),
+                  color: Colors.transparent,
+                  child: DecoratedBox(
+                    decoration: BoxDecoration(
+                      color: context.appPalette.surface,
+                      borderRadius: BorderRadius.circular(14),
+                      border: Border.all(
+                        color: context.appPalette.accent.withValues(alpha: .72),
+                      ),
+                      boxShadow: [
+                        BoxShadow(
+                          color: Colors.black.withValues(alpha: .58),
+                          blurRadius: 24,
+                          offset: const Offset(0, 10),
+                        ),
+                        BoxShadow(
+                          color: context.appPalette.focusGlow.withValues(
+                            alpha: .24,
+                          ),
+                          blurRadius: 18,
+                        ),
+                      ],
+                    ),
+                    child: SingleChildScrollView(
+                      padding: const EdgeInsets.all(12),
+                      child: Column(
+                        mainAxisSize: MainAxisSize.min,
+                        crossAxisAlignment: CrossAxisAlignment.stretch,
+                        children: [
+                          Row(
+                            children: [
+                              Expanded(
+                                child: Text(
+                                  'Notifications',
+                                  style: TextStyle(
+                                    color: context.appPalette.primaryText,
+                                    fontSize: 17,
+                                    fontWeight: FontWeight.w900,
+                                  ),
+                                ),
+                              ),
+                              _NotificationIconAction(
+                                key: const ValueKey('notification-menu-close'),
+                                icon: Icons.close_rounded,
+                                label: 'Close notifications',
+                                onPressed: () => Navigator.of(context).pop(),
+                              ),
+                            ],
+                          ),
+                          const SizedBox(height: 10),
+                          if (items.isEmpty)
+                            _NotificationEmptyState(updateState: updateState)
+                          else
+                            for (
+                              var index = 0;
+                              index < items.length;
+                              index++
+                            ) ...[
+                              _UpdateNotificationCard(
+                                item: items[index],
+                                updateState: updateState,
+                                autofocus: index == 0,
+                              ),
+                              if (index != items.length - 1)
+                                const SizedBox(height: 8),
+                            ],
+                          const SizedBox(height: 8),
+                          Row(
+                            mainAxisAlignment: MainAxisAlignment.center,
+                            children: [
+                              Icon(
+                                Icons.keyboard_arrow_left_rounded,
+                                size: 16,
+                                color: context.appPalette.mutedText,
+                              ),
+                              const SizedBox(width: 3),
+                              Flexible(
+                                child: Text(
+                                  'Left or Back closes notifications',
+                                  maxLines: 1,
+                                  overflow: TextOverflow.ellipsis,
+                                  style: TextStyle(
+                                    color: context.appPalette.mutedText,
+                                    fontSize: 10,
+                                    fontWeight: FontWeight.w700,
+                                  ),
+                                ),
+                              ),
+                            ],
+                          ),
+                        ],
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _UpdateNotificationCard extends StatelessWidget {
+  const _UpdateNotificationCard({
+    required this.item,
+    required this.updateState,
+    required this.autofocus,
+  });
+
+  final AppNotification item;
+  final AppUpdateState updateState;
+  final bool autofocus;
+
+  @override
+  Widget build(BuildContext context) {
+    final matches = _notificationMatchesUpdate(item, updateState);
+    final busy = matches && updateState.isBusy;
+    final canInstall = matches && updateState.phase == AppUpdatePhase.ready;
+    final actionLabel = canInstall
+        ? 'Install'
+        : updateState.phase == AppUpdatePhase.error && matches
+        ? 'Retry'
+        : 'Check';
+    final visibleActionLabel = busy
+        ? switch (updateState.phase) {
+            AppUpdatePhase.checking => 'Checking…',
+            AppUpdatePhase.downloading => 'Downloading…',
+            AppUpdatePhase.installing => 'Installing…',
+            _ => 'Please wait…',
+          }
+        : actionLabel;
+    return Container(
+      key: ValueKey('notification-item-${item.id}'),
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: context.appPalette.surfaceRaised,
+        borderRadius: BorderRadius.circular(11),
+        border: Border.all(
+          color: item.isRead
+              ? context.appPalette.primaryText.withValues(alpha: .09)
+              : context.appPalette.accent.withValues(alpha: .64),
+        ),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              Expanded(
+                child: Text(
+                  item.title,
+                  style: TextStyle(
+                    color: context.appPalette.primaryText,
+                    fontSize: 14,
+                    fontWeight: FontWeight.w900,
+                  ),
+                ),
+              ),
+              const SizedBox(width: 8),
+              _NotificationChannelBadge(channel: item.targetChannel),
+            ],
+          ),
+          const SizedBox(height: 6),
+          Text(
+            item.body,
+            style: TextStyle(
+              color: context.appPalette.mutedText,
+              fontSize: 12,
+              height: 1.35,
+            ),
+          ),
+          const SizedBox(height: 7),
+          Text(
+            _formatNotificationDate(item.createdAtUtc),
+            style: TextStyle(
+              color: context.appPalette.mutedText,
+              fontSize: 10,
+              fontWeight: FontWeight.w700,
+            ),
+          ),
+          if (matches) ...[
+            const SizedBox(height: 8),
+            Text(
+              _updateStatusLabel(updateState),
+              key: const ValueKey('notification-update-status'),
+              style: TextStyle(
+                color: updateState.phase == AppUpdatePhase.error
+                    ? const Color(0xFFFF8A91)
+                    : context.appPalette.accentBright,
+                fontSize: 11,
+                fontWeight: FontWeight.w800,
+              ),
+            ),
+            if (updateState.phase == AppUpdatePhase.downloading) ...[
+              const SizedBox(height: 7),
+              LinearProgressIndicator(
+                key: const ValueKey('notification-update-progress'),
+                value: updateState.progress > 0
+                    ? updateState.progress.clamp(0, 1)
+                    : null,
+                minHeight: 4,
+                color: context.appPalette.accentBright,
+                backgroundColor: context.appPalette.primaryText.withValues(
+                  alpha: .10,
+                ),
+              ),
+            ],
+          ],
+          const SizedBox(height: 10),
+          Row(
+            children: [
+              Expanded(
+                child: _NotificationTextAction(
+                  key: ValueKey('notification-action-${item.id}'),
+                  label: visibleActionLabel,
+                  autofocus: autofocus,
+                  emphasized: !busy,
+                  onPressed: busy
+                      ? () {}
+                      : () => Navigator.of(
+                          context,
+                        ).pop(canInstall ? 'install' : 'check'),
+                ),
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _NotificationEmptyState extends StatelessWidget {
+  const _NotificationEmptyState({required this.updateState});
+
+  final AppUpdateState updateState;
+
+  @override
+  Widget build(BuildContext context) => Container(
+    key: const ValueKey('notification-empty-state'),
+    padding: const EdgeInsets.all(16),
+    decoration: BoxDecoration(
+      color: context.appPalette.surfaceRaised,
+      borderRadius: BorderRadius.circular(11),
+      border: Border.all(
+        color: context.appPalette.primaryText.withValues(alpha: .09),
+      ),
+    ),
+    child: Column(
+      children: [
+        Icon(
+          Icons.notifications_none_rounded,
+          color: context.appPalette.accentBright,
+          size: 30,
+        ),
+        const SizedBox(height: 8),
+        Text(
+          'You\'re all caught up',
+          style: TextStyle(
+            color: context.appPalette.primaryText,
+            fontWeight: FontWeight.w900,
+          ),
+        ),
+        const SizedBox(height: 4),
+        Text(
+          _updateStatusLabel(updateState),
+          textAlign: TextAlign.center,
+          style: TextStyle(color: context.appPalette.mutedText, fontSize: 11),
+        ),
+        if (!updateState.isBusy) ...[
+          const SizedBox(height: 12),
+          _NotificationTextAction(
+            key: const ValueKey('notification-empty-check'),
+            label: updateState.phase == AppUpdatePhase.error
+                ? 'Retry'
+                : 'Check',
+            emphasized: true,
+            autofocus: true,
+            onPressed: () => Navigator.of(context).pop('check'),
+          ),
+        ],
+      ],
+    ),
+  );
+}
+
+class _NotificationChannelBadge extends StatelessWidget {
+  const _NotificationChannelBadge({required this.channel});
+
+  final String? channel;
+
+  @override
+  Widget build(BuildContext context) {
+    final value = channel?.trim();
+    final label = value == null || value.isEmpty
+        ? 'UPDATE'
+        : value[0].toUpperCase() + value.substring(1).toLowerCase();
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 7, vertical: 4),
+      decoration: BoxDecoration(
+        color: context.appPalette.accent.withValues(alpha: .18),
+        borderRadius: BorderRadius.circular(999),
+        border: Border.all(
+          color: context.appPalette.accent.withValues(alpha: .42),
+        ),
+      ),
+      child: Text(
+        label,
+        key: const ValueKey('notification-channel'),
+        style: TextStyle(
+          color: context.appPalette.accentBright,
+          fontSize: 9,
+          fontWeight: FontWeight.w900,
+        ),
+      ),
+    );
+  }
+}
+
+class _NotificationTextAction extends StatelessWidget {
+  const _NotificationTextAction({
+    required this.label,
+    required this.onPressed,
+    this.autofocus = false,
+    this.emphasized = false,
+    super.key,
+  });
+
+  final String label;
+  final VoidCallback onPressed;
+  final bool autofocus;
+  final bool emphasized;
+
+  @override
+  Widget build(BuildContext context) => TvFocusable(
+    autofocus: autofocus,
+    onPressed: onPressed,
+    borderRadius: BorderRadius.circular(9),
+    focusScale: 1.01,
+    child: Container(
+      height: 36,
+      padding: const EdgeInsets.symmetric(horizontal: 10),
+      alignment: Alignment.center,
+      decoration: BoxDecoration(
+        color: emphasized
+            ? context.appPalette.accent
+            : context.appPalette.surface,
+        borderRadius: BorderRadius.circular(9),
+        border: Border.all(
+          color: emphasized
+              ? context.appPalette.accentBright
+              : context.appPalette.primaryText.withValues(alpha: .12),
+        ),
+      ),
+      child: Text(
+        label,
+        maxLines: 1,
+        overflow: TextOverflow.ellipsis,
+        style: TextStyle(
+          color: context.appPalette.primaryText,
+          fontSize: 11,
+          fontWeight: FontWeight.w900,
+        ),
+      ),
+    ),
+  );
+}
+
+class _NotificationIconAction extends StatelessWidget {
+  const _NotificationIconAction({
+    required this.icon,
+    required this.label,
+    required this.onPressed,
+    super.key,
+  });
+
+  final IconData icon;
+  final String label;
+  final VoidCallback onPressed;
+
+  @override
+  Widget build(BuildContext context) => Semantics(
+    label: label,
+    button: true,
+    child: TvFocusable(
+      onPressed: onPressed,
+      borderRadius: BorderRadius.circular(9),
+      focusScale: 1.01,
+      child: Container(
+        width: 36,
+        height: 36,
+        alignment: Alignment.center,
+        decoration: BoxDecoration(
+          color: context.appPalette.surfaceRaised,
+          borderRadius: BorderRadius.circular(9),
+          border: Border.all(
+            color: context.appPalette.primaryText.withValues(alpha: .12),
+          ),
+        ),
+        child: Icon(icon, size: 21, color: context.appPalette.primaryText),
+      ),
+    ),
+  );
+}
+
+bool _notificationMatchesUpdate(
+  AppNotification notification,
+  AppUpdateState update,
+) {
+  if (notification.kind != AppNotificationKind.appUpdate ||
+      update.release == null ||
+      notification.targetChannel != update.updateChannel.name) {
+    return false;
+  }
+  final notificationCode = notification.targetVersionCode;
+  final releaseCode = update.release!.androidVersionCode;
+  if (notificationCode != null && releaseCode != null) {
+    return notificationCode == releaseCode;
+  }
+  return normalizeAppVersion(notification.targetVersion ?? '') ==
+      normalizeAppVersion(update.release!.version);
+}
+
+String _updateStatusLabel(AppUpdateState update) => switch (update.phase) {
+  AppUpdatePhase.idle => 'Ready to check for updates',
+  AppUpdatePhase.checking => 'Checking for updates…',
+  AppUpdatePhase.upToDate => 'TetoTV is up to date',
+  AppUpdatePhase.available => update.message ?? 'Update available',
+  AppUpdatePhase.downloading =>
+    update.message ?? 'Downloading… ${(update.progress * 100).round()}%',
+  AppUpdatePhase.ready => update.message ?? 'Ready to install',
+  AppUpdatePhase.installing => update.message ?? 'Opening the installer…',
+  AppUpdatePhase.error => update.message ?? 'The update check failed',
+};
+
+String _formatNotificationDate(DateTime utc) {
+  const months = [
+    'Jan',
+    'Feb',
+    'Mar',
+    'Apr',
+    'May',
+    'Jun',
+    'Jul',
+    'Aug',
+    'Sep',
+    'Oct',
+    'Nov',
+    'Dec',
+  ];
+  final local = utc.toLocal();
+  return '${months[local.month - 1]} ${local.day}, ${local.year}';
 }
 
 /// The shared profile control used by every top-level TetoTV header.

--- a/lib/features/settings/application/torbox_settings_controller.dart
+++ b/lib/features/settings/application/torbox_settings_controller.dart
@@ -3,6 +3,7 @@ import 'package:anime_tv/core/storage/secure_storage_snapshot.dart';
 import 'package:anime_tv/features/streaming/data/torbox_client.dart';
 import 'package:anime_tv/features/streaming/data/torbox_models.dart';
 import 'package:anime_tv/features/streaming/domain/debrid_service.dart';
+import 'package:anime_tv/features/streaming/domain/stream_resolver.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 
@@ -38,12 +39,14 @@ class TorBoxSettingsState {
     this.hasSavedToken = false,
     this.account,
     this.errorMessage,
+    this.retryableError = false,
   });
 
   final bool isLoading;
   final bool hasSavedToken;
   final TorBoxAccount? account;
   final String? errorMessage;
+  final bool retryableError;
 }
 
 class TorBoxSettingsController extends StateNotifier<TorBoxSettingsState> {
@@ -85,6 +88,8 @@ class TorBoxSettingsController extends StateNotifier<TorBoxSettingsState> {
       if (!account.hasApiStreaming) {
         throw const TorBoxException(
           'TorBox API streaming requires an active paid plan.',
+          code: 'SUBSCRIPTION_REQUIRED',
+          category: DebridFailureCategory.account,
         );
       }
       if (persist) {
@@ -99,6 +104,11 @@ class TorBoxSettingsController extends StateNotifier<TorBoxSettingsState> {
       state = TorBoxSettingsState(
         hasSavedToken: hadSavedToken,
         errorMessage: error.toString(),
+        retryableError:
+            error is TorBoxException &&
+            (error.failureCategory ==
+                    DebridFailureCategory.serviceUnavailable ||
+                error.failureCategory == DebridFailureCategory.rateLimited),
       );
       return false;
     }

--- a/lib/features/streaming/data/stremio_torrent_release_source.dart
+++ b/lib/features/streaming/data/stremio_torrent_release_source.dart
@@ -410,7 +410,7 @@ class StremioTorrentReleaseSource implements ReleaseSource {
       );
       final codecRaw = _firstMatch(
         RegExp(
-          r'\b(AV1|HEVC|x265|H[.]?265|x264|H[.]?264)\b',
+          r'\b(AV0?1|AV[ ._-]1|HEVC|x265|H[ ._-]?265|x264|H[ ._-]?264|VP[ ._-]?9)\b',
           caseSensitive: false,
         ),
         searchable,
@@ -577,7 +577,9 @@ class StremioTorrentReleaseSource implements ReleaseSource {
   static String? _normalizeCodec(String? value) {
     if (value == null) return null;
     final lower = value.toLowerCase();
-    if (lower == 'av1') return 'AV1';
+    final compact = lower.replaceAll(RegExp(r'[ ._-]+'), '');
+    if (compact == 'av1' || compact == 'av01') return 'AV1';
+    if (compact == 'vp9') return 'VP9';
     if (lower == 'hevc' || lower.contains('265')) return 'HEVC';
     if (lower.contains('264')) return 'H.264';
     return value.toUpperCase();

--- a/lib/features/streaming/domain/stream_ranking_preferences.dart
+++ b/lib/features/streaming/domain/stream_ranking_preferences.dart
@@ -197,6 +197,95 @@ int releaseQualityHeight(ReleaseCandidate release) =>
 int webStreamQualityHeight(WebStreamResult stream) =>
     _qualityHeight('${stream.quality ?? ''} ${stream.title}');
 
+/// Whether Android's decoder inventory can safely play a release's video
+/// codec in hardware.
+///
+/// [unknown] is deliberately distinct from [unsupported]. The native bridge
+/// can be unavailable (for example during startup or on a non-Android test
+/// host), and add-ons do not always report a codec. Neither case is evidence
+/// that the release is incompatible, so those results remain available.
+enum ReleaseCodecCompatibility { supported, unsupported, unknown }
+
+/// Resolves the codec advertised by structured metadata, with a conservative
+/// release-name fallback for torrent add-ons that only return display text.
+String? releaseVideoCodecMime(ReleaseCandidate release) {
+  return _videoCodecMime(release.codec) ?? _videoCodecMime(release.releaseName);
+}
+
+ReleaseCodecCompatibility releaseCodecCompatibility(
+  ReleaseCandidate release, {
+  TvDeviceProfile? device,
+}) {
+  final mime = releaseVideoCodecMime(release);
+  if (mime == null || device == null || device.codecs.isEmpty) {
+    return ReleaseCodecCompatibility.unknown;
+  }
+  final matchingDecoders = device.codecs.where(
+    (codec) => codec.hardware && codec.mime.trim().toLowerCase() == mime,
+  );
+  if (matchingDecoders.isEmpty) {
+    return ReleaseCodecCompatibility.unsupported;
+  }
+
+  final requiredHeight = releaseQualityHeight(release);
+  if (requiredHeight <= 0) return ReleaseCodecCompatibility.supported;
+  final requiredWidth = _standardVideoWidth(requiredHeight);
+  var hasUnknownDimensions = false;
+  for (final decoder in matchingDecoders) {
+    if (decoder.maxWidth <= 0 || decoder.maxHeight <= 0) {
+      hasUnknownDimensions = true;
+      continue;
+    }
+    if (decoder.maxWidth >= requiredWidth &&
+        decoder.maxHeight >= requiredHeight) {
+      return ReleaseCodecCompatibility.supported;
+    }
+  }
+  return hasUnknownDimensions
+      ? ReleaseCodecCompatibility.unknown
+      : ReleaseCodecCompatibility.unsupported;
+}
+
+/// Known-incompatible releases are omitted from both the visible picker and
+/// automatic playback. Unknown codec metadata and an unavailable device
+/// inventory fail open so capability detection can never hide every source.
+bool releaseCodecIsPlayableOnDevice(
+  ReleaseCandidate release, {
+  TvDeviceProfile? device,
+}) =>
+    releaseCodecCompatibility(release, device: device) !=
+    ReleaseCodecCompatibility.unsupported;
+
+String? _videoCodecMime(String? source) {
+  final value = source?.trim().toLowerCase();
+  if (value == null || value.isEmpty) return null;
+  if (RegExp(
+    r'(^|[^a-z0-9])(?:av0?1|av[ ._-]1)(?=$|[^a-z0-9])',
+  ).hasMatch(value)) {
+    return 'video/av01';
+  }
+  if (RegExp(
+    r'(^|[^a-z0-9])(?:hevc|x265|h[ ._-]?265)(?=$|[^a-z0-9])',
+  ).hasMatch(value)) {
+    return 'video/hevc';
+  }
+  if (RegExp(
+    r'(^|[^a-z0-9])(?:avc|x264|h[ ._-]?264)(?=$|[^a-z0-9])',
+  ).hasMatch(value)) {
+    return 'video/avc';
+  }
+  if (RegExp(r'(^|[^a-z0-9])(?:vp[ ._-]?9)(?=$|[^a-z0-9])').hasMatch(value)) {
+    return 'video/x-vnd.on2.vp9';
+  }
+  return null;
+}
+
+/// Torrent results normally expose a vertical quality label rather than an
+/// exact raster. Use the standard 16:9 width paired with that height. This is
+/// intentionally only a rejection check when Android reports both decoder
+/// dimensions; unusual/unknown rasters remain available.
+int _standardVideoWidth(int height) => (height * 16 / 9).ceil();
+
 /// Soft affinity for keeping automatic fallback at the current stream's
 /// normalized resolution. Unknown or unavailable quality never filters a
 /// candidate; it only removes the affinity advantage.
@@ -321,12 +410,11 @@ int tvPlaybackCompatibilityScore(
   TvDeviceProfile? device,
   int previousFailures = 0,
 }) {
-  final codec = release.codec?.toUpperCase();
-  final codecRank = switch (codec) {
-    'H.264' => 0,
+  final codecRank = switch (releaseVideoCodecMime(release)) {
+    'video/avc' => 0,
     null => 1,
-    'HEVC' => 2,
-    'AV1' => 3,
+    'video/hevc' => 2,
+    'video/av01' => 3,
     _ => 1,
   };
   final resolutionPenalty = switch (release.quality?.toLowerCase()) {
@@ -335,7 +423,10 @@ int tvPlaybackCompatibilityScore(
     _ => 0,
   };
   final unsupportedCodec =
-      device != null && !device.supportsCodec(release.codec) ? 12 : 0;
+      releaseCodecCompatibility(release, device: device) ==
+          ReleaseCodecCompatibility.unsupported
+      ? 12
+      : 0;
   final unsupportedHdr = release.isHdr && device != null && !device.hasHdr
       ? 8
       : 0;
@@ -359,7 +450,10 @@ int automaticPlaybackSafetyScore(
 }) {
   final hasCapabilityInventory = device?.codecs.isNotEmpty == true;
   final unsupportedCodec =
-      hasCapabilityInventory && !device!.supportsCodec(release.codec) ? 12 : 0;
+      releaseCodecCompatibility(release, device: device) ==
+          ReleaseCodecCompatibility.unsupported
+      ? 12
+      : 0;
   final unsupportedHdr =
       release.isHdr && hasCapabilityInventory && !device!.hasHdr ? 8 : 0;
   final softwareOnlyProfile = releaseRequiresSoftwareDecoder(release) ? 6 : 0;
@@ -691,6 +785,7 @@ List<ReleaseCandidate> rankAutomaticAutoplayReleases(
   final strict = <ReleaseCandidate>[];
   final fallback = <ReleaseCandidate>[];
   for (final release in input) {
+    if (!releaseCodecIsPlayableOnDevice(release, device: device)) continue;
     if (automaticReleaseMatchesFilters(
       release,
       language: language,

--- a/lib/features/streaming/presentation/resolve_episode_screen.dart
+++ b/lib/features/streaming/presentation/resolve_episode_screen.dart
@@ -1102,7 +1102,19 @@ class _ResolveEpisodeScreenState extends ConsumerState<ResolveEpisodeScreen> {
         await for (final progress in progressStream) {
           if (!mounted || generation != _releaseSearchGeneration) return;
           setState(() {
-            _releases = progress.candidates;
+            // Android's codec list is authoritative only when it is present.
+            // Hide a known unsupported codec (for example AV1 on an AVC-only
+            // Google TV) before it can enter the picker, autoplay, failover,
+            // Watch Party matching, or player alternatives. Unknown codec
+            // labels and an unavailable inventory deliberately remain.
+            _releases = progress.candidates
+                .where(
+                  (release) => releaseCodecIsPlayableOnDevice(
+                    release,
+                    device: _deviceProfile,
+                  ),
+                )
+                .toList(growable: false);
             _releaseFailures = progress.failures;
             _debridSourcesCompleted = progress.completedSources;
             _debridSourcesTotal = progress.totalSources;
@@ -3482,7 +3494,8 @@ class _ResolveEpisodeScreenState extends ConsumerState<ResolveEpisodeScreen> {
     bool ignoreOptionalFilters = false,
   }) {
     final filtered = releases.where((release) {
-      return _releaseMatchesEpisodeIdentity(release) &&
+      return releaseCodecIsPlayableOnDevice(release, device: _deviceProfile) &&
+          _releaseMatchesEpisodeIdentity(release) &&
           releaseMatchesStreamFilters(
             release,
             language: ignoreOptionalFilters ? 'all' : _languageFilter.name,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: 'none'
 # Public and Beta artifacts built from the same source use one monotonically
 # increasing Android versionCode. The project default carries the Beta display
 # version; the Public universal APK overrides the build name to the 1.x line.
-version: 2.0.65+410042
+version: 2.0.66+410043
 
 environment:
   sdk: ^3.12.2

--- a/test/anime_details_screen_test.dart
+++ b/test/anime_details_screen_test.dart
@@ -477,7 +477,7 @@ void main() {
       await tester.pump(const Duration(milliseconds: 50));
     }
 
-    expect(find.text('Episode 4 of 12'), findsOneWidget);
+    expect(find.text('4 of 12'), findsOneWidget);
     expect(warmedEpisodes, isEmpty);
     await tester.pump(const Duration(milliseconds: 299));
     expect(warmedEpisodes, isEmpty);
@@ -568,7 +568,7 @@ void main() {
       await tester.pump();
       await tester.sendKeyEvent(LogicalKeyboardKey.enter);
       await tester.pump(const Duration(milliseconds: 100));
-      expect(find.text('Episode 2 of 12'), findsOneWidget);
+      expect(find.text('2 of 12'), findsOneWidget);
       expect(cancelledEpisodes, [1]);
       expect(activeHandles, 1);
 
@@ -585,7 +585,7 @@ void main() {
       await tester.sendKeyEvent(LogicalKeyboardKey.enter);
       await tester.pump();
       await tester.pump(const Duration(milliseconds: 299));
-      expect(find.text('Episode 1 of 12'), findsOneWidget);
+      expect(find.text('1 of 12'), findsOneWidget);
       expect(startedEpisodes, [1]);
 
       await tester.pump(const Duration(milliseconds: 1));
@@ -749,7 +749,7 @@ void main() {
     expect(find.text('Play from beginning'), findsOneWidget);
     expect(find.text('Start watching'), findsOneWidget);
     expect(find.text('My List status'), findsOneWidget);
-    expect(find.text('Episode 1 of 24'), findsOneWidget);
+    expect(find.text('1 of 24'), findsOneWidget);
     expect(find.text('Watch trailer'), findsOneWidget);
     expect(find.text('Cast & crew'), findsOneWidget);
     expect(find.text('Related series'), findsOneWidget);
@@ -1175,7 +1175,7 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(find.byType(TvKeyboardDialog), findsNothing);
-      expect(find.text('Episode 4 of 12'), findsOneWidget);
+      expect(find.text('4 of 12'), findsOneWidget);
       expect(
         find.byKey(const ValueKey('episode-step-previous')),
         findsOneWidget,
@@ -1184,6 +1184,162 @@ void main() {
       expect(tester.takeException(), isNull);
     },
   );
+
+  testWidgets(
+    'Down on the middle episode selector browses and restores selection focus',
+    (tester) async {
+      tester.view.physicalSize = const Size(960, 540);
+      tester.view.devicePixelRatio = 1;
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+
+      const anime = AnimeSummary(
+        id: 130,
+        title: 'Remote Episode Browser',
+        description: '',
+        episodes: 12,
+        score: 8,
+        status: 'RELEASING',
+        durationMinutes: 24,
+      );
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            isTelevisionProvider.overrideWithValue(true),
+            animeDetailsProvider.overrideWith((_, _) async => anime),
+            trackingHomeProvider.overrideWith(
+              (_) async => const TrackingHomeData(
+                watching: [],
+                planToWatch: [],
+                completed: [],
+              ),
+            ),
+            settingsPreferencesProvider.overrideWith(
+              (_) => _LoadedSettingsController(),
+            ),
+          ],
+          child: const MaterialApp(home: AnimeDetailsScreen(animeId: 130)),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      final selector = tester.widget<FocusableActionDetector>(
+        find
+            .descendant(
+              of: find.byKey(const ValueKey('episode-manual-selector')),
+              matching: find.byType(FocusableActionDetector),
+            )
+            .first,
+      );
+      selector.focusNode!.requestFocus();
+      await tester.pump();
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
+      await tester.pumpAndSettle();
+
+      expect(
+        find.byKey(const ValueKey('episode-browser-dialog')),
+        findsOneWidget,
+      );
+      expect(find.byType(TvKeyboardDialog), findsNothing);
+
+      await tester.tap(find.byKey(const ValueKey('episode-browser-card-4')));
+      await tester.pumpAndSettle();
+      expect(find.text('4 of 12'), findsOneWidget);
+      expect(selector.focusNode!.hasFocus, isTrue);
+
+      final previous = tester.widget<FocusableActionDetector>(
+        find
+            .descendant(
+              of: find.byKey(const ValueKey('episode-step-previous')),
+              matching: find.byType(FocusableActionDetector),
+            )
+            .first,
+      );
+      previous.focusNode!.requestFocus();
+      await tester.pump();
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
+      await tester.pumpAndSettle();
+      expect(
+        find.byKey(const ValueKey('episode-browser-dialog')),
+        findsOneWidget,
+      );
+      await tester.binding.handlePopRoute();
+      await tester.pumpAndSettle();
+      expect(previous.focusNode!.hasFocus, isTrue);
+      await tester.sendKeyEvent(LogicalKeyboardKey.enter);
+      await tester.pump();
+      expect(find.text('3 of 12'), findsOneWidget);
+
+      selector.focusNode!.requestFocus();
+      await tester.pump();
+      await tester.sendKeyEvent(LogicalKeyboardKey.enter);
+      await tester.pumpAndSettle();
+      expect(find.byType(TvKeyboardDialog), findsOneWidget);
+      expect(find.text('Choose episode (1–12)'), findsOneWidget);
+      expect(tester.takeException(), isNull);
+    },
+  );
+
+  testWidgets('Back closes the episode browser and restores middle focus', (
+    tester,
+  ) async {
+    tester.view.physicalSize = const Size(960, 540);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    const anime = AnimeSummary(
+      id: 131,
+      title: 'Episode Browser Back',
+      description: '',
+      episodes: 12,
+      score: 8,
+    );
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          isTelevisionProvider.overrideWithValue(true),
+          animeDetailsProvider.overrideWith((_, _) async => anime),
+          trackingHomeProvider.overrideWith(
+            (_) async => const TrackingHomeData(
+              watching: [],
+              planToWatch: [],
+              completed: [],
+            ),
+          ),
+          settingsPreferencesProvider.overrideWith(
+            (_) => _LoadedSettingsController(),
+          ),
+        ],
+        child: const MaterialApp(home: AnimeDetailsScreen(animeId: 131)),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    final selector = tester.widget<FocusableActionDetector>(
+      find
+          .descendant(
+            of: find.byKey(const ValueKey('episode-manual-selector')),
+            matching: find.byType(FocusableActionDetector),
+          )
+          .first,
+    );
+    selector.focusNode!.requestFocus();
+    await tester.pump();
+    await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
+    await tester.pumpAndSettle();
+    expect(
+      find.byKey(const ValueKey('episode-browser-dialog')),
+      findsOneWidget,
+    );
+
+    await tester.binding.handlePopRoute();
+    await tester.pumpAndSettle();
+    expect(find.byKey(const ValueKey('episode-browser-dialog')), findsNothing);
+    expect(selector.focusNode!.hasFocus, isTrue);
+    expect(find.text('1 of 12'), findsOneWidget);
+    expect(tester.takeException(), isNull);
+  });
 
   testWidgets(
     'episode number picker is semantics-actionable and Back restores focus',
@@ -1298,6 +1454,18 @@ void main() {
       );
       await tester.pumpAndSettle();
 
+      expect(
+        find.byWidgetPredicate(
+          (widget) =>
+              widget is Text &&
+              (widget.data?.startsWith(
+                    'Status: Releasing · next episode in ',
+                  ) ??
+                  false) &&
+              (widget.data?.endsWith('September 8, 2099') ?? false),
+        ),
+        findsOneWidget,
+      );
       await tester.tap(find.byKey(const ValueKey('episode-manual-selector')));
       await tester.pumpAndSettle();
       await tester.tap(find.text('CLEAR'));
@@ -1306,7 +1474,7 @@ void main() {
       await tester.tap(find.text('DONE'));
       await tester.pumpAndSettle();
 
-      expect(find.text('Episode 13 of 24'), findsOneWidget);
+      expect(find.text('13 of 24'), findsOneWidget);
       expect(find.text('Episode 13 has not aired yet.'), findsOneWidget);
       expect(find.text('Expected air date: September 8, 2099'), findsOneWidget);
       expect(
@@ -1378,7 +1546,7 @@ void main() {
       await tester.sendKeyEvent(LogicalKeyboardKey.enter);
       await tester.pump(const Duration(milliseconds: 400));
 
-      expect(find.text('Episode 2 of 24'), findsOneWidget);
+      expect(find.text('2 of 24'), findsOneWidget);
       expect(find.text('Episode 2 has not aired yet.'), findsOneWidget);
       expect(find.text('Expected air date: September 8, 2099'), findsOneWidget);
       expect(prefetchedEpisodes, [1]);

--- a/test/anime_details_watch_party_action_test.dart
+++ b/test/anime_details_watch_party_action_test.dart
@@ -272,6 +272,15 @@ void main() {
       ),
     );
     expect(nextEpisodeDetector.focusNode?.hasFocus, isTrue);
+    await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
+    await tester.pumpAndSettle();
+    expect(
+      find.byKey(const ValueKey('episode-browser-dialog')),
+      findsOneWidget,
+    );
+    await tester.binding.handlePopRoute();
+    await tester.pumpAndSettle();
+    expect(nextEpisodeDetector.focusNode?.hasFocus, isTrue);
     expect(
       find.descendant(
         of: find.byKey(const ValueKey('episode-actions-panel')),
@@ -306,7 +315,7 @@ void main() {
 
     expect(find.text('23456789'), findsOneWidget);
     expect(find.text('Watch Party Details Test • Episode 4'), findsOneWidget);
-    expect(find.text('Episode 4 of 12'), findsOneWidget);
+    expect(find.text('4 of 12'), findsOneWidget);
     expect(find.byKey(const ValueKey('episode-action-resume')), findsNothing);
     expect(find.byKey(const ValueKey('episode-action-restart')), findsNothing);
     expect(find.byKey(const ValueKey('episode-action-selected')), findsNothing);

--- a/test/anonymous_crash_reporter_test.dart
+++ b/test/anonymous_crash_reporter_test.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 import 'package:anime_tv/core/diagnostics/anonymous_crash_reporter.dart';
 import 'package:anime_tv/core/platform/android_tv_bridge.dart';
 import 'package:anime_tv/features/catalog/domain/catalog_availability_exception.dart';
+import 'package:anime_tv/features/settings/application/simkl_account_controller.dart';
 import 'package:anime_tv/features/streaming/domain/debrid_service.dart';
 import 'package:anime_tv/features/streaming/domain/stream_resolver.dart';
 import 'package:anime_tv/features/tracking/application/my_list_controller.dart';
@@ -162,6 +163,7 @@ void main() {
         CatalogTrackingValidationError.connectionRequired(),
         CatalogTrackingValidationError.missingMediaId(),
         const AiringCalendarUnavailableException(),
+        const SimklBrokerNotConfigured(),
         StateError('No results matched these filters.'),
         StateError('authorization_pending'),
         StateError('access_denied'),

--- a/test/app_notification_controller_test.dart
+++ b/test/app_notification_controller_test.dart
@@ -77,6 +77,19 @@ void main() {
         expect((await store.load()).where((item) => !item.isRead), isEmpty);
       },
     );
+
+    test('reading survives a device clock correction', () async {
+      final createdAt = DateTime.utc(2026, 9, 2);
+      final notice = _notice(createdAt: createdAt);
+      await store.upsert(notice);
+
+      await store.markRead(
+        notice.id,
+        createdAt.subtract(const Duration(days: 1)),
+      );
+
+      expect((await store.load()).single.readAtUtc, createdAt);
+    });
   });
 
   test(
@@ -164,32 +177,29 @@ void main() {
       await database.close();
     });
 
-    test(
-      'available update is durable, deduplicated, and opens updates',
-      () async {
-        final update = _updateState();
+    test('available update is durable, deduplicated, and actionable', () async {
+      final update = _updateState();
 
-        await controller.syncAppUpdate(update);
-        expect(controller.state.unreadCount, 1);
-        expect(
-          controller.state.items.single.actionRoute,
-          '/settings/accounts?section=app-updates',
-        );
+      await controller.syncAppUpdate(update);
+      expect(controller.state.unreadCount, 1);
+      expect(
+        controller.state.items.single.action,
+        AppNotificationAction.openAppUpdates,
+      );
 
-        await controller.markRead(controller.state.items.single.id);
-        expect(controller.state.unreadCount, 0);
-        await controller.syncAppUpdate(update.copyWith(progress: .8));
+      await controller.markRead(controller.state.items.single.id);
+      expect(controller.state.unreadCount, 0);
+      await controller.syncAppUpdate(update.copyWith(progress: .8));
 
-        expect(controller.state.items, hasLength(1));
-        expect(controller.state.items.single.isRead, isTrue);
+      expect(controller.state.items, hasLength(1));
+      expect(controller.state.items.single.isRead, isTrue);
 
-        final restored = AppNotificationController(store, clock: () => clock);
-        addTearDown(restored.dispose);
-        await restored.load();
-        expect(restored.state.items, hasLength(1));
-        expect(restored.state.unreadCount, 0);
-      },
-    );
+      final restored = AppNotificationController(store, clock: () => clock);
+      addTearDown(restored.dispose);
+      await restored.load();
+      expect(restored.state.items, hasLength(1));
+      expect(restored.state.unreadCount, 0);
+    });
 
     test('newer build replaces the stale same-channel item', () async {
       await controller.syncAppUpdate(_updateState());
@@ -215,6 +225,34 @@ void main() {
       expect(body, isNot(contains('https://')));
       expect(body, isNot(contains('**')));
       expect(body.length, lessThanOrEqualTo(480));
+    });
+
+    test('switching update channels removes the unactionable notice', () async {
+      await store.upsert(
+        AppNotification(
+          id: 'app-update:public:420001',
+          kind: AppNotificationKind.appUpdate,
+          title: 'TetoTV 1.0.1 is available',
+          body: 'Public update',
+          action: AppNotificationAction.openAppUpdates,
+          createdAtUtc: clock,
+          targetVersion: '1.0.1',
+          targetVersionCode: 420001,
+          targetChannel: 'public',
+        ),
+      );
+      await controller.load();
+      expect(controller.state.items, hasLength(1));
+
+      await controller.syncAppUpdate(
+        const AppUpdateState(
+          loaded: true,
+          currentVersion: '2.0.64+410041',
+          updateChannel: AppUpdateChannel.beta,
+        ),
+      );
+
+      expect(controller.state.items, isEmpty);
     });
 
     test(

--- a/test/app_notification_controller_test.dart
+++ b/test/app_notification_controller_test.dart
@@ -1,0 +1,293 @@
+import 'dart:io';
+
+import 'package:anime_tv/core/notifications/app_notification.dart';
+import 'package:anime_tv/core/notifications/app_notification_controller.dart';
+import 'package:anime_tv/core/notifications/app_notification_store.dart';
+import 'package:anime_tv/core/storage/tetotv_database.dart';
+import 'package:anime_tv/features/settings/application/app_update_controller.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sqflite_common_ffi/sqflite_ffi.dart';
+
+void main() {
+  setUpAll(sqfliteFfiInit);
+
+  group('AppNotificationStore', () {
+    late Database database;
+    late AppNotificationStore store;
+
+    setUp(() async {
+      database = await databaseFactoryFfi.openDatabase(
+        inMemoryDatabasePath,
+        options: OpenDatabaseOptions(
+          version: 1,
+          onCreate: (database, _) => createAppNotificationsTable(database),
+        ),
+      );
+      store = AppNotificationStore(TetoTvDatabase.forTesting(database));
+    });
+
+    tearDown(() => database.close());
+
+    test('duplicate upserts preserve the original read state', () async {
+      final createdAt = DateTime.utc(2026, 9, 2, 12);
+      final readAt = createdAt.add(const Duration(minutes: 1));
+      final notice = _notice(createdAt: createdAt);
+
+      await store.upsert(notice);
+      await store.markRead(notice.id, readAt);
+      await store.upsert(
+        AppNotification(
+          id: notice.id,
+          kind: notice.kind,
+          title: 'Updated title',
+          body: 'Updated body',
+          action: notice.action,
+          createdAtUtc: createdAt.add(const Duration(hours: 1)),
+          targetVersion: notice.targetVersion,
+          targetVersionCode: notice.targetVersionCode,
+          targetChannel: notice.targetChannel,
+        ),
+      );
+
+      final stored = (await store.load()).single;
+      expect(stored.title, 'Updated title');
+      expect(stored.body, 'Updated body');
+      expect(stored.createdAtUtc, createdAt);
+      expect(stored.readAtUtc, readAt);
+    });
+
+    test(
+      'mark all read persists and unread ordering is newest first',
+      () async {
+        final first = _notice(createdAt: DateTime.utc(2026, 9, 1));
+        final second = _notice(
+          id: 'app-update:beta:410043',
+          version: '2.0.66',
+          versionCode: 410043,
+          createdAt: DateTime.utc(2026, 9, 2),
+        );
+        await store.upsert(first);
+        await store.upsert(second);
+
+        expect((await store.load()).map((item) => item.id), [
+          second.id,
+          first.id,
+        ]);
+        await store.markAllRead(DateTime.utc(2026, 9, 3));
+        expect((await store.load()).where((item) => !item.isRead), isEmpty);
+      },
+    );
+  });
+
+  test(
+    'v10 to v11 migration preserves data and creates notification inbox',
+    () async {
+      final temporary = await Directory.systemTemp.createTemp(
+        'tetotv-notifications-v11-',
+      );
+      final databasePath =
+          '${temporary.path}${Platform.pathSeparator}tetotv.db';
+      addTearDown(() async {
+        await databaseFactoryFfi.deleteDatabase(databasePath);
+        if (temporary.existsSync()) temporary.deleteSync(recursive: true);
+      });
+
+      var database = await databaseFactoryFfi.openDatabase(
+        databasePath,
+        options: OpenDatabaseOptions(
+          version: 10,
+          onCreate: (database, _) async {
+            await database.execute('''
+            CREATE TABLE legacy_fixture (
+              id INTEGER PRIMARY KEY,
+              value TEXT NOT NULL
+            )
+          ''');
+            await database.insert('legacy_fixture', {
+              'id': 1,
+              'value': 'preserved',
+            });
+          },
+        ),
+      );
+      await database.close();
+
+      database = await databaseFactoryFfi.openDatabase(
+        databasePath,
+        options: OpenDatabaseOptions(
+          version: tetoTvDatabaseSchemaVersion,
+          onConfigure: configureTetoTvDatabase,
+          onUpgrade: upgradeTetoTvDatabaseSchema,
+        ),
+      );
+      addTearDown(database.close);
+
+      expect(
+        (await database.query('legacy_fixture')).single['value'],
+        'preserved',
+      );
+      expect(await database.getVersion(), 11);
+      final table = await database.rawQuery(
+        "SELECT name FROM sqlite_master WHERE type = 'table' AND name = ?",
+        ['app_notifications'],
+      );
+      expect(table, hasLength(1));
+      final indexes = await database.rawQuery(
+        "SELECT name FROM sqlite_master WHERE type = 'index' AND name = ?",
+        ['app_notifications_unread_created'],
+      );
+      expect(indexes, hasLength(1));
+    },
+  );
+
+  group('AppNotificationController', () {
+    late Database database;
+    late AppNotificationStore store;
+    late AppNotificationController controller;
+    final clock = DateTime.utc(2026, 9, 2, 12);
+
+    setUp(() async {
+      database = await databaseFactoryFfi.openDatabase(
+        inMemoryDatabasePath,
+        options: OpenDatabaseOptions(
+          version: 1,
+          onCreate: (database, _) => createAppNotificationsTable(database),
+        ),
+      );
+      store = AppNotificationStore(TetoTvDatabase.forTesting(database));
+      controller = AppNotificationController(store, clock: () => clock);
+      await controller.load();
+    });
+
+    tearDown(() async {
+      controller.dispose();
+      await database.close();
+    });
+
+    test(
+      'available update is durable, deduplicated, and opens updates',
+      () async {
+        final update = _updateState();
+
+        await controller.syncAppUpdate(update);
+        expect(controller.state.unreadCount, 1);
+        expect(
+          controller.state.items.single.actionRoute,
+          '/settings/accounts?section=app-updates',
+        );
+
+        await controller.markRead(controller.state.items.single.id);
+        expect(controller.state.unreadCount, 0);
+        await controller.syncAppUpdate(update.copyWith(progress: .8));
+
+        expect(controller.state.items, hasLength(1));
+        expect(controller.state.items.single.isRead, isTrue);
+
+        final restored = AppNotificationController(store, clock: () => clock);
+        addTearDown(restored.dispose);
+        await restored.load();
+        expect(restored.state.items, hasLength(1));
+        expect(restored.state.unreadCount, 0);
+      },
+    );
+
+    test('newer build replaces the stale same-channel item', () async {
+      await controller.syncAppUpdate(_updateState());
+      await controller.markAllRead();
+      await controller.syncAppUpdate(
+        _updateState(version: '2.0.66', versionCode: 410043),
+      );
+
+      expect(controller.state.items, hasLength(1));
+      expect(controller.state.unreadCount, 1);
+      expect(controller.state.items.single.targetVersionCode, 410043);
+    });
+
+    test('release notes are stored as bounded plain text', () async {
+      final markdown =
+          '# Changes\n[Details](https://example.invalid/private) **Faster** updates '
+          '${'with more fixes ' * 80}`code`';
+
+      await controller.syncAppUpdate(_updateState(notes: markdown));
+
+      final body = controller.state.items.single.body;
+      expect(body, startsWith('Changes Details Faster updates'));
+      expect(body, isNot(contains('https://')));
+      expect(body, isNot(contains('**')));
+      expect(body.length, lessThanOrEqualTo(480));
+    });
+
+    test(
+      'installed and up-to-date releases clear stale update items',
+      () async {
+        await controller.syncAppUpdate(_updateState());
+        expect(controller.state.items, hasLength(1));
+
+        await controller.syncAppUpdate(
+          _updateState(
+            currentVersion: '2.0.65+410042',
+            phase: AppUpdatePhase.idle,
+          ),
+        );
+        expect(controller.state.items, isEmpty);
+
+        await controller.syncAppUpdate(
+          _updateState(version: '2.0.66', versionCode: 410043),
+        );
+        await controller.syncAppUpdate(
+          _updateState(
+            version: '2.0.66',
+            versionCode: 410043,
+            currentVersion: '2.0.66+410043',
+            phase: AppUpdatePhase.upToDate,
+          ),
+        );
+        expect(controller.state.items, isEmpty);
+      },
+    );
+  });
+}
+
+AppNotification _notice({
+  String id = 'app-update:beta:410042',
+  String version = '2.0.65',
+  int versionCode = 410042,
+  required DateTime createdAt,
+}) => AppNotification(
+  id: id,
+  kind: AppNotificationKind.appUpdate,
+  title: 'TetoTV $version Beta is available',
+  body: 'A new Beta update is ready to install from TetoTV settings.',
+  action: AppNotificationAction.openAppUpdates,
+  createdAtUtc: createdAt,
+  targetVersion: version,
+  targetVersionCode: versionCode,
+  targetChannel: 'beta',
+);
+
+AppUpdateState _updateState({
+  String version = '2.0.65',
+  int versionCode = 410042,
+  String currentVersion = '2.0.64+410041',
+  AppUpdatePhase phase = AppUpdatePhase.ready,
+  String notes = '',
+}) => AppUpdateState(
+  loaded: true,
+  phase: phase,
+  currentVersion: currentVersion,
+  latestVersion: version,
+  updateChannel: AppUpdateChannel.beta,
+  release: AppReleaseInfo(
+    tagName: 'v$version',
+    version: version,
+    name: 'TetoTV $version',
+    notes: notes,
+    androidVersionCode: versionCode,
+    asset: const AppReleaseAsset(
+      name: 'TetoTV-universal.apk',
+      apiUrl: 'https://api.github.com/example',
+      publicUrl: 'https://github.com/example',
+      size: 1,
+    ),
+  ),
+);

--- a/test/episode_airing_availability_test.dart
+++ b/test/episode_airing_availability_test.dart
@@ -5,6 +5,46 @@ import 'package:flutter_test/flutter_test.dart';
 void main() {
   final now = DateTime.utc(2026, 9, 2, 12);
 
+  test('describes a known next episode without estimating a schedule', () {
+    final anime = AnimeSummary(
+      id: 6,
+      title: 'Countdown series',
+      description: '',
+      episodes: 12,
+      score: null,
+      status: 'RELEASING',
+      nextAiringEpisode: 7,
+      nextAiringAt: DateTime.utc(2026, 9, 5, 12),
+    );
+
+    expect(
+      nextEpisodeAiringCountdownLabel(anime: anime, now: now),
+      'next episode in 3 days',
+    );
+    expect(
+      episodeAiringDateLabel(anime.nextAiringAt!),
+      contains('September 5, 2026'),
+    );
+  });
+
+  test('does not fabricate a next-episode countdown', () {
+    expect(
+      nextEpisodeAiringCountdownLabel(
+        anime: const AnimeSummary(
+          id: 7,
+          title: 'Schedule unknown',
+          description: '',
+          episodes: 12,
+          score: null,
+          status: 'RELEASING',
+          nextAiringEpisode: 7,
+        ),
+        now: now,
+      ),
+      isNull,
+    );
+  });
+
   test('marks the explicitly scheduled next episode unaired with its date', () {
     final availability = episodeAiringAvailability(
       anime: AnimeSummary(

--- a/test/episode_browser_dialog_test.dart
+++ b/test/episode_browser_dialog_test.dart
@@ -1,0 +1,180 @@
+import 'package:anime_tv/core/theme/app_theme.dart';
+import 'package:anime_tv/features/catalog/domain/anime_summary.dart';
+import 'package:anime_tv/features/catalog/presentation/episode_browser_dialog.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('large TV browser presents a paged four-by-four episode grid', (
+    tester,
+  ) async {
+    tester.view.physicalSize = const Size(1920, 1080);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    int? selectedEpisode;
+    const anime = AnimeSummary(
+      id: 901,
+      title: 'Episode Browser Show',
+      description: 'Series synopsis must not be reused for an episode.',
+      episodes: 1184,
+      score: 8,
+      durationMinutes: 24,
+    );
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: AppTheme.dark,
+        home: Scaffold(
+          body: Builder(
+            builder: (context) => FilledButton(
+              onPressed: () async {
+                selectedEpisode = await showEpisodeBrowserDialog(
+                  context,
+                  anime: anime,
+                  selectedEpisode: 1,
+                  totalEpisodes: 1184,
+                );
+              },
+              child: const Text('Browse'),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.text('Browse'));
+    await tester.pumpAndSettle();
+
+    expect(
+      find.byKey(const ValueKey('episode-browser-dialog')),
+      findsOneWidget,
+    );
+    for (var episode = 1; episode <= 16; episode++) {
+      expect(
+        find.byKey(ValueKey('episode-browser-card-$episode')),
+        findsOneWidget,
+      );
+    }
+    expect(find.byKey(const ValueKey('episode-browser-card-17')), findsNothing);
+    final first = tester.getRect(
+      find.byKey(const ValueKey('episode-browser-card-1')),
+    );
+    final fourth = tester.getRect(
+      find.byKey(const ValueKey('episode-browser-card-4')),
+    );
+    final fifth = tester.getRect(
+      find.byKey(const ValueKey('episode-browser-card-5')),
+    );
+    expect(fourth.top, closeTo(first.top, .01));
+    expect(fourth.left, greaterThan(first.left));
+    expect(fifth.top, greaterThan(first.top));
+    expect(fifth.left, closeTo(first.left, .01));
+    expect(find.text('Episode synopsis unavailable.'), findsWidgets);
+    expect(find.text('24 min'), findsWidgets);
+    expect(
+      find.byKey(const ValueKey('episode-browser-page-ellipsis-4')),
+      findsOneWidget,
+    );
+    expect(find.text('74'), findsOneWidget);
+
+    await tester.tap(find.byKey(const ValueKey('episode-browser-next-page')));
+    await tester.pumpAndSettle();
+    expect(find.byKey(const ValueKey('episode-browser-card-1')), findsNothing);
+    expect(
+      find.byKey(const ValueKey('episode-browser-card-17')),
+      findsOneWidget,
+    );
+    expect(
+      find.byKey(const ValueKey('episode-browser-card-32')),
+      findsOneWidget,
+    );
+
+    await tester.tap(find.byKey(const ValueKey('episode-browser-card-20')));
+    await tester.pumpAndSettle();
+    expect(selectedEpisode, 20);
+    expect(find.byKey(const ValueKey('episode-browser-dialog')), findsNothing);
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('browser marks known unaired episodes without inventing dates', (
+    tester,
+  ) async {
+    tester.view.physicalSize = const Size(960, 540);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    final anime = AnimeSummary(
+      id: 902,
+      title: 'Weekly Show',
+      description: '',
+      episodes: 24,
+      score: null,
+      status: 'RELEASING',
+      durationMinutes: 23,
+      nextAiringEpisode: 13,
+      nextAiringAt: DateTime(2099, 9, 8, 12),
+    );
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: AppTheme.dark,
+        home: EpisodeBrowserDialog(
+          anime: anime,
+          selectedEpisode: 13,
+          totalEpisodes: 24,
+          now: DateTime(2099, 9, 1),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(
+      find.byKey(const ValueKey('episode-browser-card-13')),
+      findsOneWidget,
+    );
+    expect(find.text('September 8, 2099'), findsOneWidget);
+    // Only the immediate next episode has an authoritative date. Later
+    // future episodes stay clearly unavailable without borrowing that date.
+    expect(find.text('UNAIRED'), findsWidgets);
+    expect(find.text('This episode has not aired yet.'), findsWidgets);
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('a one-page episode browser does not render pagination', (
+    tester,
+  ) async {
+    tester.view.physicalSize = const Size(960, 540);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: AppTheme.dark,
+        home: const EpisodeBrowserDialog(
+          anime: AnimeSummary(
+            id: 903,
+            title: 'Short Show',
+            description: '',
+            episodes: 4,
+            score: null,
+          ),
+          selectedEpisode: 1,
+          totalEpisodes: 4,
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(
+      find.byKey(const ValueKey('episode-browser-card-4')),
+      findsOneWidget,
+    );
+    expect(
+      find.byKey(const ValueKey('episode-browser-pagination')),
+      findsNothing,
+    );
+    expect(tester.takeException(), isNull);
+  });
+}

--- a/test/home_notification_bell_test.dart
+++ b/test/home_notification_bell_test.dart
@@ -1,0 +1,304 @@
+import 'dart:io';
+
+import 'package:anime_tv/core/notifications/app_notification.dart';
+import 'package:anime_tv/core/notifications/app_notification_controller.dart';
+import 'package:anime_tv/core/notifications/app_notification_store.dart';
+import 'package:anime_tv/core/storage/tetotv_database.dart';
+import 'package:anime_tv/core/theme/app_theme.dart';
+import 'package:anime_tv/features/home/presentation/main_navigation_bar.dart';
+import 'package:anime_tv/features/settings/application/app_update_controller.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('bell caps the visible badge but announces the exact count', (
+    tester,
+  ) async {
+    final notifications = AppNotificationController(
+      _MemoryNotificationStore([
+        for (var index = 0; index < 100; index++)
+          AppNotification(
+            id: 'app-update:beta:${410042 + index}',
+            kind: AppNotificationKind.appUpdate,
+            title: 'TetoTV update ${index + 1}',
+            body: 'Update available.',
+            action: AppNotificationAction.openAppUpdates,
+            createdAtUtc: DateTime.utc(
+              2026,
+              9,
+              2,
+            ).add(Duration(minutes: index)),
+            targetVersion: '2.0.${65 + index}',
+            targetVersionCode: 410042 + index,
+            targetChannel: 'beta',
+          ),
+      ]),
+    );
+    await notifications.load();
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          appNotificationControllerProvider.overrideWith((_) => notifications),
+        ],
+        child: MaterialApp(
+          theme: AppTheme.dark,
+          home: const Scaffold(body: TetoNotificationBell()),
+        ),
+      ),
+    );
+    await tester.pump();
+
+    expect(find.text('99+'), findsOneWidget);
+    final semantics = tester.widget<Semantics>(
+      find.byKey(const ValueKey('notification-bell-semantics')),
+    );
+    expect(
+      semantics.properties.label,
+      'Notifications, 100 unread notifications',
+    );
+
+    await tester.pumpWidget(const SizedBox());
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('update panel stays live, closes safely, and installs', (
+    tester,
+  ) async {
+    tester.view.physicalSize = const Size(1280, 720);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+    final store = _MemoryNotificationStore([_notice()]);
+    final notifications = AppNotificationController(store);
+    await notifications.load();
+    final updates = _TestAppUpdateController(_readyUpdateState());
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          appNotificationControllerProvider.overrideWith((_) => notifications),
+          appUpdateControllerProvider.overrideWith((_) => updates),
+        ],
+        child: MaterialApp(
+          theme: AppTheme.dark,
+          home: const Scaffold(
+            body: Align(
+              alignment: Alignment.topRight,
+              child: TetoNotificationBell(),
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(
+      tester.getSize(find.byType(TetoNotificationBell)),
+      const Size.square(52),
+    );
+    expect(find.text('1'), findsOneWidget);
+    await tester.tap(find.byType(TetoNotificationBell));
+    await tester.pumpAndSettle();
+    expect(
+      find.byKey(const ValueKey('notification-menu-surface')),
+      findsOneWidget,
+    );
+    expect(find.text('Beta'), findsOneWidget);
+    expect(find.text('Install'), findsOneWidget);
+    expect(notifications.state.unreadCount, 0);
+
+    updates.setTestState(
+      _readyUpdateState().copyWith(
+        phase: AppUpdatePhase.downloading,
+        progress: .42,
+        message: 'Downloading update…',
+      ),
+    );
+    await tester.pump();
+    expect(
+      find.byKey(const ValueKey('notification-update-progress')),
+      findsOneWidget,
+    );
+    expect(find.text('Downloading update…'), findsOneWidget);
+
+    await tester.sendKeyDownEvent(
+      LogicalKeyboardKey.goBack,
+      physicalKey: PhysicalKeyboardKey.escape,
+    );
+    await tester.pump();
+    expect(
+      find.byKey(const ValueKey('notification-menu-surface')),
+      findsOneWidget,
+    );
+    await tester.sendKeyUpEvent(
+      LogicalKeyboardKey.goBack,
+      physicalKey: PhysicalKeyboardKey.escape,
+    );
+    await tester.pumpAndSettle();
+    expect(
+      find.byKey(const ValueKey('notification-menu-surface')),
+      findsNothing,
+    );
+
+    updates.setTestState(_readyUpdateState());
+    await tester.tap(find.byType(TetoNotificationBell));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Install'));
+    await tester.pumpAndSettle();
+    expect(updates.installCalls, 1);
+
+    await tester.pumpWidget(const SizedBox());
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('empty inbox can manually check for updates', (tester) async {
+    tester.view.physicalSize = const Size(390, 844);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+    final notifications = AppNotificationController(
+      _MemoryNotificationStore(const []),
+    );
+    await notifications.load();
+    final updates = _TestAppUpdateController(
+      const AppUpdateState(loaded: true, phase: AppUpdatePhase.idle),
+    );
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          appNotificationControllerProvider.overrideWith((_) => notifications),
+          appUpdateControllerProvider.overrideWith((_) => updates),
+        ],
+        child: MaterialApp(
+          theme: AppTheme.dark,
+          home: const Scaffold(
+            body: Align(
+              alignment: Alignment.topRight,
+              child: TetoNotificationBell(),
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(
+      find.byKey(const ValueKey('notification-unread-badge')),
+      findsNothing,
+    );
+    await tester.tap(find.byType(TetoNotificationBell));
+    await tester.pumpAndSettle();
+    expect(find.text('You\'re all caught up'), findsOneWidget);
+    await tester.tap(find.byKey(const ValueKey('notification-empty-check')));
+    await tester.pumpAndSettle();
+    expect(updates.checkCalls, 1);
+    expect(updates.lastAutomatic, isFalse);
+    expect(updates.lastLaunchInstaller, isFalse);
+
+    await tester.pumpWidget(const SizedBox());
+    expect(tester.takeException(), isNull);
+  });
+}
+
+AppNotification _notice() => AppNotification(
+  id: 'app-update:beta:410042',
+  kind: AppNotificationKind.appUpdate,
+  title: 'TetoTV 2.0.65 Beta is available',
+  body: 'A new Beta update is ready to install from TetoTV settings.',
+  action: AppNotificationAction.openAppUpdates,
+  createdAtUtc: DateTime.utc(2026, 9, 2),
+  targetVersion: '2.0.65',
+  targetVersionCode: 410042,
+  targetChannel: 'beta',
+);
+
+AppUpdateState _readyUpdateState() => AppUpdateState(
+  loaded: true,
+  phase: AppUpdatePhase.ready,
+  currentVersion: '2.0.64+410041',
+  latestVersion: '2.0.65',
+  updateChannel: AppUpdateChannel.beta,
+  message: 'TetoTV 2.0.65 Beta is ready to install.',
+  release: AppReleaseInfo(
+    tagName: 'v2.0.65',
+    version: '2.0.65',
+    name: 'TetoTV 2.0.65',
+    androidVersionCode: 410042,
+    asset: const AppReleaseAsset(
+      name: 'TetoTV-v2.0.65-universal.apk',
+      apiUrl: 'https://api.github.com/example',
+      publicUrl: 'https://github.com/example',
+      size: 1,
+    ),
+  ),
+);
+
+class _TestAppUpdateController extends AppUpdateController {
+  _TestAppUpdateController(AppUpdateState initial)
+    : super(
+        const FlutterSecureStorage(),
+        _UnusedReleaseSource(),
+        () async => initial.currentVersion,
+        () async => const [],
+        () async => Directory.systemTemp,
+        (_) async => '',
+      ) {
+    state = initial;
+  }
+
+  int checkCalls = 0;
+  int installCalls = 0;
+  bool? lastAutomatic;
+  bool? lastLaunchInstaller;
+
+  void setTestState(AppUpdateState value) => state = value;
+
+  @override
+  Future<void> checkForUpdates({
+    bool automatic = false,
+    bool launchInstaller = false,
+  }) async {
+    checkCalls++;
+    lastAutomatic = automatic;
+    lastLaunchInstaller = launchInstaller;
+  }
+
+  @override
+  Future<void> installDownloadedUpdate() async {
+    installCalls++;
+  }
+}
+
+class _UnusedReleaseSource extends AppReleaseSource {
+  @override
+  Future<AppReleaseInfo> latest({required List<String> deviceAbis}) =>
+      throw UnimplementedError();
+
+  @override
+  Future<void> download({
+    required AppReleaseInfo release,
+    required String destination,
+    required void Function(int received, int total) onProgress,
+  }) => throw UnimplementedError();
+}
+
+class _MemoryNotificationStore extends AppNotificationStore {
+  _MemoryNotificationStore(List<AppNotification> seed)
+    : _items = List.of(seed),
+      super(TetoTvDatabase.instance);
+
+  List<AppNotification> _items;
+
+  @override
+  Future<List<AppNotification>> load() async => List.unmodifiable(_items);
+
+  @override
+  Future<void> markAllRead(DateTime readAtUtc) async {
+    _items = [for (final item in _items) item.copyWith(readAtUtc: readAtUtc)];
+  }
+}

--- a/test/home_tv_navigation_test.dart
+++ b/test/home_tv_navigation_test.dart
@@ -161,6 +161,10 @@ void main() {
       await tester.pump(const Duration(milliseconds: 120));
 
       expect(find.byKey(const ValueKey('home-header-search')), findsOneWidget);
+      expect(
+        find.byKey(const ValueKey('home-notification-bell')),
+        findsOneWidget,
+      );
       expect(find.byKey(const ValueKey('home-profile-switcher')), findsNothing);
 
       final measuredWidths = <double>[];
@@ -1072,7 +1076,11 @@ void main() {
       final switcherFinder = find.byKey(
         const ValueKey('home-profile-switcher'),
       );
+      final notificationFinder = find.byKey(
+        const ValueKey('home-notification-bell'),
+      );
       expect(searchFinder, findsOneWidget);
+      expect(notificationFinder, findsOneWidget);
       expect(switcherFinder, findsOneWidget);
       expect(
         find.descendant(of: searchFinder, matching: find.text('Search')),
@@ -1092,6 +1100,7 @@ void main() {
       expect(find.byKey(const ValueKey('teto-profile-chevron')), findsNothing);
       final searchRect = tester.getRect(searchFinder);
       final switcherRect = tester.getRect(switcherFinder);
+      final notificationRect = tester.getRect(notificationFinder);
       final searchIconRect = tester.getRect(
         find.byKey(const ValueKey('home-header-search-icon')),
       );
@@ -1122,10 +1131,16 @@ void main() {
       );
       final searchDecoration = searchSurface.decoration! as BoxDecoration;
       expect(searchDecoration.borderRadius, BorderRadius.circular(12));
-      expect(searchRect.right, lessThan(switcherRect.left));
+      expect(searchRect.right, lessThan(notificationRect.left));
+      expect(notificationRect.right, lessThan(switcherRect.left));
+      expect(notificationRect.size, const Size.square(52));
       expect(switcherRect.size, const Size(52, 52));
       expect(
         (searchRect.center.dy - switcherRect.center.dy).abs(),
+        lessThan(.5),
+      );
+      expect(
+        (notificationRect.center.dy - switcherRect.center.dy).abs(),
         lessThan(.5),
       );
 
@@ -1166,6 +1181,12 @@ void main() {
       await tester.pump();
       expect(
         FocusManager.instance.primaryFocus?.debugLabel,
+        'home.notifications',
+      );
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowRight);
+      await tester.pump();
+      expect(
+        FocusManager.instance.primaryFocus?.debugLabel,
         'home.profile-switcher',
       );
       await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
@@ -1178,7 +1199,19 @@ void main() {
       await tester.pump();
       expect(
         FocusManager.instance.primaryFocus?.debugLabel,
+        'home.notifications',
+      );
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowRight);
+      await tester.pump();
+      expect(
+        FocusManager.instance.primaryFocus?.debugLabel,
         'home.profile-switcher',
+      );
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowLeft);
+      await tester.pump();
+      expect(
+        FocusManager.instance.primaryFocus?.debugLabel,
+        'home.notifications',
       );
       await tester.sendKeyEvent(LogicalKeyboardKey.arrowLeft);
       await tester.pump();

--- a/test/mobile_adaptive_navigation_test.dart
+++ b/test/mobile_adaptive_navigation_test.dart
@@ -414,6 +414,7 @@ void main() {
       findsOneWidget,
     );
     final switcher = find.byKey(const ValueKey('home-profile-switcher'));
+    final notification = find.byKey(const ValueKey('home-notification-bell'));
     final avatar = find.byKey(
       const ValueKey('main-nav-profile-avatar-anilist'),
     );
@@ -422,12 +423,14 @@ void main() {
       matching: find.byIcon(Icons.keyboard_arrow_down_rounded),
     );
     expect(switcher, findsOneWidget);
+    expect(notification, findsOneWidget);
     expect(avatar, findsOneWidget);
     expect(find.text('LindowsOS'), findsNothing);
     expect(chevron, findsNothing);
     expect(find.byKey(const ValueKey('teto-profile-username')), findsNothing);
     expect(find.byKey(const ValueKey('teto-profile-chevron')), findsNothing);
     expect(tester.getSize(switcher).width, 52);
+    expect(tester.getSize(notification), const Size.square(52));
     final headerRect = tester.getRect(
       find.byKey(const ValueKey('home-top-right-header')),
     );
@@ -435,6 +438,7 @@ void main() {
       find.byKey(const ValueKey('home-header-search')),
     );
     final switcherRect = tester.getRect(switcher);
+    final notificationRect = tester.getRect(notification);
     final searchIconFrameRect = tester.getRect(
       find.byKey(const ValueKey('home-header-search-icon-frame')),
     );
@@ -452,6 +456,12 @@ void main() {
     expect(searchIconRect.top - searchRect.top, greaterThanOrEqualTo(16));
     expect(searchRect.bottom - searchIconRect.bottom, greaterThanOrEqualTo(16));
     expect((searchRect.center.dy - switcherRect.center.dy).abs(), lessThan(.5));
+    expect(
+      (notificationRect.center.dy - switcherRect.center.dy).abs(),
+      lessThan(.5),
+    );
+    expect(searchRect.right, lessThan(notificationRect.left));
+    expect(notificationRect.right, lessThan(switcherRect.left));
     final searchSurface = tester.widget<Container>(
       find.byKey(const ValueKey('tv-text-input-header-search')),
     );

--- a/test/resolve_episode_screen_test.dart
+++ b/test/resolve_episode_screen_test.dart
@@ -549,6 +549,84 @@ void main() {
         );
   });
 
+  testWidgets(
+    'manual picker hides AV1 only when this device lacks a hardware decoder',
+    (tester) async {
+      FlutterSecureStorage.setMockInitialValues({
+        DebridService.realDebrid.tokenStorageKey: 'valid-manual-token',
+        'streaming_web_enabled': 'false',
+      });
+      await tester.binding.setSurfaceSize(const Size(1920, 1080));
+      addTearDown(() => tester.binding.setSurfaceSize(null));
+      const av1 = ReleaseCandidate(
+        infoHash: '1111111111111111111111111111111111111111',
+        magnetUri:
+            'magnet:?xt=urn:btih:1111111111111111111111111111111111111111',
+        releaseName: 'Unsupported AV1 release',
+        seeders: 50,
+        sourceId: 'test',
+        quality: '1080p',
+        codec: 'AV1',
+        isDubbed: true,
+      );
+      const h264 = ReleaseCandidate(
+        infoHash: '2222222222222222222222222222222222222222',
+        magnetUri:
+            'magnet:?xt=urn:btih:2222222222222222222222222222222222222222',
+        releaseName: 'Supported H264 release',
+        seeders: 5,
+        sourceId: 'test',
+        quality: '1080p',
+        codec: 'H.264',
+        isDubbed: true,
+      );
+      const avcOnly = TvDeviceProfile(
+        manufacturer: 'Test',
+        model: 'AVC only',
+        sdk: 34,
+        abis: ['arm64-v8a'],
+        displayModes: [],
+        hdrTypes: [],
+        codecs: [
+          TvCodecCapability(
+            name: 'hardware.avc.decoder',
+            mime: 'video/avc',
+            hardware: true,
+          ),
+        ],
+        audioOutputs: [],
+      );
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            configuredReleaseSourceProvider.overrideWithValue(
+              const _ListReleaseSource([av1, h264]),
+            ),
+            resolveDeviceProfileReaderProvider.overrideWithValue(
+              () async => avcOnly,
+            ),
+            resolveFailureCountsReaderProvider.overrideWithValue(
+              (_) async => const {},
+            ),
+          ],
+          child: const MaterialApp(
+            home: ResolveEpisodeScreen(
+              episode: EpisodeReference(
+                anilistMediaId: 99001,
+                title: 'Codec picker test',
+                episode: 1,
+              ),
+            ),
+          ),
+        ),
+      );
+
+      await _pumpUntilFound(tester, find.text(h264.releaseName));
+      expect(find.text(av1.releaseName), findsNothing);
+    },
+  );
+
   testWidgets('saved Web-first preference orders picker source sections', (
     tester,
   ) async {

--- a/test/stream_ranking_preferences_test.dart
+++ b/test/stream_ranking_preferences_test.dart
@@ -41,6 +41,244 @@ void main() {
     audioLanguages: audioLanguages,
   );
 
+  ReleaseCandidate codecRelease({
+    required String id,
+    required String name,
+    String? codec,
+    String? quality = '1080p',
+  }) => ReleaseCandidate(
+    infoHash: id.padRight(40, id),
+    magnetUri: 'magnet:?xt=urn:btih:${id.padRight(40, id)}',
+    releaseName: name,
+    seeders: 10,
+    sourceId: 'codec-source',
+    quality: quality,
+    codec: codec,
+    isDubbed: true,
+  );
+
+  const avcOnlyDevice = TvDeviceProfile(
+    manufacturer: 'Test',
+    model: 'AVC only',
+    sdk: 34,
+    abis: ['arm64-v8a'],
+    displayModes: [],
+    hdrTypes: [],
+    codecs: [
+      TvCodecCapability(
+        name: 'hardware.avc.decoder',
+        mime: 'video/avc',
+        hardware: true,
+      ),
+    ],
+    audioOutputs: [],
+  );
+
+  const av1Device = TvDeviceProfile(
+    manufacturer: 'Test',
+    model: 'AV1 capable',
+    sdk: 34,
+    abis: ['arm64-v8a'],
+    displayModes: [],
+    hdrTypes: [],
+    codecs: [
+      TvCodecCapability(
+        name: 'hardware.avc.decoder',
+        mime: 'video/avc',
+        hardware: true,
+      ),
+      TvCodecCapability(
+        name: 'hardware.av1.decoder',
+        mime: 'video/av01',
+        hardware: true,
+        maxWidth: 3840,
+        maxHeight: 2160,
+      ),
+    ],
+    audioOutputs: [],
+  );
+
+  test(
+    'codec compatibility is device-specific and fails open when unknown',
+    () {
+      final av1 = codecRelease(id: 'a', name: 'Example 1080p', codec: 'AV1');
+      final av01FromName = codecRelease(
+        id: 'b',
+        name: 'Example S01E01 1080p AV01',
+      );
+      final unknown = codecRelease(
+        id: 'c',
+        name: 'Example S01E01 1080p WEB-DL',
+      );
+
+      expect(
+        releaseCodecCompatibility(av1, device: avcOnlyDevice),
+        ReleaseCodecCompatibility.unsupported,
+      );
+      expect(
+        releaseCodecCompatibility(av01FromName, device: avcOnlyDevice),
+        ReleaseCodecCompatibility.unsupported,
+      );
+      expect(
+        releaseCodecCompatibility(av1, device: av1Device),
+        ReleaseCodecCompatibility.supported,
+      );
+      expect(
+        releaseCodecCompatibility(av1, device: const TvDeviceProfile.unknown()),
+        ReleaseCodecCompatibility.unknown,
+      );
+      expect(
+        releaseCodecCompatibility(unknown, device: avcOnlyDevice),
+        ReleaseCodecCompatibility.unknown,
+      );
+      expect(
+        releaseCodecIsPlayableOnDevice(unknown, device: avcOnlyDevice),
+        isTrue,
+      );
+    },
+  );
+
+  test('a software-only AV1 decoder is not advertised as playable', () {
+    final av1 = codecRelease(id: 'a', name: 'Example 1080p AV1', codec: 'AV1');
+    const softwareAv1Device = TvDeviceProfile(
+      manufacturer: 'Test',
+      model: 'Software AV1 only',
+      sdk: 34,
+      abis: ['arm64-v8a'],
+      displayModes: [],
+      hdrTypes: [],
+      codecs: [
+        TvCodecCapability(
+          name: 'c2.android.av1.decoder',
+          mime: 'video/av01',
+          hardware: false,
+        ),
+      ],
+      audioOutputs: [],
+    );
+
+    expect(
+      releaseCodecCompatibility(av1, device: softwareAv1Device),
+      ReleaseCodecCompatibility.unsupported,
+    );
+  });
+
+  test('decoder dimensions reject only known oversized releases', () {
+    final av1p2160 = codecRelease(
+      id: 'a',
+      name: 'Example 2160p AV1',
+      codec: 'AV1',
+      quality: '2160p',
+    );
+    final av1p1080 = codecRelease(
+      id: 'b',
+      name: 'Example 1080p AV1',
+      codec: 'AV1',
+    );
+    final av1UnknownResolution = codecRelease(
+      id: 'c',
+      name: 'Example AV1 WEB-DL',
+      codec: 'AV1',
+      quality: null,
+    );
+    const cappedAv1Device = TvDeviceProfile(
+      manufacturer: 'Test',
+      model: '1080p AV1',
+      sdk: 34,
+      abis: ['arm64-v8a'],
+      displayModes: [],
+      hdrTypes: [],
+      codecs: [
+        TvCodecCapability(
+          name: 'hardware.av1.decoder',
+          mime: 'video/av01',
+          hardware: true,
+          maxWidth: 1920,
+          maxHeight: 1080,
+        ),
+      ],
+      audioOutputs: [],
+    );
+
+    expect(
+      releaseCodecCompatibility(av1p2160, device: cappedAv1Device),
+      ReleaseCodecCompatibility.unsupported,
+    );
+    expect(
+      releaseCodecCompatibility(av1p1080, device: cappedAv1Device),
+      ReleaseCodecCompatibility.supported,
+    );
+    expect(
+      releaseCodecCompatibility(av1UnknownResolution, device: cappedAv1Device),
+      ReleaseCodecCompatibility.supported,
+    );
+  });
+
+  test('unknown decoder dimensions fail open for known resolutions', () {
+    final av1p2160 = codecRelease(
+      id: 'a',
+      name: 'Example 2160p AV1',
+      codec: 'AV1',
+      quality: '2160p',
+    );
+    const dimensionsUnknown = TvDeviceProfile(
+      manufacturer: 'Test',
+      model: 'Unknown AV1 limits',
+      sdk: 34,
+      abis: ['arm64-v8a'],
+      displayModes: [],
+      hdrTypes: [],
+      codecs: [
+        TvCodecCapability(
+          name: 'hardware.av1.decoder',
+          mime: 'video/av01',
+          hardware: true,
+        ),
+      ],
+      audioOutputs: [],
+    );
+
+    expect(
+      releaseCodecCompatibility(av1p2160, device: dimensionsUnknown),
+      ReleaseCodecCompatibility.unknown,
+    );
+    expect(
+      releaseCodecIsPlayableOnDevice(av1p2160, device: dimensionsUnknown),
+      isTrue,
+    );
+  });
+
+  test('automatic release pools omit only codecs known unsupported', () {
+    final av1 = codecRelease(id: 'a', name: 'Example 1080p AV1', codec: 'AV1');
+    final h264 = codecRelease(
+      id: 'b',
+      name: 'Example 1080p x264',
+      codec: 'H.264',
+    );
+    final unknown = codecRelease(id: 'c', name: 'Example 1080p WEB-DL');
+
+    List<ReleaseCandidate> rankFor(TvDeviceProfile device) =>
+        rankAutomaticAutoplayReleases(
+          [av1, h264, unknown],
+          language: 'dub',
+          quality: 'any',
+          codec: 'any',
+          hdr: 'any',
+          allowBatch: true,
+          preferredAudio: PlaybackAudioPreference.dub,
+          rankingPreference: DebridStreamSort.bestQuality,
+          device: device,
+        );
+
+    expect(rankFor(avcOnlyDevice), containsAll([h264, unknown]));
+    expect(rankFor(avcOnlyDevice), isNot(contains(av1)));
+    expect(rankFor(av1Device), containsAll([av1, h264, unknown]));
+    expect(
+      rankFor(const TvDeviceProfile.unknown()),
+      containsAll([av1, h264, unknown]),
+    );
+  });
+
   test(
     'debrid modes rank quality, seeders, and known size deterministically',
     () {

--- a/test/stremio_torrent_release_source_test.dart
+++ b/test/stremio_torrent_release_source_test.dart
@@ -74,6 +74,27 @@ void main() {
     expect(releases.map((release) => release.isDubbed), [true, true, false]);
   });
 
+  test('normalizes common AV1 and VP9 torrent codec labels', () {
+    final releases = StremioTorrentReleaseSource.parseStreams({
+      'streams': [
+        {
+          'name': '[Group] Example S01E01 1080p AV01',
+          'infoHash': '1111111111111111111111111111111111111111',
+        },
+        {
+          'name': '[Group] Example S01E01 1080p AV-1',
+          'infoHash': '2222222222222222222222222222222222222222',
+        },
+        {
+          'name': '[Group] Example S01E01 1080p VP-9',
+          'infoHash': '3333333333333333333333333333333333333333',
+        },
+      ],
+    });
+
+    expect(releases.map((release) => release.codec), ['AV1', 'AV1', 'VP9']);
+  });
+
   test('keeps the installed manifest source stable across episode hashes', () {
     const sourceId = 'stremio:example.com/addon/manifest.json';
     final first = StremioTorrentReleaseSource.parseStreams({

--- a/test/torbox_device_auth_client_test.dart
+++ b/test/torbox_device_auth_client_test.dart
@@ -108,6 +108,26 @@ void main() {
       );
     });
 
+    test('expired local sessions are terminal and never contact TorBox', () {
+      final expiredSession = TorBoxDeviceSession(
+        deviceCode: 'expired-device-secret',
+        userCode: '654321',
+        verificationUrl: Uri.parse('https://torbox.app/oauth/device'),
+        friendlyVerificationUrl: Uri.parse('https://tor.box/link'),
+        expiresAt: DateTime.now().subtract(const Duration(seconds: 1)),
+        interval: const Duration(seconds: 5),
+      );
+
+      expect(
+        () => TorBoxDeviceAuthClient().poll(expiredSession),
+        throwsA(
+          isA<TorBoxDeviceAuthException>()
+              .having((error) => error.code, 'code', 'AUTHORIZATION_EXPIRED')
+              .having((error) => error.retryable, 'retryable', isFalse),
+        ),
+      );
+    });
+
     test('surfaces non-pending 400 responses instead of polling forever', () {
       final dio = _responseDio(
         statusCode: 400,
@@ -131,6 +151,75 @@ void main() {
               ),
         ),
       );
+    });
+
+    test(
+      'marks temporary DNS failures as retryable without leaking details',
+      () {
+        final dio = Dio(BaseOptions(baseUrl: 'https://torbox.test'))
+          ..interceptors.add(
+            InterceptorsWrapper(
+              onRequest: (options, handler) => handler.reject(
+                DioException(
+                  requestOptions: options,
+                  type: DioExceptionType.connectionError,
+                  message: "Failed host lookup: 'api.torbox.app'",
+                ),
+              ),
+            ),
+          );
+
+        expect(
+          () => TorBoxDeviceAuthClient(dio: dio).poll(session()),
+          throwsA(
+            isA<TorBoxDeviceAuthException>()
+                .having((error) => error.retryable, 'retryable', isTrue)
+                .having(
+                  (error) => error.message,
+                  'message',
+                  allOf(
+                    contains('keep retrying'),
+                    isNot(contains('host lookup')),
+                  ),
+                ),
+          ),
+        );
+      },
+    );
+
+    test('keeps rate limits and temporary provider errors retryable', () async {
+      for (final response in [
+        (
+          429,
+          const <String, dynamic>{
+            'success': false,
+            'error': 'TOO_MANY_REQUESTS',
+            'detail': 'Slow down.',
+          },
+        ),
+        (
+          400,
+          const <String, dynamic>{
+            'success': false,
+            'error': 'DATABASE_ERROR',
+            'detail': 'Try later.',
+          },
+        ),
+      ]) {
+        final client = TorBoxDeviceAuthClient(
+          dio: _responseDio(statusCode: response.$1, body: response.$2),
+        );
+        await expectLater(
+          client.poll(session()),
+          throwsA(
+            isA<TorBoxDeviceAuthException>().having(
+              (error) => error.retryable,
+              'retryable',
+              isTrue,
+            ),
+          ),
+        );
+      }
     });
   });
 }

--- a/test/torbox_pairing_retry_test.dart
+++ b/test/torbox_pairing_retry_test.dart
@@ -1,0 +1,137 @@
+import 'package:anime_tv/core/theme/app_theme.dart';
+import 'package:anime_tv/features/auth/data/torbox_device_auth_client.dart';
+import 'package:anime_tv/features/auth/presentation/torbox_pairing_screen.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('a temporary TorBox outage keeps the active code and retries', (
+    tester,
+  ) async {
+    tester.view.physicalSize = const Size(1280, 720);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+    final client = _RetryingTorBoxClient();
+    final diagnosticEvents = <Map<String, Object?>>[];
+
+    await tester.pumpWidget(
+      ProviderScope(
+        child: MaterialApp(
+          theme: AppTheme.dark,
+          home: TorBoxPairingScreen(
+            client: client,
+            diagnosticRecorder: (details) async =>
+                diagnosticEvents.add(details),
+          ),
+        ),
+      ),
+    );
+    await tester.pump();
+    expect(find.text('483414'), findsOneWidget);
+
+    await tester.pump(const Duration(seconds: 1));
+    await tester.pump();
+    expect(find.textContaining('temporarily unreachable'), findsOneWidget);
+    expect(find.text('Could not connect TorBox'), findsNothing);
+    expect(find.text('483414'), findsOneWidget);
+    expect(
+      diagnosticEvents.map((event) => event['stage']),
+      containsAllInOrder(['start', 'pending', 'transient-retry']),
+    );
+    expect(
+      diagnosticEvents.toString(),
+      isNot(anyOf(contains('483414'), contains('device-secret'))),
+    );
+
+    await tester.pump(const Duration(seconds: 1));
+    await tester.pump();
+    expect(client.pollCalls, greaterThanOrEqualTo(2));
+    expect(find.textContaining('temporarily unreachable'), findsNothing);
+    expect(find.text('WAITING FOR APPROVAL'), findsOneWidget);
+
+    await tester.pumpWidget(const SizedBox.shrink());
+    await tester.pump();
+  });
+
+  testWidgets('resuming the app polls a still-valid TorBox code immediately', (
+    tester,
+  ) async {
+    tester.view.physicalSize = const Size(1280, 720);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+    final client = _PendingTorBoxClient();
+    await tester.pumpWidget(
+      ProviderScope(
+        child: MaterialApp(
+          theme: AppTheme.dark,
+          home: TorBoxPairingScreen(
+            client: client,
+            diagnosticRecorder: (_) async {},
+          ),
+        ),
+      ),
+    );
+    await tester.pump();
+    expect(client.pollCalls, 0);
+
+    tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.paused);
+    tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.resumed);
+    await tester.pump();
+
+    expect(client.pollCalls, 1);
+    expect(find.text('483414'), findsOneWidget);
+
+    await tester.pumpWidget(const SizedBox.shrink());
+    await tester.pump();
+  });
+}
+
+class _RetryingTorBoxClient extends TorBoxDeviceAuthClient {
+  int pollCalls = 0;
+
+  @override
+  Future<TorBoxDeviceSession> start() async => TorBoxDeviceSession(
+    deviceCode: 'device-secret',
+    userCode: '483414',
+    verificationUrl: Uri.parse('https://torbox.app/oauth/device?app=TetoTV'),
+    friendlyVerificationUrl: Uri.parse('https://tor.box/link'),
+    expiresAt: DateTime.now().add(const Duration(minutes: 15)),
+    interval: const Duration(seconds: 1),
+  );
+
+  @override
+  Future<String?> poll(TorBoxDeviceSession session) async {
+    pollCalls += 1;
+    if (pollCalls == 1) {
+      throw const TorBoxDeviceAuthException(
+        'TorBox is temporarily unreachable. TetoTV will keep retrying this code.',
+        code: 'NETWORK_ERROR',
+        retryable: true,
+      );
+    }
+    return null;
+  }
+}
+
+class _PendingTorBoxClient extends TorBoxDeviceAuthClient {
+  int pollCalls = 0;
+
+  @override
+  Future<TorBoxDeviceSession> start() async => TorBoxDeviceSession(
+    deviceCode: 'device-secret',
+    userCode: '483414',
+    verificationUrl: Uri.parse('https://torbox.app/oauth/device?app=TetoTV'),
+    friendlyVerificationUrl: Uri.parse('https://tor.box/link'),
+    expiresAt: DateTime.now().add(const Duration(minutes: 10)),
+    interval: const Duration(minutes: 5),
+  );
+
+  @override
+  Future<String?> poll(TorBoxDeviceSession session) async {
+    pollCalls += 1;
+    return null;
+  }
+}

--- a/test/torbox_settings_controller_test.dart
+++ b/test/torbox_settings_controller_test.dart
@@ -2,6 +2,7 @@ import 'package:anime_tv/features/settings/application/torbox_settings_controlle
 import 'package:anime_tv/features/streaming/data/torbox_client.dart';
 import 'package:anime_tv/features/streaming/data/torbox_models.dart';
 import 'package:anime_tv/features/streaming/domain/debrid_service.dart';
+import 'package:anime_tv/features/streaming/domain/stream_resolver.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -64,6 +65,23 @@ void main() {
 
     expect(await controller.saveAndValidate('expired-token'), isFalse);
     expect(controller.state.hasSavedToken, isFalse);
+    expect(controller.state.retryableError, isFalse);
+    expect(
+      await storage.read(key: DebridService.torBox.tokenStorageKey),
+      isNull,
+    );
+  });
+
+  test('temporary TorBox account lookup failures can be retried', () async {
+    FlutterSecureStorage.setMockInitialValues({});
+    final controller = TorBoxSettingsController(
+      storage,
+      (_) => _UnavailableTorBoxClient(),
+    );
+
+    expect(await controller.saveAndValidate('approved-device-token'), isFalse);
+    expect(controller.state.hasSavedToken, isFalse);
+    expect(controller.state.retryableError, isTrue);
     expect(
       await storage.read(key: DebridService.torBox.tokenStorageKey),
       isNull,
@@ -119,5 +137,16 @@ class _ExpiredTorBoxClient extends TorBoxClient {
     plan: 1,
     isSubscribed: true,
     premiumUntil: DateTime.utc(2020),
+  );
+}
+
+class _UnavailableTorBoxClient extends TorBoxClient {
+  _UnavailableTorBoxClient() : super(token: 'test');
+
+  @override
+  Future<TorBoxAccount> account() async => throw const TorBoxException(
+    'Could not reach TorBox.',
+    code: 'NETWORK_ERROR',
+    category: DebridFailureCategory.serviceUnavailable,
   );
 }


### PR DESCRIPTION
## Summary
- keep TorBox device pairing alive across browser/app switching and transient network failures
- filter known-incompatible video codecs using each Android device's hardware decoder inventory
- add the paged TV episode browser and unaired-episode messaging
- add a persistent update notification bell and inbox with download/install actions
- stop unavailable SIMKL configuration from being misreported as a crash
- prepare Beta 2.0.66 (Android build code 410043)

## Validation
- flutter analyze
- 2,253 tests passed; 33 intentionally skipped
- focused TorBox, codec compatibility, episode browser, notification persistence, and TV navigation tests passed