### PR TITLE
Prepare TetoTV Beta 2.0.69

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 
 <p align="center">
   <a href="https://github.com/LindersOSX/TetoTV-Beta/releases/latest"><strong>Download Beta</strong></a>
-  · <a href="docs/RELEASE_NOTES_2.0.68.md">What's new</a>
+  · <a href="docs/RELEASE_NOTES_2.0.69.md">What's new</a>
   · <a href="https://github.com/LindersOSX/TetoTV-Beta/issues/new">Report an issue</a>
   · <a href="https://discord.gg/juC6k7d4WY">Discord</a>
   · <a href="https://www.youtube.com/@TetoTVApp">YouTube</a>
@@ -96,10 +96,10 @@ TetoTV runs directly on the Android device with no companion server required for
 | Channel | Version | Best for |
 | --- | --- | --- |
 | Public | Not published | Source and release-readiness documents are available, but no Public APK is currently offered |
-| Beta | [2.0.68](docs/RELEASE_NOTES_2.0.68.md) | User-added manga sources, richer personal-library tracks, and polished TV navigation |
+| Beta | [2.0.69](docs/RELEASE_NOTES_2.0.69.md) | Direct-torrent stability, smoother episode browsing, and live notification refresh |
 
 > [!WARNING]
-> Beta 2.0.68 uses the repository's explicit unreviewed-Beta exception. Its native-library and corresponding-source material did not receive independent license review, and automated integrity checks are not a legal compliance determination. Read the [complete Beta disclosure](docs/RELEASE_NOTES_2.0.68.md). This exception does not apply to a future Public release.
+> Beta 2.0.69 uses the repository's explicit unreviewed-Beta exception. Its native-library and corresponding-source material did not receive independent license review, and automated integrity checks are not a legal compliance determination. Read the [complete Beta disclosure](docs/RELEASE_NOTES_2.0.69.md). This exception does not apply to a future Public release.
 
 The Public updater repository intentionally has no release while the Public build is held for review. Existing Beta installations continue to update from the Beta repository. Android never permits an in-place install of an APK with a lower build code; Developer Mode does not bypass that platform rule.
 

--- a/android/app/src/main/kotlin/dev/animetv/anime_tv/DirectTorrentManager.kt
+++ b/android/app/src/main/kotlin/dev/animetv/anime_tv/DirectTorrentManager.kt
@@ -13,8 +13,10 @@ import org.libtorrent4j.TorrentInfo
 import org.libtorrent4j.alerts.AddTorrentAlert
 import org.libtorrent4j.alerts.Alert
 import org.libtorrent4j.alerts.AlertType
+import org.libtorrent4j.alerts.TorrentAlert
 import org.libtorrent4j.swig.session_handle
 import org.libtorrent4j.swig.settings_pack
+import org.libtorrent4j.swig.torrent_handle
 import java.io.BufferedInputStream
 import java.io.BufferedOutputStream
 import java.io.File
@@ -164,6 +166,54 @@ internal object DirectTorrentEngine {
         }.getOrDefault(false)
     }
 
+    /**
+     * Copies the alert's borrowed torrent handle through the live session.
+     *
+     * libtorrent4j's TorrentAlert.handle() points inside the native alert and
+     * becomes dangling as soon as SessionManager pops the next alert. A
+     * session find returns an owning torrent_handle value that remains safe to
+     * retain for playback and timeout cleanup. Resolve it while the callback's
+     * alert is still alive and support both v1 and v2-only magnets.
+     */
+    fun retainAlertHandle(alert: TorrentAlert<*>): TorrentHandle? = synchronized(monitor) {
+        if (!state.leased || state.poisoned) return@synchronized null
+        val borrowed = runCatching { alert.handle() }.getOrNull()
+            ?: return@synchronized null
+        val hashes = runCatching { borrowed.swig().info_hashes() }.getOrNull()
+            ?: return@synchronized null
+        try {
+            if (hashes.has_v1()) {
+                val hash = hashes.v1
+                val retained = try {
+                    session.swig().find_torrent(hash)
+                } finally {
+                    hash.delete()
+                }
+                ownedHandleOrNull(retained)?.let { return@synchronized it }
+            }
+            if (hashes.has_v2()) {
+                val hash = hashes.v2
+                val retained = try {
+                    session.swig().find_torrent(hash)
+                } finally {
+                    hash.delete()
+                }
+                ownedHandleOrNull(retained)?.let { return@synchronized it }
+            }
+            null
+        } finally {
+            hashes.delete()
+        }
+    }
+
+    private fun ownedHandleOrNull(handle: torrent_handle): TorrentHandle? {
+        if (runCatching { handle.is_valid() }.getOrDefault(false)) {
+            return TorrentHandle(handle)
+        }
+        runCatching { handle.delete() }
+        return null
+    }
+
     fun release(listener: AlertListener) {
         synchronized(monitor) {
             if (!state.release()) return
@@ -265,13 +315,27 @@ internal class DirectTorrentManager(
                         metadataFailure.compareAndSet(null, "DIRECT_TORRENT_ADD_FAILED")
                         metadataReady.countDown()
                     } else {
-                        torrentHandle.set(added.handle())
-                        if (added.handle().torrentFile() != null) metadataReady.countDown()
+                        val retained = DirectTorrentEngine.retainAlertHandle(added)
+                        if (retained == null) {
+                            metadataFailure.compareAndSet(null, "DIRECT_TORRENT_ADD_FAILED")
+                            metadataReady.countDown()
+                        } else {
+                            torrentHandle.set(retained)
+                            if (retained.torrentFile() != null) metadataReady.countDown()
+                        }
                     }
                     torrentAdded.countDown()
                 }
                 AlertType.METADATA_RECEIVED -> {
-                    torrentHandle.compareAndSet(null, alert.handleOrNull())
+                    if (torrentHandle.get() == null && !stopped.get()) {
+                        val torrentAlert = alert as? TorrentAlert<*>
+                        val retained = torrentAlert?.let(DirectTorrentEngine::retainAlertHandle)
+                        if (retained == null) {
+                            metadataFailure.compareAndSet(null, "DIRECT_TORRENT_METADATA_FAILED")
+                        } else if (!torrentHandle.compareAndSet(null, retained)) {
+                            runCatching { retained.swig().delete() }
+                        }
+                    }
                     metadataReady.countDown()
                 }
                 AlertType.METADATA_FAILED -> {
@@ -712,9 +776,6 @@ internal class DirectTorrentManager(
             )
         }
     }
-
-    private fun Alert<*>.handleOrNull(): TorrentHandle? =
-        (this as? org.libtorrent4j.alerts.TorrentAlert<*>)?.handle()
 
     private data class HttpRequest(
         val method: String,

--- a/android/app/src/test/kotlin/dev/animetv/anime_tv/DirectTorrentHandleOwnershipContractTest.kt
+++ b/android/app/src/test/kotlin/dev/animetv/anime_tv/DirectTorrentHandleOwnershipContractTest.kt
@@ -1,0 +1,55 @@
+package dev.animetv.anime_tv
+
+import java.io.File
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class DirectTorrentHandleOwnershipContractTest {
+    private val source by lazy { directTorrentManagerSource() }
+
+    @Test
+    fun `alert callbacks retain only session-owned torrent handles`() {
+        val engine = source
+            .substringAfter("internal object DirectTorrentEngine", "")
+            .substringBefore("internal class DirectTorrentManager", "")
+        val listener = source
+            .substringAfter("private val alertListener", "")
+            .substringBefore("fun start(", "")
+
+        assertTrue(engine.contains("fun retainAlertHandle(alert: TorrentAlert<*>)"))
+        assertTrue(engine.contains("session.swig().find_torrent(hash)"))
+        assertTrue(engine.contains("hashes.has_v1()"))
+        assertTrue(engine.contains("hashes.has_v2()"))
+        assertTrue(engine.contains("!state.leased || state.poisoned"))
+        assertTrue(listener.contains("DirectTorrentEngine.retainAlertHandle(added)"))
+        assertFalse(listener.contains("torrentHandle.set(added.handle())"))
+        assertFalse(listener.contains("handleOrNull()"))
+
+        val addAlert = listener
+            .substringAfter("AlertType.ADD_TORRENT ->", "")
+            .substringBefore("AlertType.METADATA_RECEIVED", "")
+        assertEquals(
+            "Only an explicit native add error may prove that no torrent exists",
+            1,
+            Regex("addFailed\\.set\\(true\\)").findAll(addAlert).count(),
+        )
+    }
+
+    private fun directTorrentManagerSource(): String {
+        val workingDirectory = System.getProperty("user.dir") ?: "."
+        return generateSequence(File(workingDirectory)) { it.parentFile }
+            .take(7)
+            .flatMap { directory ->
+                sequenceOf(
+                    File(directory, "src/main/kotlin/dev/animetv/anime_tv/DirectTorrentManager.kt"),
+                    File(directory, "app/src/main/kotlin/dev/animetv/anime_tv/DirectTorrentManager.kt"),
+                    File(directory, "android/app/src/main/kotlin/dev/animetv/anime_tv/DirectTorrentManager.kt"),
+                )
+            }
+            .firstOrNull(File::isFile)
+            ?.readText()
+            ?: error("Missing DirectTorrentManager.kt")
+    }
+}

--- a/docs/BUILD_WINDOWS.md
+++ b/docs/BUILD_WINDOWS.md
@@ -220,39 +220,39 @@ APK containing both supported application ABIs.
 Public and Beta updates use anonymous GitHub requests. No Beta key, GitHub
 token, update-proxy URL, or update-specific Dart define is required. Every
 published APK uses the production signing identity. No Public APK is currently
-published. Beta 2.0.68 uses Android build code `410045`. Flutter reuses
+published. Beta 2.0.69 uses Android build code `410046`. Flutter reuses
 `app-release.apk`, so copy and rename the Beta artifact immediately after the
 build:
 
 ```powershell
-New-Item -ItemType Directory -Force .\build\fire-tv\v2.0.68 | Out-Null
+New-Item -ItemType Directory -Force .\build\fire-tv\v2.0.69 | Out-Null
 
-# Beta 2.0.68
+# Beta 2.0.69
 flutter build apk --release --target-platform android-arm,android-arm64 `
-  --build-name 2.0.68 --build-number 410045 --no-tree-shake-icons
+  --build-name 2.0.69 --build-number 410046 --no-tree-shake-icons
 Copy-Item .\build\app\outputs\flutter-apk\app-release.apk `
-  .\build\fire-tv\v2.0.68\TetoTV-v2.0.68-universal.apk
+  .\build\fire-tv\v2.0.69\TetoTV-v2.0.69-universal.apk
 
 .\tool\release\verify_release_apk.ps1 `
   -Channel Beta `
-  -ApkPath .\build\fire-tv\v2.0.68\TetoTV-v2.0.68-universal.apk
+  -ApkPath .\build\fire-tv\v2.0.69\TetoTV-v2.0.69-universal.apk
 
 .\tool\release\verify_native_redistribution.ps1 `
   -RequireResolvedBinaries `
   -ResolvedBinaryDirectory .\build\native-playback\outputs `
-  -StageBundle -ReleaseTag v2.0.68
+  -StageBundle -ReleaseTag v2.0.69
 
 .\tool\release\new_release_checksums.ps1 `
-  -ApkPath .\build\fire-tv\v2.0.68\TetoTV-v2.0.68-universal.apk `
-  -NativeSourcePath .\build\release-compliance\v2.0.68\TetoTV-v2.0.68-native-playback-sources.zip `
-  -OutputPath .\build\fire-tv\v2.0.68\SHA256SUMS
+  -ApkPath .\build\fire-tv\v2.0.69\TetoTV-v2.0.69-universal.apk `
+  -NativeSourcePath .\build\release-compliance\v2.0.69\TetoTV-v2.0.69-native-playback-sources.zip `
+  -OutputPath .\build\fire-tv\v2.0.69\SHA256SUMS
 
 .\tool\release\verify_release_payloads.ps1 `
   -Channel Beta `
-  -ApkPath .\build\fire-tv\v2.0.68\TetoTV-v2.0.68-universal.apk `
-  -NativeSourcePath .\build\release-compliance\v2.0.68\TetoTV-v2.0.68-native-playback-sources.zip `
-  -ChecksumsPath .\build\fire-tv\v2.0.68\SHA256SUMS `
-  -ReleaseNotesPath .\docs\RELEASE_NOTES_2.0.68.md `
+  -ApkPath .\build\fire-tv\v2.0.69\TetoTV-v2.0.69-universal.apk `
+  -NativeSourcePath .\build\release-compliance\v2.0.69\TetoTV-v2.0.69-native-playback-sources.zip `
+  -ChecksumsPath .\build\fire-tv\v2.0.69\SHA256SUMS `
+  -ReleaseNotesPath .\docs\RELEASE_NOTES_2.0.69.md `
   -ResolvedBinaryDirectory .\build\native-playback\outputs
 ```
 

--- a/docs/RELEASE_NOTES_2.0.69.md
+++ b/docs/RELEASE_NOTES_2.0.69.md
@@ -1,0 +1,30 @@
+# TetoTV 2.0.69 Beta
+
+> [!WARNING]
+> No independent native-license review: This Beta has not received independent native-library licensing review. Automated checks verify the APK, native-source bundle, notices, pinned inputs, and checksums, but do not establish legal compliance or reproducible builds.
+
+This Beta fixes a native direct-torrent startup crash, smooths episode browsing, and delivers announcements and update notices while the app remains open.
+
+## What's changed
+
+- Direct-torrent playback now retains only independently owned libtorrent handles after processing native alerts. This prevents a released alert object from leaving a stale handle that can crash Android during torrent metadata startup or cleanup.
+- The embedded episode browser now enters with a short fade-and-lift transition that matches the rest of the interface and respects reduced-motion preferences.
+- A focused episode's description waits three seconds, then scrolls slowly when all of its text does not fit. Episode titles remain stationary, and leaving the card resets the description.
+- App announcements refresh once per minute while TetoTV is in the foreground, GitHub update metadata refreshes every five minutes, and both refresh immediately when the app returns to the foreground. Restarting the app is no longer required to discover a new notice.
+- Automatic update checks continue to discover and display newer releases when automatic APK downloads are disabled. When automatic downloads are enabled, background checks can download the verified APK without opening Android's installer.
+- A previously verified APK is preserved after an installer error, while a genuinely newer GitHub release correctly replaces an older pending download.
+
+## Release assets
+
+- `TetoTV-v2.0.69-universal.apk` — install this file on a supported Android device.
+- `TetoTV-v2.0.69-native-playback-sources.zip` — native playback source and license material for developers and compliance review; normal users do not need it.
+- `SHA256SUMS` — integrity hashes for the two files above.
+
+## Beta notes
+
+- This is a Beta-channel build with Android build code `410046`.
+- No Public APK is being published with this release.
+- Direct peer-to-peer playback remains an optional Beta feature that is disabled by default and requires explicit opt-in.
+- Android does not permit an in-place install over an APK with a higher build code. A future Public counterpart must use build code `410046` or newer for data-preserving channel switching.
+
+<!-- tetotv-android-version-code: 410046 -->

--- a/docs/UPDATE_CHANNELS.md
+++ b/docs/UPDATE_CHANNELS.md
@@ -35,11 +35,11 @@ Beta reads completed 2.x releases from:
 https://api.github.com/repos/LindersOSX/TetoTV-Beta/releases/latest
 ```
 
-The current Beta source build is `v2.0.68` with Android build code `410045`.
+The current Beta source build is `v2.0.69` with Android build code `410046`.
 Its release title is:
 
 ```text
-TetoTV 2.0.68 Beta - Android TV / Google TV / Fire TV
+TetoTV 2.0.69 Beta - Android TV / Google TV / Fire TV
 ```
 
 Publish it as a normal, non-draft, non-prerelease GitHub release so
@@ -72,7 +72,7 @@ proxy.
 Release notes must include the exact asset names and this build-code marker:
 
 ```html
-<!-- tetotv-android-version-code: 410045 -->
+<!-- tetotv-android-version-code: 410046 -->
 ```
 
 When build-code metadata is present, the updater rejects a known lower build
@@ -94,10 +94,10 @@ These rules apply equally on phones, Android TV, Google TV, and Fire TV.
 
 ## Switching and rollback
 
-The current Beta uses build code `410045`. No Public counterpart is available.
+The current Beta uses build code `410046`. No Public counterpart is available.
 An older Public install can move to this Beta when Android accepts the higher
 build code, but it cannot move back in place until a future Public build uses
-code `410045` or higher. Uninstalling first permits an older APK but deletes
+code `410046` or higher. Uninstalling first permits an older APK but deletes
 local application data. Developer Mode and in-app settings cannot override
 this Android rule.
 

--- a/lib/core/notifications/app_notification_controller.dart
+++ b/lib/core/notifications/app_notification_controller.dart
@@ -7,7 +7,11 @@ import 'package:anime_tv/core/config/app_config.dart';
 import 'package:anime_tv/core/storage/storage_providers.dart';
 import 'package:anime_tv/features/settings/application/app_update_controller.dart';
 import 'package:flutter/foundation.dart';
+import 'package:flutter/widgets.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+const foregroundAnnouncementRefreshInterval = Duration(minutes: 1);
+const foregroundUpdateRefreshInterval = Duration(minutes: 5);
 
 final appNotificationControllerProvider =
     StateNotifierProvider<AppNotificationController, AppNotificationState>((
@@ -24,16 +28,26 @@ final appNotificationControllerProvider =
         announcementApi: announcementClient,
       );
       unawaited(controller.load());
-      Timer? announcementTimer;
+      AppNotificationRefreshScheduler? refreshScheduler;
       if (announcementClient != null) {
         unawaited(controller.refreshAnnouncements());
-        announcementTimer = Timer.periodic(
-          const Duration(minutes: 15),
-          (_) => unawaited(controller.refreshAnnouncements()),
+        refreshScheduler = AppNotificationRefreshScheduler(
+          refreshAnnouncements: controller.refreshAnnouncements,
+          refreshAppUpdate: () => ref
+              .read(appUpdateControllerProvider.notifier)
+              .checkForUpdates(
+                automatic: true,
+                launchInstaller: false,
+                // Automatic-download consent is enforced by the updater. This
+                // foreground check still discovers release metadata when the
+                // preference is off, and downloads when it is on.
+                downloadAvailable: true,
+              ),
         );
+        refreshScheduler.start();
       }
       ref.onDispose(() {
-        announcementTimer?.cancel();
+        refreshScheduler?.dispose();
         announcementClient?.close();
       });
       // Download progress can update the updater state once per percentage.
@@ -93,6 +107,128 @@ class AppNotificationState {
 }
 
 typedef AppNotificationClock = DateTime Function();
+
+/// Keeps the inbox current while TetoTV is visible without waking a suspended
+/// TV or stacking network calls when a slow request outlives its interval.
+///
+/// The first announcement fetch and first update check remain owned by their
+/// existing startup paths. Resuming the app refreshes both immediately, while
+/// normal foreground use follows the bounded polling intervals below.
+class AppNotificationRefreshScheduler with WidgetsBindingObserver {
+  AppNotificationRefreshScheduler({
+    required this.refreshAnnouncements,
+    required this.refreshAppUpdate,
+    this.announcementInterval = foregroundAnnouncementRefreshInterval,
+    this.updateInterval = foregroundUpdateRefreshInterval,
+  });
+
+  final Future<void> Function() refreshAnnouncements;
+  final Future<void> Function() refreshAppUpdate;
+  final Duration announcementInterval;
+  final Duration updateInterval;
+
+  Timer? _announcementTimer;
+  Timer? _updateTimer;
+  bool _announcementRefreshInFlight = false;
+  bool _updateRefreshInFlight = false;
+  bool _foreground = false;
+  bool _started = false;
+  bool _disposed = false;
+
+  void start() {
+    if (_started || _disposed) return;
+    _started = true;
+    WidgetsBinding.instance.addObserver(this);
+    final lifecycle = WidgetsBinding.instance.lifecycleState;
+    if (lifecycle == null || lifecycle == AppLifecycleState.resumed) {
+      _startForegroundTimers();
+    }
+  }
+
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    if (_disposed) return;
+    if (state == AppLifecycleState.resumed) {
+      _startForegroundTimers();
+      _runAnnouncementRefresh();
+      _runUpdateRefresh();
+    } else {
+      _stopForegroundTimers();
+    }
+  }
+
+  void _startForegroundTimers() {
+    _foreground = true;
+    _announcementTimer ??= Timer.periodic(
+      announcementInterval,
+      (_) => _runAnnouncementRefresh(),
+    );
+    _scheduleNextUpdateRefresh();
+  }
+
+  void _stopForegroundTimers() {
+    _foreground = false;
+    _announcementTimer?.cancel();
+    _announcementTimer = null;
+    _updateTimer?.cancel();
+    _updateTimer = null;
+  }
+
+  void _scheduleNextUpdateRefresh({bool reset = false}) {
+    if (_disposed || !_foreground) return;
+    if (reset) {
+      _updateTimer?.cancel();
+      _updateTimer = null;
+    }
+    _updateTimer ??= Timer(updateInterval, () {
+      _updateTimer = null;
+      _runUpdateRefresh();
+    });
+  }
+
+  void _runAnnouncementRefresh() {
+    if (_disposed || _announcementRefreshInFlight) return;
+    _announcementRefreshInFlight = true;
+    unawaited(_guardAnnouncementRefresh());
+  }
+
+  Future<void> _guardAnnouncementRefresh() async {
+    try {
+      await refreshAnnouncements();
+    } catch (_) {
+      // Foreground refresh is best-effort and must never disrupt the app.
+    } finally {
+      _announcementRefreshInFlight = false;
+    }
+  }
+
+  void _runUpdateRefresh() {
+    if (_disposed || _updateRefreshInFlight) return;
+    _updateRefreshInFlight = true;
+    unawaited(_guardUpdateRefresh());
+  }
+
+  Future<void> _guardUpdateRefresh() async {
+    try {
+      await refreshAppUpdate();
+    } catch (_) {
+      // A failed background check can retry on the next interval or resume.
+    } finally {
+      _updateRefreshInFlight = false;
+      // Measure the throttle-compatible interval from completion, rather than
+      // from scheduler startup. Network latency must not make the next tick
+      // arrive just before the updater's own five-minute check window.
+      _scheduleNextUpdateRefresh(reset: true);
+    }
+  }
+
+  void dispose() {
+    if (_disposed) return;
+    _disposed = true;
+    _stopForegroundTimers();
+    if (_started) WidgetsBinding.instance.removeObserver(this);
+  }
+}
 
 class AppNotificationController extends StateNotifier<AppNotificationState> {
   AppNotificationController(

--- a/lib/features/catalog/presentation/episode_browser_dialog.dart
+++ b/lib/features/catalog/presentation/episode_browser_dialog.dart
@@ -247,7 +247,7 @@ class _EpisodeBrowserDialogState extends State<EpisodeBrowserDialog> {
       _pageIndex = _pageIndex.clamp(0, pageCount - 1);
     }
 
-    return Dialog(
+    final dialog = Dialog(
       key: ValueKey(
         widget.embedded ? 'episode-browser-page' : 'episode-browser-dialog',
       ),
@@ -383,6 +383,27 @@ class _EpisodeBrowserDialogState extends State<EpisodeBrowserDialog> {
         ),
       ),
     );
+
+    if (!widget.embedded) return dialog;
+    final animationsDisabled = MediaQuery.disableAnimationsOf(context);
+    return TweenAnimationBuilder<double>(
+      key: const ValueKey('episode-browser-open-animation'),
+      tween: Tween<double>(begin: 0, end: 1),
+      duration: animationsDisabled
+          ? Duration.zero
+          : const Duration(milliseconds: 160),
+      curve: Curves.easeOutCubic,
+      child: dialog,
+      builder: (context, progress, child) => Opacity(
+        key: const ValueKey('episode-browser-open-opacity'),
+        opacity: progress,
+        child: Transform.translate(
+          key: const ValueKey('episode-browser-open-slide'),
+          offset: Offset(0, 10 * (1 - progress)),
+          child: child,
+        ),
+      ),
+    );
   }
 }
 
@@ -488,7 +509,7 @@ class _EpisodeBrowserHeader extends StatelessWidget {
   }
 }
 
-class _EpisodeBrowserCard extends StatelessWidget {
+class _EpisodeBrowserCard extends StatefulWidget {
   const _EpisodeBrowserCard({
     required this.anime,
     required this.metadata,
@@ -517,57 +538,159 @@ class _EpisodeBrowserCard extends StatelessWidget {
   final VoidCallback onPressed;
 
   @override
+  State<_EpisodeBrowserCard> createState() => _EpisodeBrowserCardState();
+}
+
+class _EpisodeBrowserCardState extends State<_EpisodeBrowserCard> {
+  static const _descriptionScrollDelay = Duration(seconds: 3);
+  static const _descriptionScrollPixelsPerSecond = 12.0;
+
+  final ScrollController _descriptionScrollController = ScrollController();
+  Timer? _descriptionScrollTimer;
+  bool _focused = false;
+
+  String get _description => widget.availability.isAvailable
+      ? widget.metadata?.synopsis ?? 'Episode details unavailable.'
+      : 'This episode has not aired yet.';
+
+  @override
+  void didUpdateWidget(covariant _EpisodeBrowserCard oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    final oldDescription = oldWidget.availability.isAvailable
+        ? oldWidget.metadata?.synopsis ?? 'Episode details unavailable.'
+        : 'This episode has not aired yet.';
+    if (oldDescription != _description) {
+      _cancelDescriptionScroll();
+      _resetDescriptionScroll();
+      if (_focused) _scheduleDescriptionScroll();
+    }
+  }
+
+  @override
+  void dispose() {
+    _cancelDescriptionScroll();
+    _descriptionScrollController.dispose();
+    super.dispose();
+  }
+
+  void _handleFocusChanged(bool focused) {
+    if (_focused == focused) return;
+    _focused = focused;
+    _cancelDescriptionScroll();
+    _resetDescriptionScroll();
+    if (focused) _scheduleDescriptionScroll();
+  }
+
+  void _scheduleDescriptionScroll() {
+    _descriptionScrollTimer = Timer(_descriptionScrollDelay, () {
+      if (!mounted || !_focused || !_descriptionScrollController.hasClients) {
+        return;
+      }
+      // Respect the platform accessibility preference. The full synopsis is
+      // still exposed through semantics, without forcing continuous motion.
+      if (MediaQuery.disableAnimationsOf(context)) return;
+      final extent = _descriptionScrollController.position.maxScrollExtent;
+      if (extent <= 0) return;
+      final duration = Duration(
+        milliseconds: math.max(
+          1500,
+          (extent / _descriptionScrollPixelsPerSecond * 1000).round(),
+        ),
+      );
+      unawaited(
+        _descriptionScrollController
+            .animateTo(extent, duration: duration, curve: Curves.linear)
+            .catchError((Object _) {
+              // A focus change or disposal intentionally cancels the scroll.
+            }),
+      );
+    });
+  }
+
+  void _cancelDescriptionScroll() {
+    _descriptionScrollTimer?.cancel();
+    _descriptionScrollTimer = null;
+  }
+
+  void _resetDescriptionScroll() {
+    if (_descriptionScrollController.hasClients) {
+      // jumpTo also cancels an in-flight animateTo, including the brief frame
+      // where the animation is active but has not moved away from zero yet.
+      _descriptionScrollController.jumpTo(0);
+    }
+  }
+
+  @override
   Widget build(BuildContext context) {
     final palette = context.appPalette;
-    final expectedAt = availability.expectedAt;
-    final runtime = metadata?.durationMinutes ?? anime.durationMinutes;
-    final episodeArtwork = metadata?.thumbnailUrl;
+    final expectedAt = widget.availability.expectedAt;
+    final runtime =
+        widget.metadata?.durationMinutes ?? widget.anime.durationMinutes;
+    final episodeArtwork = widget.metadata?.thumbnailUrl;
     final artwork =
-        episodeArtwork ?? anime.bannerImageUrl ?? anime.coverImageUrl;
+        episodeArtwork ??
+        widget.anime.bannerImageUrl ??
+        widget.anime.coverImageUrl;
     final usesSeriesArtwork = episodeArtwork == null && artwork != null;
-    final title = metadata?.title ?? 'Title unavailable';
-    final synopsis = metadata?.synopsis;
-    final statusLabel = availability.isAvailable
+    final title = widget.metadata?.title ?? 'Title unavailable';
+    final statusLabel = widget.availability.isAvailable
         ? null
         : expectedAt == null
         ? 'UNAIRED'
         : episodeAiringDateLabel(expectedAt);
     final semantics = <String>[
-      'Episode $episode, $title',
+      'Episode ${widget.episode}, $title',
       if (runtime != null) '$runtime minutes',
-      if (availability.isAvailable) 'available' else 'not aired yet',
+      if (widget.availability.isAvailable) 'available' else 'not aired yet',
       if (expectedAt != null) 'expected ${episodeAiringDateLabel(expectedAt)}',
+      if (_description.isNotEmpty) _description,
     ].join(', ');
+    final descriptionMaxLines = widget.compact && statusLabel != null
+        ? 1
+        : widget.compact
+        ? 2
+        : 3;
+    final descriptionStyle = TextStyle(
+      color: palette.mutedText,
+      fontSize: widget.compact ? 10 : 12,
+      height: 1.25,
+      fontWeight: FontWeight.w600,
+    );
+    final descriptionViewportHeight =
+        MediaQuery.textScalerOf(context).scale(descriptionStyle.fontSize!) *
+        descriptionStyle.height! *
+        descriptionMaxLines;
 
     return Semantics(
       label: semantics,
       button: true,
-      selected: selected,
+      selected: widget.selected,
       excludeSemantics: true,
       child: TvFocusable(
-        autofocus: autofocus,
-        focusNode: focusNode,
+        autofocus: widget.autofocus,
+        focusNode: widget.focusNode,
         focusScale: 1.018,
-        borderRadius: BorderRadius.circular(compact ? 11 : 14),
-        onPressed: onPressed,
-        onKeyEvent: onKeyEvent,
+        borderRadius: BorderRadius.circular(widget.compact ? 11 : 14),
+        onPressed: widget.onPressed,
+        onKeyEvent: widget.onKeyEvent,
+        onFocusChanged: _handleFocusChanged,
         child: Container(
           decoration: BoxDecoration(
             color: palette.surfaceRaised,
-            borderRadius: BorderRadius.circular(compact ? 11 : 14),
+            borderRadius: BorderRadius.circular(widget.compact ? 11 : 14),
             border: Border.all(
-              color: selected
+              color: widget.selected
                   ? palette.accentBright.withValues(alpha: .82)
                   : palette.primaryText.withValues(alpha: .13),
-              width: selected ? 2 : 1,
+              width: widget.selected ? 2 : 1,
             ),
           ),
           child: ClipRRect(
-            borderRadius: BorderRadius.circular(compact ? 10 : 13),
+            borderRadius: BorderRadius.circular(widget.compact ? 10 : 13),
             child: Row(
               children: [
                 SizedBox(
-                  width: artworkWidth,
+                  width: widget.artworkWidth,
                   height: double.infinity,
                   child: Stack(
                     fit: StackFit.expand,
@@ -575,7 +698,7 @@ class _EpisodeBrowserCard extends StatelessWidget {
                       NetworkArtwork(
                         url: artwork,
                         fit: BoxFit.contain,
-                        cacheWidth: compact ? 320 : 640,
+                        cacheWidth: widget.compact ? 320 : 640,
                         icon: Icons.video_library_outlined,
                       ),
                       const DecoratedBox(
@@ -588,13 +711,13 @@ class _EpisodeBrowserCard extends StatelessWidget {
                         ),
                       ),
                       Positioned(
-                        left: compact ? 8 : 10,
-                        bottom: compact ? 7 : 9,
+                        left: widget.compact ? 8 : 10,
+                        bottom: widget.compact ? 7 : 9,
                         child: Text(
-                          'EP $episode',
+                          'EP ${widget.episode}',
                           style: TextStyle(
                             color: Colors.white,
-                            fontSize: compact ? 11 : 13,
+                            fontSize: widget.compact ? 11 : 13,
                             fontWeight: FontWeight.w900,
                             letterSpacing: .6,
                           ),
@@ -602,12 +725,12 @@ class _EpisodeBrowserCard extends StatelessWidget {
                       ),
                       if (usesSeriesArtwork)
                         Positioned(
-                          left: compact ? 6 : 8,
-                          top: compact ? 6 : 8,
+                          left: widget.compact ? 6 : 8,
+                          top: widget.compact ? 6 : 8,
                           child: Container(
                             padding: EdgeInsets.symmetric(
-                              horizontal: compact ? 4 : 6,
-                              vertical: compact ? 2 : 3,
+                              horizontal: widget.compact ? 4 : 6,
+                              vertical: widget.compact ? 2 : 3,
                             ),
                             decoration: BoxDecoration(
                               color: Colors.black.withValues(alpha: .72),
@@ -617,7 +740,7 @@ class _EpisodeBrowserCard extends StatelessWidget {
                               'SERIES ART',
                               style: TextStyle(
                                 color: Colors.white.withValues(alpha: .9),
-                                fontSize: compact ? 6 : 8,
+                                fontSize: widget.compact ? 6 : 8,
                                 fontWeight: FontWeight.w900,
                                 letterSpacing: .35,
                               ),
@@ -629,55 +752,67 @@ class _EpisodeBrowserCard extends StatelessWidget {
                 ),
                 Expanded(
                   child: Padding(
-                    padding: EdgeInsets.all(compact ? 5 : 13),
+                    padding: EdgeInsets.all(widget.compact ? 5 : 13),
                     child: Column(
                       crossAxisAlignment: CrossAxisAlignment.start,
                       mainAxisAlignment: MainAxisAlignment.center,
                       children: [
                         Text(
-                          'Episode $episode${runtime == null ? '' : ' · $runtime min'}',
+                          'Episode ${widget.episode}${runtime == null ? '' : ' · $runtime min'}',
                           maxLines: 1,
                           overflow: TextOverflow.ellipsis,
                           style: TextStyle(
                             color: palette.primaryText,
-                            fontSize: compact ? 13 : 16,
+                            fontSize: widget.compact ? 13 : 16,
                             fontWeight: FontWeight.w900,
                           ),
                         ),
-                        SizedBox(height: compact ? 3 : 6),
+                        SizedBox(height: widget.compact ? 3 : 6),
                         Text(
                           title,
+                          key: ValueKey(
+                            'episode-browser-title-${widget.episode}',
+                          ),
                           maxLines: 1,
                           overflow: TextOverflow.ellipsis,
                           style: TextStyle(
                             color: palette.primaryText,
-                            fontSize: compact ? 12 : 15,
+                            fontSize: widget.compact ? 12 : 15,
                             fontWeight: FontWeight.w900,
                           ),
                         ),
-                        SizedBox(height: compact ? 4 : 7),
-                        Text(
-                          availability.isAvailable
-                              ? synopsis ?? 'Episode details unavailable.'
-                              : 'This episode has not aired yet.',
-                          maxLines: compact && statusLabel != null
-                              ? 1
-                              : compact
-                              ? 2
-                              : 3,
-                          overflow: TextOverflow.ellipsis,
-                          style: TextStyle(
-                            color: palette.mutedText,
-                            fontSize: compact ? 10 : 12,
-                            height: 1.25,
-                            fontWeight: FontWeight.w600,
+                        SizedBox(height: widget.compact ? 4 : 7),
+                        ConstrainedBox(
+                          constraints: BoxConstraints(
+                            maxHeight: descriptionViewportHeight,
+                          ),
+                          child: ClipRect(
+                            child: ScrollConfiguration(
+                              behavior: ScrollConfiguration.of(
+                                context,
+                              ).copyWith(scrollbars: false, overscroll: false),
+                              child: SingleChildScrollView(
+                                key: ValueKey(
+                                  'episode-browser-description-scroll-${widget.episode}',
+                                ),
+                                controller: _descriptionScrollController,
+                                physics: const NeverScrollableScrollPhysics(),
+                                child: Text(
+                                  _description,
+                                  key: ValueKey(
+                                    'episode-browser-description-${widget.episode}',
+                                  ),
+                                  style: descriptionStyle,
+                                ),
+                              ),
+                            ),
                           ),
                         ),
                         if (statusLabel != null) ...[
-                          SizedBox(height: compact ? 4 : 7),
+                          SizedBox(height: widget.compact ? 4 : 7),
                           _EpisodeCardBadge(
                             label: statusLabel,
-                            compact: compact,
+                            compact: widget.compact,
                           ),
                         ],
                       ],

--- a/lib/features/settings/application/app_update_controller.dart
+++ b/lib/features/settings/application/app_update_controller.dart
@@ -68,6 +68,7 @@ final appUpdateControllerProvider =
           allowPrerelease: true,
         ),
         apkInspector: bridge.inspectApk,
+        automaticCheckInterval: const Duration(minutes: 5),
       );
       Future.microtask(controller.load);
       return controller;
@@ -884,6 +885,21 @@ bool shouldOfferAppRelease({
   return compareAppVersions(releaseVersion, currentVersion) > 0;
 }
 
+/// Whether a previously verified APK still represents the exact release asset
+/// currently advertised by the update service. Release-note edits do not
+/// invalidate the package, but replacing the asset, digest, or build identity
+/// does so the updater can fetch and verify the new bytes.
+bool _sameDownloadArtifact(AppReleaseInfo previous, AppReleaseInfo current) =>
+    previous.tagName == current.tagName &&
+    normalizeAppVersion(previous.version) ==
+        normalizeAppVersion(current.version) &&
+    previous.androidVersionCode == current.androidVersionCode &&
+    previous.asset.name == current.asset.name &&
+    previous.asset.publicUrl == current.asset.publicUrl &&
+    previous.asset.size == current.asset.size &&
+    previous.asset.sha256Digest?.toLowerCase() ==
+        current.asset.sha256Digest?.toLowerCase();
+
 typedef CurrentVersionLoader = Future<String> Function();
 typedef DeviceAbisLoader = Future<List<String>> Function();
 typedef CacheDirectoryLoader = Future<Directory> Function();
@@ -1166,11 +1182,12 @@ class AppUpdateController extends StateNotifier<AppUpdateState> {
   Future<void> checkForUpdates({
     bool automatic = false,
     bool launchInstaller = false,
+    bool downloadAvailable = true,
   }) async {
     await load();
     if (state.isBusy) return;
+    final stateBeforeCheck = state;
     if (automatic) {
-      if (!state.automaticUpdates) return;
       final saved = await _storage.read(key: _automaticCheckStorageKey);
       final lastCheck = DateTime.tryParse(saved ?? '');
       if (lastCheck != null) {
@@ -1224,6 +1241,30 @@ class AppUpdateController extends StateNotifier<AppUpdateState> {
         await _recordSuccessfulAutomaticCheck(automatic);
         return;
       }
+      final preservedDownloadPath = stateBeforeCheck.downloadedPath;
+      final canPreserveDownloadedRelease =
+          preservedDownloadPath != null &&
+          stateBeforeCheck.release != null &&
+          _sameDownloadArtifact(stateBeforeCheck.release!, release) &&
+          await _downloadedUpdateStillExists(
+            preservedDownloadPath,
+            release.asset.size,
+          );
+      if (canPreserveDownloadedRelease) {
+        state = state.copyWith(
+          phase: AppUpdatePhase.ready,
+          latestVersion: release.version,
+          release: release,
+          downloadedPath: preservedDownloadPath,
+          progress: 1,
+          message:
+              'TetoTV ${state.updateChannel.versionLabel(release.version)} '
+              'is ready to install.',
+        );
+        await _recordSuccessfulAutomaticCheck(automatic);
+        if (launchInstaller) await installDownloadedUpdate();
+        return;
+      }
       state = state.copyWith(
         phase: AppUpdatePhase.available,
         latestVersion: release.version,
@@ -1234,6 +1275,15 @@ class AppUpdateController extends StateNotifier<AppUpdateState> {
             'is available on the '
             '${state.updateChannel.displayName} channel.',
       );
+      // A background metadata check is always allowed. Only downloading is
+      // governed by the Automatic updates preference; an explicit user check
+      // may still download while that preference is disabled.
+      final shouldDownload =
+          downloadAvailable && (!automatic || state.automaticUpdates);
+      if (!shouldDownload) {
+        await _recordSuccessfulAutomaticCheck(automatic);
+        return;
+      }
       await downloadUpdate(
         release: release,
         releaseSource: releaseSource,
@@ -1268,6 +1318,19 @@ class AppUpdateController extends StateNotifier<AppUpdateState> {
     } catch (_) {
       // A failed bookkeeping write must not turn a valid update check into an
       // error. The next launch may simply check GitHub again.
+    }
+  }
+
+  Future<bool> _downloadedUpdateStillExists(
+    String downloadedPath,
+    int expectedSize,
+  ) async {
+    try {
+      final file = File(downloadedPath);
+      if (!await file.exists()) return false;
+      return expectedSize <= 0 || await file.length() == expectedSize;
+    } catch (_) {
+      return false;
     }
   }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: 'none'
 # Public and Beta artifacts built from the same source use one monotonically
 # increasing Android versionCode. The project default carries the Beta display
 # version; the Public universal APK overrides the build name to the 1.x line.
-version: 2.0.68+410045
+version: 2.0.69+410046
 
 environment:
   sdk: ^3.12.2

--- a/test/app_notification_controller_test.dart
+++ b/test/app_notification_controller_test.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:io';
 
 import 'package:anime_tv/core/notifications/app_notification.dart';
@@ -6,11 +7,100 @@ import 'package:anime_tv/core/notifications/app_notification_controller.dart';
 import 'package:anime_tv/core/notifications/app_notification_store.dart';
 import 'package:anime_tv/core/storage/tetotv_database.dart';
 import 'package:anime_tv/features/settings/application/app_update_controller.dart';
+import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:sqflite_common_ffi/sqflite_ffi.dart';
 
 void main() {
   setUpAll(sqfliteFfiInit);
+
+  testWidgets(
+    'foreground refresh scheduler pauses, resumes immediately, and avoids overlap',
+    (tester) async {
+      var announcementCalls = 0;
+      var updateCalls = 0;
+      var holdAnnouncement = Completer<void>();
+      final scheduler = AppNotificationRefreshScheduler(
+        announcementInterval: const Duration(seconds: 1),
+        updateInterval: const Duration(seconds: 2),
+        refreshAnnouncements: () {
+          announcementCalls++;
+          return holdAnnouncement.future;
+        },
+        refreshAppUpdate: () async {
+          updateCalls++;
+        },
+      );
+      addTearDown(() {
+        scheduler.dispose();
+        if (!holdAnnouncement.isCompleted) holdAnnouncement.complete();
+      });
+
+      scheduler.start();
+      await tester.pump(const Duration(seconds: 1));
+      expect(announcementCalls, 1);
+      await tester.pump(const Duration(seconds: 3));
+      expect(announcementCalls, 1, reason: 'slow fetches must not stack');
+      expect(updateCalls, 2);
+
+      holdAnnouncement.complete();
+      await tester.pump();
+      holdAnnouncement = Completer<void>()..complete();
+      await tester.pump(const Duration(seconds: 1));
+      expect(announcementCalls, 2);
+
+      tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.paused);
+      await tester.pump();
+      final pausedAnnouncements = announcementCalls;
+      final pausedUpdates = updateCalls;
+      await tester.pump(const Duration(seconds: 5));
+      expect(announcementCalls, pausedAnnouncements);
+      expect(updateCalls, pausedUpdates);
+
+      tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.resumed);
+      await tester.pump();
+      expect(announcementCalls, pausedAnnouncements + 1);
+      expect(updateCalls, pausedUpdates + 1);
+      scheduler.dispose();
+    },
+  );
+
+  testWidgets(
+    'update polling interval starts after the prior check completes',
+    (tester) async {
+      var updateCalls = 0;
+      final firstUpdate = Completer<void>();
+      final scheduler = AppNotificationRefreshScheduler(
+        announcementInterval: const Duration(hours: 1),
+        updateInterval: const Duration(seconds: 2),
+        refreshAnnouncements: () async {},
+        refreshAppUpdate: () {
+          updateCalls++;
+          return updateCalls == 1 ? firstUpdate.future : Future<void>.value();
+        },
+      );
+      addTearDown(() {
+        scheduler.dispose();
+        if (!firstUpdate.isCompleted) firstUpdate.complete();
+      });
+
+      scheduler.start();
+      await tester.pump(const Duration(seconds: 2));
+      expect(updateCalls, 1);
+
+      await tester.pump(const Duration(seconds: 10));
+      expect(updateCalls, 1, reason: 'an in-flight check must not be stacked');
+
+      firstUpdate.complete();
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 1999));
+      expect(updateCalls, 1);
+      await tester.pump(const Duration(milliseconds: 1));
+      expect(updateCalls, 2);
+      await tester.pump();
+      scheduler.dispose();
+    },
+  );
 
   group('AppNotificationStore', () {
     late Database database;

--- a/test/app_update_controller_test.dart
+++ b/test/app_update_controller_test.dart
@@ -1374,6 +1374,155 @@ void main() {
       expect(installs, 0);
     });
 
+    test(
+      'foreground polling discovers updates without downloading them',
+      () async {
+        final source = _MemoryReleaseSource('1.0.2');
+        final controller = _controller(storage: storage, publicSource: source);
+
+        await controller.checkForUpdates(
+          automatic: true,
+          downloadAvailable: false,
+        );
+
+        expect(source.latestCalls, 1);
+        expect(source.downloadCalls, 0);
+        expect(controller.state.phase, AppUpdatePhase.available);
+        expect(controller.state.release?.version, '1.0.2');
+
+        await controller.checkForUpdates(
+          automatic: true,
+          downloadAvailable: false,
+        );
+        expect(source.latestCalls, 1, reason: 'the automatic throttle is kept');
+      },
+    );
+
+    test(
+      'foreground polling still discovers updates when auto-download is off',
+      () async {
+        final source = _MemoryReleaseSource('1.0.2');
+        final controller = _controller(storage: storage, publicSource: source);
+        await controller.setAutomaticUpdates(false);
+
+        await controller.checkForUpdates(automatic: true);
+
+        expect(source.latestCalls, 1);
+        expect(source.downloadCalls, 0);
+        expect(controller.state.phase, AppUpdatePhase.available);
+        expect(controller.state.release?.version, '1.0.2');
+        expect(controller.state.automaticUpdates, isFalse);
+      },
+    );
+
+    test('foreground polling downloads when auto-download is on', () async {
+      final directory = await Directory.systemTemp.createTemp(
+        'automatic-update-download-',
+      );
+      addTearDown(() => directory.delete(recursive: true));
+      final source = _MemoryReleaseSource('1.0.2');
+      final controller = _controller(
+        storage: storage,
+        publicSource: source,
+        cache: directory,
+      );
+
+      await controller.checkForUpdates(automatic: true);
+
+      expect(source.latestCalls, 1);
+      expect(source.downloadCalls, 1);
+      expect(controller.state.phase, AppUpdatePhase.ready);
+      expect(controller.state.downloadedPath, isNotNull);
+    });
+
+    test('automatic polling preserves an update already downloaded', () async {
+      final directory = await Directory.systemTemp.createTemp(
+        'ready-update-poll-',
+      );
+      addTearDown(() => directory.delete(recursive: true));
+      final source = _MemoryReleaseSource('1.0.2');
+      final controller = _controller(
+        storage: storage,
+        publicSource: source,
+        cache: directory,
+      );
+      await controller.checkForUpdates();
+      final downloadedPath = controller.state.downloadedPath;
+      expect(controller.state.phase, AppUpdatePhase.ready);
+      expect(source.downloadCalls, 1);
+
+      await controller.checkForUpdates(
+        automatic: true,
+        downloadAvailable: false,
+      );
+
+      expect(source.latestCalls, 2);
+      expect(source.downloadCalls, 1);
+      expect(controller.state.phase, AppUpdatePhase.ready);
+      expect(controller.state.downloadedPath, downloadedPath);
+    });
+
+    test('a newer remote release supersedes an older ready update', () async {
+      final directory = await Directory.systemTemp.createTemp(
+        'newer-ready-update-',
+      );
+      addTearDown(() => directory.delete(recursive: true));
+      final source = _MemoryReleaseSource('1.0.2');
+      final controller = _controller(
+        storage: storage,
+        publicSource: source,
+        cache: directory,
+      );
+      await controller.checkForUpdates();
+      final olderPath = controller.state.downloadedPath;
+      expect(olderPath, contains('v1.0.2'));
+
+      source.version = '1.0.3';
+      await controller.checkForUpdates(automatic: true);
+
+      expect(source.latestCalls, 2);
+      expect(source.downloadCalls, 2);
+      expect(source.downloadedVersions, ['1.0.2', '1.0.3']);
+      expect(controller.state.phase, AppUpdatePhase.ready);
+      expect(controller.state.release?.version, '1.0.3');
+      expect(controller.state.downloadedPath, contains('v1.0.3'));
+      expect(controller.state.downloadedPath, isNot(olderPath));
+    });
+
+    test(
+      'polling preserves a matching downloaded APK after installer failure',
+      () async {
+        final directory = await Directory.systemTemp.createTemp(
+          'installer-error-update-',
+        );
+        addTearDown(() => directory.delete(recursive: true));
+        final source = _MemoryReleaseSource('1.0.2');
+        final controller = _controller(
+          storage: storage,
+          publicSource: source,
+          cache: directory,
+          installer: (_) async => throw StateError('installer unavailable'),
+        );
+        await controller.checkForUpdates();
+        final downloadedPath = controller.state.downloadedPath;
+        await controller.installDownloadedUpdate();
+        expect(controller.state.phase, AppUpdatePhase.error);
+        expect(controller.state.downloadedPath, downloadedPath);
+
+        await controller.checkForUpdates(
+          automatic: true,
+          downloadAvailable: false,
+        );
+
+        expect(source.latestCalls, 2);
+        expect(source.downloadCalls, 1);
+        expect(controller.state.phase, AppUpdatePhase.ready);
+        expect(controller.state.message, contains('ready to install'));
+        expect(controller.state.downloadedPath, downloadedPath);
+        expect(File(downloadedPath!).existsSync(), isTrue);
+      },
+    );
+
     test('future automatic-check timestamps do not suppress retries', () async {
       FlutterSecureStorage.setMockInitialValues({
         lastAutomaticUpdateCheckStorageKey: DateTime.now()
@@ -1542,7 +1691,7 @@ class _MemoryReleaseSource implements AppReleaseSource {
 
   static final List<int> payload = List<int>.filled(1024 * 1024, 7);
 
-  final String version;
+  String version;
   final List<String>? historyVersions;
   final Map<String, int> androidVersionCodes;
   final String? digest;

--- a/test/episode_browser_dialog_test.dart
+++ b/test/episode_browser_dialog_test.dart
@@ -3,6 +3,7 @@ import 'package:anime_tv/core/widgets/network_artwork.dart';
 import 'package:anime_tv/features/catalog/domain/anime_summary.dart';
 import 'package:anime_tv/features/catalog/domain/catalog_episode_metadata.dart';
 import 'package:anime_tv/features/catalog/presentation/episode_browser_dialog.dart';
+import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -229,6 +230,392 @@ void main() {
     expect(tester.takeException(), isNull);
   });
 
+  testWidgets('embedded browser opens with a restrained fade and lift', (
+    tester,
+  ) async {
+    tester.view.physicalSize = const Size(960, 540);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: AppTheme.dark,
+        home: EpisodeBrowserDialog(
+          anime: const AnimeSummary(
+            id: 908,
+            title: 'Animated Episodes',
+            description: '',
+            episodes: 2,
+            score: null,
+          ),
+          selectedEpisode: 1,
+          totalEpisodes: 2,
+          embedded: true,
+          onClose: () {},
+          onEpisodeSelected: (_) {},
+        ),
+      ),
+    );
+
+    final animation = tester.widget<TweenAnimationBuilder<double>>(
+      find.byKey(const ValueKey('episode-browser-open-animation')),
+    );
+    expect(animation.duration, const Duration(milliseconds: 160));
+    expect(animation.curve, Curves.easeOutCubic);
+
+    final initialOpacity = tester.widget<Opacity>(
+      find.byKey(const ValueKey('episode-browser-open-opacity')),
+    );
+    final initialSlide = tester.widget<Transform>(
+      find.byKey(const ValueKey('episode-browser-open-slide')),
+    );
+    expect(initialOpacity.opacity, 0);
+    expect(initialSlide.transform.getTranslation().y, 10);
+
+    await tester.pump(const Duration(milliseconds: 80));
+    final midOpacity = tester.widget<Opacity>(
+      find.byKey(const ValueKey('episode-browser-open-opacity')),
+    );
+    final midSlide = tester.widget<Transform>(
+      find.byKey(const ValueKey('episode-browser-open-slide')),
+    );
+    expect(midOpacity.opacity, inExclusiveRange(0, 1));
+    expect(midSlide.transform.getTranslation().y, inExclusiveRange(0, 10));
+
+    await tester.pump(const Duration(milliseconds: 80));
+    final finalOpacity = tester.widget<Opacity>(
+      find.byKey(const ValueKey('episode-browser-open-opacity')),
+    );
+    final finalSlide = tester.widget<Transform>(
+      find.byKey(const ValueKey('episode-browser-open-slide')),
+    );
+    expect(finalOpacity.opacity, 1);
+    expect(finalSlide.transform.getTranslation().y, 0);
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets(
+    'only a focused card description scrolls after three seconds and resets',
+    (tester) async {
+      tester.view.physicalSize = const Size(1920, 1080);
+      tester.view.devicePixelRatio = 1;
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+
+      const longSynopsis =
+          'A patient investigation carries the crew across the entire city '
+          'while each new clue changes what they know about the missing ship. '
+          'Old allies return, hidden motives surface, and the team must decide '
+          'who they can trust before the final signal disappears forever. '
+          'The journey continues through several districts so every important '
+          'detail has enough room to be presented to the viewer.';
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: AppTheme.dark,
+          home: const EpisodeBrowserDialog(
+            anime: AnimeSummary(
+              id: 909,
+              title: 'Scrolling Episodes',
+              description: '',
+              episodes: 2,
+              score: null,
+            ),
+            selectedEpisode: 1,
+            totalEpisodes: 2,
+            episodeMetadata: <int, CatalogEpisodeMetadata>{
+              1: CatalogEpisodeMetadata(
+                episode: 1,
+                title: 'The Title Must Stay Still',
+                synopsis: longSynopsis,
+              ),
+              2: CatalogEpisodeMetadata(
+                episode: 2,
+                title: 'A Short Follow-up',
+                synopsis: 'A short description.',
+              ),
+            },
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      final descriptionController = _descriptionController(tester, 1);
+      expect(descriptionController.position.maxScrollExtent, greaterThan(0));
+      final titleTop = tester.getTopLeft(
+        find.byKey(const ValueKey('episode-browser-title-1')),
+      );
+      final descriptionTop = tester.getTopLeft(
+        find.byKey(const ValueKey('episode-browser-description-1')),
+      );
+
+      await tester.pump(const Duration(milliseconds: 2999));
+      expect(descriptionController.offset, 0);
+      await tester.pump(const Duration(milliseconds: 1));
+      await tester.pump(const Duration(seconds: 1));
+
+      expect(descriptionController.offset, greaterThan(0));
+      expect(
+        descriptionController.offset,
+        lessThan(descriptionController.position.maxScrollExtent),
+      );
+      expect(
+        tester
+            .getTopLeft(
+              find.byKey(const ValueKey('episode-browser-description-1')),
+            )
+            .dy,
+        lessThan(descriptionTop.dy),
+      );
+      expect(
+        tester.getTopLeft(
+          find.byKey(const ValueKey('episode-browser-title-1')),
+        ),
+        titleTop,
+      );
+
+      await tester.pump(const Duration(minutes: 1));
+      expect(
+        descriptionController.offset,
+        closeTo(descriptionController.position.maxScrollExtent, .01),
+      );
+
+      _cardFocusNode(tester, 2).requestFocus();
+      await tester.pump();
+      expect(descriptionController.offset, 0);
+      await tester.pump(const Duration(seconds: 4));
+      expect(descriptionController.offset, 0);
+
+      _cardFocusNode(tester, 1).requestFocus();
+      await tester.pump();
+      await tester.pump(const Duration(seconds: 3));
+      _cardFocusNode(tester, 2).requestFocus();
+      await tester.pump();
+      await tester.pump(const Duration(seconds: 1));
+      expect(descriptionController.offset, 0);
+      expect(tester.takeException(), isNull);
+    },
+  );
+
+  testWidgets('reduced motion keeps the focused synopsis still', (
+    tester,
+  ) async {
+    tester.view.physicalSize = const Size(1920, 1080);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    const synopsis =
+        'A deliberately long accessible synopsis fills enough lines to exceed '
+        'the visible card. It should remain completely still when the device '
+        'has disabled animations, even after the normal three second delay. '
+        'The complete text remains available to assistive technology.';
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: AppTheme.dark,
+        home: Builder(
+          builder: (context) => MediaQuery(
+            data: MediaQuery.of(context).copyWith(disableAnimations: true),
+            child: const EpisodeBrowserDialog(
+              anime: AnimeSummary(
+                id: 912,
+                title: 'Reduced Motion Episodes',
+                description: '',
+                episodes: 1,
+                score: null,
+              ),
+              selectedEpisode: 1,
+              totalEpisodes: 1,
+              episodeMetadata: <int, CatalogEpisodeMetadata>{
+                1: CatalogEpisodeMetadata(
+                  episode: 1,
+                  title: 'An Accessible Episode',
+                  synopsis: synopsis,
+                ),
+              },
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    final descriptionController = _descriptionController(tester, 1);
+    expect(descriptionController.position.maxScrollExtent, greaterThan(0));
+    expect(_cardHasFocus(tester, 1), isTrue);
+    await tester.pump(const Duration(seconds: 10));
+    expect(descriptionController.offset, 0);
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('episode card semantics include the complete synopsis', (
+    tester,
+  ) async {
+    final semanticsHandle = tester.ensureSemantics();
+    tester.view.physicalSize = const Size(1920, 1080);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    const synopsis =
+        'Every word of this synopsis should be spoken by TalkBack.';
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: AppTheme.dark,
+        home: const EpisodeBrowserDialog(
+          anime: AnimeSummary(
+            id: 913,
+            title: 'Semantic Episodes',
+            description: '',
+            episodes: 1,
+            score: null,
+          ),
+          selectedEpisode: 1,
+          totalEpisodes: 1,
+          episodeMetadata: <int, CatalogEpisodeMetadata>{
+            1: CatalogEpisodeMetadata(
+              episode: 1,
+              title: 'The Spoken Episode',
+              synopsis: synopsis,
+            ),
+          },
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    final semanticsWidgets = tester.widgetList<Semantics>(
+      find.descendant(
+        of: find.byKey(const ValueKey('episode-browser-card-1')),
+        matching: find.byType(Semantics),
+      ),
+    );
+    expect(
+      semanticsWidgets.any(
+        (widget) => widget.properties.label?.contains(synopsis) ?? false,
+      ),
+      isTrue,
+    );
+    semanticsHandle.dispose();
+  });
+
+  testWidgets('pointer hover and touch focus start the description delay', (
+    tester,
+  ) async {
+    final previousHighlightStrategy = FocusManager.instance.highlightStrategy;
+    FocusManager.instance.highlightStrategy =
+        FocusHighlightStrategy.alwaysTraditional;
+    addTearDown(
+      () => FocusManager.instance.highlightStrategy = previousHighlightStrategy,
+    );
+    tester.view.physicalSize = const Size(1920, 1080);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    const longSynopsis =
+        'This deliberately long episode description provides enough text to '
+        'overflow the synopsis viewport. It keeps adding context about the '
+        'characters, their route, their discoveries, and their eventual plan '
+        'so the automatic upward movement is observable in this focused test.';
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: AppTheme.dark,
+        home: EpisodeBrowserDialog(
+          anime: const AnimeSummary(
+            id: 910,
+            title: 'Pointer Episodes',
+            description: '',
+            episodes: 2,
+            score: null,
+          ),
+          selectedEpisode: 2,
+          totalEpisodes: 2,
+          embedded: true,
+          episodeMetadata: const <int, CatalogEpisodeMetadata>{
+            1: CatalogEpisodeMetadata(
+              episode: 1,
+              title: 'Pointer Target',
+              synopsis: longSynopsis,
+            ),
+          },
+          onClose: () {},
+          onEpisodeSelected: (_) {},
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    final descriptionController = _descriptionController(tester, 1);
+    expect(descriptionController.position.maxScrollExtent, greaterThan(0));
+    final mouse = await tester.createGesture(kind: PointerDeviceKind.mouse);
+    addTearDown(mouse.removePointer);
+    await mouse.addPointer(location: Offset.zero);
+    await tester.pump();
+    await mouse.moveTo(
+      tester.getCenter(find.byKey(const ValueKey('episode-browser-card-1'))),
+    );
+    await tester.pump();
+    expect(_cardHasFocus(tester, 1), isTrue);
+
+    await tester.pump(const Duration(seconds: 3));
+    await tester.pump(const Duration(seconds: 1));
+    expect(descriptionController.offset, greaterThan(0));
+
+    await mouse.moveTo(Offset.zero);
+    _cardFocusNode(tester, 2).requestFocus();
+    await tester.pump();
+    expect(descriptionController.offset, 0);
+
+    await tester.tap(find.byKey(const ValueKey('episode-browser-card-1')));
+    await tester.pump();
+    expect(_cardHasFocus(tester, 1), isTrue);
+    await tester.pump(const Duration(seconds: 3));
+    await tester.pump(const Duration(seconds: 1));
+    expect(descriptionController.offset, greaterThan(0));
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('disposing a focused card cancels its delayed scroll', (
+    tester,
+  ) async {
+    tester.view.physicalSize = const Size(960, 540);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: AppTheme.dark,
+        home: const EpisodeBrowserDialog(
+          anime: AnimeSummary(
+            id: 911,
+            title: 'Disposable Episodes',
+            description: '',
+            episodes: 1,
+            score: null,
+          ),
+          selectedEpisode: 1,
+          totalEpisodes: 1,
+          episodeMetadata: <int, CatalogEpisodeMetadata>{
+            1: CatalogEpisodeMetadata(
+              episode: 1,
+              title: 'A Focused Episode',
+              synopsis: 'A description that will never start scrolling.',
+            ),
+          },
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+    expect(_cardHasFocus(tester, 1), isTrue);
+    await tester.pump(const Duration(seconds: 1));
+
+    await tester.pumpWidget(const MaterialApp(home: SizedBox.shrink()));
+    await tester.pump(const Duration(seconds: 4));
+    expect(tester.takeException(), isNull);
+  });
+
   testWidgets('embedded browser exits upward from its first visible row', (
     tester,
   ) async {
@@ -396,13 +783,25 @@ void main() {
 }
 
 bool _cardHasFocus(WidgetTester tester, int episode) {
+  return _cardFocusNode(tester, episode).hasFocus;
+}
+
+FocusableActionDetector _cardFocusable(WidgetTester tester, int episode) {
   final focusable = find.descendant(
     of: find.byKey(ValueKey('episode-browser-card-$episode')),
     matching: find.byType(FocusableActionDetector),
   );
+  return tester.widget<FocusableActionDetector>(focusable);
+}
+
+FocusNode _cardFocusNode(WidgetTester tester, int episode) {
+  return _cardFocusable(tester, episode).focusNode!;
+}
+
+ScrollController _descriptionController(WidgetTester tester, int episode) {
   return tester
-          .widget<FocusableActionDetector>(focusable)
-          .focusNode
-          ?.hasFocus ==
-      true;
+      .widget<SingleChildScrollView>(
+        find.byKey(ValueKey('episode-browser-description-scroll-$episode')),
+      )
+      .controller!;
 }

--- a/test/home_notification_bell_test.dart
+++ b/test/home_notification_bell_test.dart
@@ -456,6 +456,7 @@ class _TestAppUpdateController extends AppUpdateController {
   Future<void> checkForUpdates({
     bool automatic = false,
     bool launchInstaller = false,
+    bool downloadAvailable = true,
   }) async {
     checkCalls++;
     lastAutomatic = automatic;


### PR DESCRIPTION
Fix the native direct-torrent handle lifetime crash reported by customers, harden uncertain cleanup, polish the episode browser transition and delayed description scrolling, and refresh announcements/update metadata while the app remains open. Includes the 2.0.69 release metadata and regression coverage.\n\nValidated locally with Flutter analysis, 2,337 Flutter tests, focused Android direct-torrent unit tests, release-policy tests, and native redistribution verification.