### PR TITLE
Prepare TetoTV Beta 2.0.70

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 
 <p align="center">
   <a href="https://github.com/LindersOSX/TetoTV-Beta/releases/latest"><strong>Download Beta</strong></a>
-  · <a href="docs/RELEASE_NOTES_2.0.69.md">What's new</a>
+  · <a href="docs/RELEASE_NOTES_2.0.70.md">What's new</a>
   · <a href="https://github.com/LindersOSX/TetoTV-Beta/issues/new">Report an issue</a>
   · <a href="https://discord.gg/juC6k7d4WY">Discord</a>
   · <a href="https://www.youtube.com/@TetoTVApp">YouTube</a>
@@ -96,10 +96,10 @@ TetoTV runs directly on the Android device with no companion server required for
 | Channel | Version | Best for |
 | --- | --- | --- |
 | Public | Not published | Source and release-readiness documents are available, but no Public APK is currently offered |
-| Beta | [2.0.69](docs/RELEASE_NOTES_2.0.69.md) | Direct-torrent stability, smoother episode browsing, and live notification refresh |
+| Beta | [2.0.70](docs/RELEASE_NOTES_2.0.70.md) | Secure manga page loading and richer paused-player episode details |
 
 > [!WARNING]
-> Beta 2.0.69 uses the repository's explicit unreviewed-Beta exception. Its native-library and corresponding-source material did not receive independent license review, and automated integrity checks are not a legal compliance determination. Read the [complete Beta disclosure](docs/RELEASE_NOTES_2.0.69.md). This exception does not apply to a future Public release.
+> Beta 2.0.70 uses the repository's explicit unreviewed-Beta exception. Its native-library and corresponding-source material did not receive independent license review, and automated integrity checks are not a legal compliance determination. Read the [complete Beta disclosure](docs/RELEASE_NOTES_2.0.70.md). This exception does not apply to a future Public release.
 
 The Public updater repository intentionally has no release while the Public build is held for review. Existing Beta installations continue to update from the Beta repository. Android never permits an in-place install of an APK with a lower build code; Developer Mode does not bypass that platform rule.
 

--- a/docs/BUILD_WINDOWS.md
+++ b/docs/BUILD_WINDOWS.md
@@ -220,39 +220,39 @@ APK containing both supported application ABIs.
 Public and Beta updates use anonymous GitHub requests. No Beta key, GitHub
 token, update-proxy URL, or update-specific Dart define is required. Every
 published APK uses the production signing identity. No Public APK is currently
-published. Beta 2.0.69 uses Android build code `410046`. Flutter reuses
+published. Beta 2.0.70 uses Android build code `410047`. Flutter reuses
 `app-release.apk`, so copy and rename the Beta artifact immediately after the
 build:
 
 ```powershell
-New-Item -ItemType Directory -Force .\build\fire-tv\v2.0.69 | Out-Null
+New-Item -ItemType Directory -Force .\build\fire-tv\v2.0.70 | Out-Null
 
-# Beta 2.0.69
+# Beta 2.0.70
 flutter build apk --release --target-platform android-arm,android-arm64 `
-  --build-name 2.0.69 --build-number 410046 --no-tree-shake-icons
+  --build-name 2.0.70 --build-number 410047 --no-tree-shake-icons
 Copy-Item .\build\app\outputs\flutter-apk\app-release.apk `
-  .\build\fire-tv\v2.0.69\TetoTV-v2.0.69-universal.apk
+  .\build\fire-tv\v2.0.70\TetoTV-v2.0.70-universal.apk
 
 .\tool\release\verify_release_apk.ps1 `
   -Channel Beta `
-  -ApkPath .\build\fire-tv\v2.0.69\TetoTV-v2.0.69-universal.apk
+  -ApkPath .\build\fire-tv\v2.0.70\TetoTV-v2.0.70-universal.apk
 
 .\tool\release\verify_native_redistribution.ps1 `
   -RequireResolvedBinaries `
   -ResolvedBinaryDirectory .\build\native-playback\outputs `
-  -StageBundle -ReleaseTag v2.0.69
+  -StageBundle -ReleaseTag v2.0.70
 
 .\tool\release\new_release_checksums.ps1 `
-  -ApkPath .\build\fire-tv\v2.0.69\TetoTV-v2.0.69-universal.apk `
-  -NativeSourcePath .\build\release-compliance\v2.0.69\TetoTV-v2.0.69-native-playback-sources.zip `
-  -OutputPath .\build\fire-tv\v2.0.69\SHA256SUMS
+  -ApkPath .\build\fire-tv\v2.0.70\TetoTV-v2.0.70-universal.apk `
+  -NativeSourcePath .\build\release-compliance\v2.0.70\TetoTV-v2.0.70-native-playback-sources.zip `
+  -OutputPath .\build\fire-tv\v2.0.70\SHA256SUMS
 
 .\tool\release\verify_release_payloads.ps1 `
   -Channel Beta `
-  -ApkPath .\build\fire-tv\v2.0.69\TetoTV-v2.0.69-universal.apk `
-  -NativeSourcePath .\build\release-compliance\v2.0.69\TetoTV-v2.0.69-native-playback-sources.zip `
-  -ChecksumsPath .\build\fire-tv\v2.0.69\SHA256SUMS `
-  -ReleaseNotesPath .\docs\RELEASE_NOTES_2.0.69.md `
+  -ApkPath .\build\fire-tv\v2.0.70\TetoTV-v2.0.70-universal.apk `
+  -NativeSourcePath .\build\release-compliance\v2.0.70\TetoTV-v2.0.70-native-playback-sources.zip `
+  -ChecksumsPath .\build\fire-tv\v2.0.70\SHA256SUMS `
+  -ReleaseNotesPath .\docs\RELEASE_NOTES_2.0.70.md `
   -ResolvedBinaryDirectory .\build\native-playback\outputs
 ```
 

--- a/docs/RELEASE_NOTES_2.0.70.md
+++ b/docs/RELEASE_NOTES_2.0.70.md
@@ -1,0 +1,30 @@
+# TetoTV 2.0.70 Beta
+
+> [!WARNING]
+> No independent native-license review: This Beta has not received independent native-library licensing review. Automated checks verify the APK, native-source bundle, notices, pinned inputs, and checksums, but do not establish legal compliance or reproducible builds.
+
+This Beta fixes secure manga page loading across approved CDN redirects and adds polished episode details to the paused player HUD.
+
+## What's changed
+
+- Manga pages can now follow bounded HTTPS redirects used by compatible user-added sources while every destination is revalidated before loading. Sensitive credentials are stripped across origins, unsafe destinations remain blocked, and image size and format limits remain enforced.
+- Manga loading errors now distinguish common source, authorization, availability, and security failures without exposing private URLs, headers, or credentials in diagnostics.
+- Pausing an episode shows its catalog episode name and synopsis in the top-left while the player HUD is visible. The panel ends at the screen midpoint and the synopsis is clipped to three visible lines.
+- Long episode descriptions begin a slow vertical scroll after five seconds while the episode title stays fixed. Reduced-motion settings disable the automatic movement.
+- The paused HUD remains available for reading until playback resumes or the viewer dismisses it. Startup, completed playback, and error states do not present themselves as a user pause.
+- AI-assisted development disclosure: AI tools assisted with implementation, documentation, tests, and review. The project owner directed the work, validated the changes, and remains responsible for this release.
+
+## Release assets
+
+- `TetoTV-v2.0.70-universal.apk` — install this file on a supported Android device.
+- `TetoTV-v2.0.70-native-playback-sources.zip` — native playback source and license material for developers and compliance review; normal users do not need it.
+- `SHA256SUMS` — integrity hashes for the two files above.
+
+## Beta notes
+
+- This is a Beta-channel build with Android build code `410047`.
+- No Public APK is being published with this release.
+- No manga repository, extension, provider, catalog, or title is bundled or recommended by TetoTV.
+- Android does not permit an in-place install over an APK with a higher build code. A future Public counterpart must use build code `410047` or newer for data-preserving channel switching.
+
+<!-- tetotv-android-version-code: 410047 -->

--- a/docs/UPDATE_CHANNELS.md
+++ b/docs/UPDATE_CHANNELS.md
@@ -35,11 +35,11 @@ Beta reads completed 2.x releases from:
 https://api.github.com/repos/LindersOSX/TetoTV-Beta/releases/latest
 ```
 
-The current Beta source build is `v2.0.69` with Android build code `410046`.
+The current Beta source build is `v2.0.70` with Android build code `410047`.
 Its release title is:
 
 ```text
-TetoTV 2.0.69 Beta - Android TV / Google TV / Fire TV
+TetoTV 2.0.70 Beta - Android TV / Google TV / Fire TV
 ```
 
 Publish it as a normal, non-draft, non-prerelease GitHub release so
@@ -72,7 +72,7 @@ proxy.
 Release notes must include the exact asset names and this build-code marker:
 
 ```html
-<!-- tetotv-android-version-code: 410046 -->
+<!-- tetotv-android-version-code: 410047 -->
 ```
 
 When build-code metadata is present, the updater rejects a known lower build
@@ -94,10 +94,10 @@ These rules apply equally on phones, Android TV, Google TV, and Fire TV.
 
 ## Switching and rollback
 
-The current Beta uses build code `410046`. No Public counterpart is available.
+The current Beta uses build code `410047`. No Public counterpart is available.
 An older Public install can move to this Beta when Android accepts the higher
 build code, but it cannot move back in place until a future Public build uses
-code `410046` or higher. Uninstalling first permits an older APK but deletes
+code `410047` or higher. Uninstalling first permits an older APK but deletes
 local application data. Developer Mode and in-app settings cannot override
 this Android rule.
 

--- a/lib/features/manga/data/manga_acquisition_service.dart
+++ b/lib/features/manga/data/manga_acquisition_service.dart
@@ -1665,20 +1665,30 @@ Map<String, String> _validatedEphemeralHeaderMap(
     final name = entry.key.trim();
     final lowerName = name.toLowerCase();
     final value = entry.value;
+    final canonicalPageMetadata = allowPageMetadata
+        ? switch (lowerName) {
+            'origin' => canonicalMangaPageOriginHeader(value),
+            'referer' => canonicalMangaPageRefererHeader(value),
+            _ => value,
+          }
+        : value;
     if (!_acquisitionHeaderNamePattern.hasMatch(name) ||
         !(allowPageMetadata
-            ? _allowedMangaPageHeader(lowerName, value)
+            ? _allowedMangaPageHeader(lowerName)
             : _allowedAcquisitionCredentialHeader(lowerName)) ||
+        canonicalPageMetadata == null ||
         !normalizedNames.add(lowerName) ||
-        value.length > 8192 ||
-        value.codeUnits.any((unit) => unit < 0x20 || unit == 0x7f)) {
+        canonicalPageMetadata.length > 8192 ||
+        canonicalPageMetadata.codeUnits.any(
+          (unit) => unit < 0x20 || unit == 0x7f,
+        )) {
       throw const FormatException('Invalid manga acquisition header.');
     }
-    totalLength += name.length + value.length;
+    totalLength += name.length + canonicalPageMetadata.length;
     if (totalLength > 16 * 1024) {
       throw const FormatException('Manga acquisition headers are too large.');
     }
-    safe[name] = value;
+    safe[name] = canonicalPageMetadata;
   }
   return Map<String, String>.unmodifiable(safe);
 }
@@ -1688,30 +1698,13 @@ bool _allowedAcquisitionCredentialHeader(String name) =>
     !name.startsWith('proxy-') &&
     !name.startsWith('sec-');
 
-bool _allowedMangaPageHeader(String name, String value) {
+bool _allowedMangaPageHeader(String name) {
   if (_blockedMangaPageHeaders.contains(name) ||
       name.startsWith('proxy-') ||
       name.startsWith('sec-')) {
     return false;
   }
-  if (name == 'origin') return _isSafeMangaMediaOrigin(value);
-  if (name == 'referer') {
-    final parsed = Uri.tryParse(value.trim());
-    return parsed != null &&
-        !parsed.hasFragment &&
-        safePublicHttpsUri(value) != null;
-  }
   return true;
-}
-
-bool _isSafeMangaMediaOrigin(String value) {
-  final parsed = Uri.tryParse(value.trim());
-  final uri = safePublicHttpsUri(value);
-  return parsed != null &&
-      uri != null &&
-      !parsed.hasQuery &&
-      !parsed.hasFragment &&
-      (parsed.path.isEmpty || parsed.path == '/');
 }
 
 Future<Map<String, String>> _noCredentialHeaders(String _) async =>

--- a/lib/features/manga/data/manga_page_fetch_client.dart
+++ b/lib/features/manga/data/manga_page_fetch_client.dart
@@ -3,6 +3,7 @@ import 'dart:collection';
 import 'dart:io';
 import 'dart:typed_data';
 
+import 'package:anime_tv/core/storage/tetotv_database.dart';
 import 'package:anime_tv/features/manga/data/manga_image_safety.dart';
 import 'package:anime_tv/features/manga/data/manga_uri_policy.dart';
 import 'package:anime_tv/features/manga/domain/manga_reader_models.dart';
@@ -17,15 +18,34 @@ const int maximumMangaRemotePageBytes = 20 * 1024 * 1024;
 typedef MangaPageTargetValidator = Future<void> Function(Uri uri);
 
 final mangaPageFetchClientProvider = Provider<MangaPageFetchClient>((ref) {
-  final client = MangaPageFetchClient();
+  final client = MangaPageFetchClient(
+    reportFailure: (failure) => TetoTvDatabase.instance.recordDiagnosticEvent(
+      category: 'manga-reader',
+      severity: 'warning',
+      message: 'Manga page fetch failed',
+      details: <String, Object?>{
+        'reason_code': failure.reasonCode,
+        'status': ?failure.statusCode,
+      },
+    ),
+  );
   ref.onDispose(client.close);
   return client;
 });
 
+typedef MangaPageFailureReporter =
+    FutureOr<void> Function(MangaPageFetchException failure);
+
 class MangaPageFetchException implements Exception {
-  const MangaPageFetchException(this.message);
+  const MangaPageFetchException(
+    this.message, {
+    this.reasonCode = 'unknown',
+    this.statusCode,
+  });
 
   final String message;
+  final String reasonCode;
+  final int? statusCode;
 
   @override
   String toString() => message;
@@ -51,6 +71,7 @@ class MangaPageFetchClient {
     this.maximumCachedBytes = 48 * 1024 * 1024,
     this.maximumConcurrentRequests = 8,
     this.maximumCacheEntries = 64,
+    this.reportFailure,
   }) : _validateTarget = validateTarget ?? validatePublicNetworkTarget,
        _dio =
            dio ??
@@ -81,6 +102,7 @@ class MangaPageFetchClient {
 
   final Dio _dio;
   final MangaPageTargetValidator _validateTarget;
+  final MangaPageFailureReporter? reportFailure;
   final Duration connectTimeout;
   final Duration receiveTimeout;
   final Duration requestDeadline;
@@ -100,7 +122,10 @@ class MangaPageFetchClient {
   Future<Uint8List> fetch(MangaRemotePageResource resource) {
     if (_closed) {
       return Future<Uint8List>.error(
-        const MangaPageFetchException('The manga page loader is closed.'),
+        const MangaPageFetchException(
+          'The manga page loader is closed.',
+          reasonCode: 'loader_closed',
+        ),
       );
     }
     final key = _cacheKey(resource);
@@ -114,23 +139,17 @@ class MangaPageFetchClient {
       return Future<Uint8List>.error(
         const MangaPageFetchException(
           'Too many manga pages are already loading. Try again shortly.',
+          reasonCode: 'queue_saturated',
         ),
       );
     }
 
     final token = CancelToken();
     _activeTokens.add(token);
-    final future = _fetchWithPermit(resource, token)
-        .timeout(
-          requestDeadline,
-          onTimeout: () {
-            token.cancel('Manga page exceeded its total request deadline.');
-            throw const MangaPageFetchException(
-              'The manga page took too long to load.',
-            );
-          },
-        )
-        .whenComplete(() => _activeTokens.remove(token));
+    final future = _fetchWithDiagnostics(
+      resource,
+      token,
+    ).whenComplete(() => _activeTokens.remove(token));
     final entry = _MangaPageCacheEntry(future);
     _cache[key] = entry;
     unawaited(
@@ -148,6 +167,68 @@ class MangaPageFetchClient {
       ),
     );
     return future;
+  }
+
+  Future<Uint8List> _fetchWithDiagnostics(
+    MangaRemotePageResource resource,
+    CancelToken token,
+  ) async {
+    try {
+      return await _fetchWithPermit(resource, token).timeout(
+        requestDeadline,
+        onTimeout: () {
+          token.cancel('Manga page exceeded its total request deadline.');
+          throw const MangaPageFetchException(
+            'The manga page took too long to load.',
+            reasonCode: 'request_timeout',
+          );
+        },
+      );
+    } catch (error, stackTrace) {
+      final failure = _normalizeFailure(error);
+      _recordFailure(failure);
+      Error.throwWithStackTrace(failure, stackTrace);
+    }
+  }
+
+  MangaPageFetchException _normalizeFailure(Object error) {
+    if (error is MangaPageFetchException) return error;
+    if (error is DioException) {
+      if (_closed || error.type == DioExceptionType.cancel) {
+        return const MangaPageFetchException(
+          'The manga page loader was interrupted.',
+          reasonCode: 'request_cancelled',
+        );
+      }
+      if (error.type == DioExceptionType.connectionTimeout ||
+          error.type == DioExceptionType.receiveTimeout ||
+          error.type == DioExceptionType.sendTimeout) {
+        return const MangaPageFetchException(
+          'The manga page took too long to load.',
+          reasonCode: 'transport_timeout',
+        );
+      }
+      return const MangaPageFetchException(
+        'The manga page host could not be reached. Check the connection and try again.',
+        reasonCode: 'transport_failure',
+      );
+    }
+    return const MangaPageFetchException(
+      'The manga page could not be loaded.',
+      reasonCode: 'unexpected_failure',
+    );
+  }
+
+  void _recordFailure(MangaPageFetchException failure) {
+    final reporter = reportFailure;
+    if (reporter == null ||
+        failure.reasonCode == 'loader_closed' ||
+        failure.reasonCode == 'request_cancelled') {
+      return;
+    }
+    unawaited(
+      Future<void>.sync(() async => reporter(failure)).catchError((_) {}),
+    );
   }
 
   Future<Uint8List> _fetchWithPermit(
@@ -168,7 +249,10 @@ class MangaPageFetchClient {
   Future<void> _acquirePermit(CancelToken token) {
     if (_closed) {
       return Future<void>.error(
-        const MangaPageFetchException('The manga page loader is closed.'),
+        const MangaPageFetchException(
+          'The manga page loader is closed.',
+          reasonCode: 'loader_closed',
+        ),
       );
     }
     if (token.isCancelled) return Future<void>.error(token.cancelError!);
@@ -238,9 +322,10 @@ class MangaPageFetchClient {
       if (lifetimeToken.isCancelled) throw lifetimeToken.cancelError!;
       await _validateTarget(target);
       if (lifetimeToken.isCancelled) throw lifetimeToken.cancelError!;
-      final headers = _origin(target) == originalOrigin
-          ? resource.headers
-          : const <String, String>{};
+      final headers = _pageRequestHeaders(
+        resource.headers,
+        sameOrigin: _origin(target) == originalOrigin,
+      );
       final requestToken = CancelToken();
       unawaited(
         lifetimeToken.whenCancel.then((error) {
@@ -264,12 +349,14 @@ class MangaPageFetchClient {
         if (redirect == maximumRedirects) {
           throw const MangaPageFetchException(
             'The manga page redirected too many times.',
+            reasonCode: 'redirect_limit',
           );
         }
         final location = response.headers.value(HttpHeaders.locationHeader);
         if (location == null || location.trim().isEmpty) {
           throw const MangaPageFetchException(
             'The manga page returned an invalid redirect.',
+            reasonCode: 'invalid_redirect',
           );
         }
         target = resolveMangaPublicHttpsReference(
@@ -281,11 +368,7 @@ class MangaPageFetchClient {
       }
       if (status != HttpStatus.ok) {
         await _discardResponse(response.data, requestToken);
-        throw MangaPageFetchException(
-          status == HttpStatus.unauthorized || status == HttpStatus.forbidden
-              ? 'This manga page rejected the source credential.'
-              : 'This manga page could not be loaded.',
-        );
+        throw _httpPageFailure(status);
       }
       final declared = int.tryParse(
         response.headers.value(HttpHeaders.contentLengthHeader) ?? '',
@@ -294,12 +377,16 @@ class MangaPageFetchClient {
         await _discardResponse(response.data, requestToken);
         throw const MangaPageFetchException(
           'This manga page is larger than the safe limit.',
+          reasonCode: 'size_limit',
         );
       }
       final body = response.data;
       if (body == null) {
         await _discardResponse(null, requestToken);
-        throw const MangaPageFetchException('The manga page was empty.');
+        throw const MangaPageFetchException(
+          'The manga page was empty.',
+          reasonCode: 'empty_response',
+        );
       }
       final builder = BytesBuilder(copy: false);
       var received = 0;
@@ -309,22 +396,37 @@ class MangaPageFetchClient {
           requestToken.cancel('Manga page exceeded its byte limit.');
           throw const MangaPageFetchException(
             'This manga page is larger than the safe limit.',
+            reasonCode: 'size_limit',
           );
         }
         builder.add(chunk);
       }
       final bytes = builder.takeBytes();
       if (bytes.isEmpty) {
-        throw const MangaPageFetchException('The manga page was empty.');
+        throw const MangaPageFetchException(
+          'The manga page was empty.',
+          reasonCode: 'empty_response',
+        );
       }
       try {
         inspectMangaImage(bytes);
       } on MangaImageValidationException catch (error) {
-        throw MangaPageFetchException(error.message);
+        throw MangaPageFetchException(
+          error.message,
+          reasonCode: switch (error.failure) {
+            MangaImageValidationFailure.unsupported => 'unsupported_image',
+            MangaImageValidationFailure.malformed => 'malformed_image',
+            MangaImageValidationFailure.dimensionsExceeded =>
+              'image_dimensions_exceeded',
+          },
+        );
       }
       return bytes;
     }
-    throw const MangaPageFetchException('The manga page could not be loaded.');
+    throw const MangaPageFetchException(
+      'The manga page could not be loaded.',
+      reasonCode: 'redirect_failure',
+    );
   }
 
   void _trimCache({required String protectedKey}) {
@@ -353,7 +455,10 @@ class MangaPageFetchClient {
       final waiter = _permitWaiters.removeFirst();
       if (!waiter.completer.isCompleted) {
         waiter.completer.completeError(
-          const MangaPageFetchException('The manga page loader is closed.'),
+          const MangaPageFetchException(
+            'The manga page loader is closed.',
+            reasonCode: 'loader_closed',
+          ),
         );
       }
     }
@@ -417,5 +522,87 @@ String _cacheKey(MangaRemotePageResource resource) {
 
 String _origin(Uri uri) =>
     '${uri.scheme.toLowerCase()}://${uri.host.toLowerCase()}:${uri.port}';
+
+/// Cross-origin image redirects are common for manga CDNs. Preserve only the
+/// ordinary media-request metadata needed by hotlink-protected hosts while
+/// continuing to strip credentials and arbitrary provider headers.
+Map<String, String> _pageRequestHeaders(
+  Map<String, String> headers, {
+  required bool sameOrigin,
+}) {
+  final safe = <String, String>{};
+  for (final header in headers.entries) {
+    final name = header.key.toLowerCase();
+    if (sameOrigin) {
+      safe[header.key] = header.value;
+      continue;
+    }
+    if (_crossOriginSafePageHeaders.contains(name)) {
+      final value = _safeCrossOriginHeaderValue(name, header.value);
+      if (value != null) safe[header.key] = value;
+    }
+  }
+  final present = safe.keys.map((key) => key.toLowerCase()).toSet();
+  if (!present.contains('accept')) {
+    safe['Accept'] =
+        'image/jpeg,image/png,image/webp,image/gif;q=0.9,*/*;q=0.1';
+  }
+  if (!present.contains('user-agent')) {
+    safe['User-Agent'] = 'TetoTV/2 Android manga';
+  }
+  return Map<String, String>.unmodifiable(safe);
+}
+
+String? _safeCrossOriginHeaderValue(String name, String value) {
+  if (name != 'origin' && name != 'referer') return value;
+  final uri = safePublicHttpsUri(value);
+  if (uri == null) return null;
+  // A provider may need the source site for hotlink checks, but a path or
+  // query can contain a chapter capability. Only forward the validated origin.
+  return name == 'referer' ? '${uri.origin}/' : uri.origin;
+}
+
+MangaPageFetchException _httpPageFailure(int status) => switch (status) {
+  HttpStatus.unauthorized => MangaPageFetchException(
+    'The manga source rejected its access credential.',
+    reasonCode: 'http_unauthorized',
+    statusCode: status,
+  ),
+  HttpStatus.forbidden => MangaPageFetchException(
+    'The manga source refused this page request.',
+    reasonCode: 'http_forbidden',
+    statusCode: status,
+  ),
+  HttpStatus.notFound => MangaPageFetchException(
+    'This manga page is no longer available from the source.',
+    reasonCode: 'http_not_found',
+    statusCode: status,
+  ),
+  HttpStatus.tooManyRequests => MangaPageFetchException(
+    'The manga source is temporarily limiting requests. Try again shortly.',
+    reasonCode: 'http_rate_limited',
+    statusCode: status,
+  ),
+  >= 500 && <= 599 => MangaPageFetchException(
+    'The manga source is temporarily unavailable. Try again shortly.',
+    reasonCode: 'http_server_failure',
+    statusCode: status,
+  ),
+  _ => MangaPageFetchException(
+    'This manga page could not be loaded.',
+    reasonCode: 'http_failure',
+    statusCode: status,
+  ),
+};
+
+const Set<String> _crossOriginSafePageHeaders = <String>{
+  'accept',
+  'accept-language',
+  'content-type',
+  'origin',
+  'range',
+  'referer',
+  'user-agent',
+};
 
 const Set<int> _redirectStatuses = <int>{301, 302, 303, 307, 308};

--- a/lib/features/manga/data/manga_page_fetch_client.dart
+++ b/lib/features/manga/data/manga_page_fetch_client.dart
@@ -26,6 +26,8 @@ final mangaPageFetchClientProvider = Provider<MangaPageFetchClient>((ref) {
       details: <String, Object?>{
         'reason_code': failure.reasonCode,
         'status': ?failure.statusCode,
+        'redirect_count': failure.redirectCount,
+        'cross_origin': failure.crossOriginRedirect,
       },
     ),
   );
@@ -41,11 +43,32 @@ class MangaPageFetchException implements Exception {
     this.message, {
     this.reasonCode = 'unknown',
     this.statusCode,
+    this.redirectCount = 0,
+    this.crossOriginRedirect = false,
   });
 
   final String message;
   final String reasonCode;
   final int? statusCode;
+  final int redirectCount;
+  final bool crossOriginRedirect;
+
+  MangaPageFetchException withRedirectContext({
+    required int redirectCount,
+    required bool crossOriginRedirect,
+  }) {
+    if (this.redirectCount == redirectCount &&
+        this.crossOriginRedirect == crossOriginRedirect) {
+      return this;
+    }
+    return MangaPageFetchException(
+      message,
+      reasonCode: reasonCode,
+      statusCode: statusCode,
+      redirectCount: redirectCount,
+      crossOriginRedirect: crossOriginRedirect,
+    );
+  }
 
   @override
   String toString() => message;
@@ -173,8 +196,9 @@ class MangaPageFetchClient {
     MangaRemotePageResource resource,
     CancelToken token,
   ) async {
+    final context = _MangaPageFetchContext();
     try {
-      return await _fetchWithPermit(resource, token).timeout(
+      return await _fetchWithPermit(resource, token, context).timeout(
         requestDeadline,
         onTimeout: () {
           token.cancel('Manga page exceeded its total request deadline.');
@@ -185,7 +209,10 @@ class MangaPageFetchClient {
         },
       );
     } catch (error, stackTrace) {
-      final failure = _normalizeFailure(error);
+      final failure = _normalizeFailure(error).withRedirectContext(
+        redirectCount: context.redirectCount,
+        crossOriginRedirect: context.crossOriginRedirect,
+      );
       _recordFailure(failure);
       Error.throwWithStackTrace(failure, stackTrace);
     }
@@ -194,7 +221,13 @@ class MangaPageFetchClient {
   MangaPageFetchException _normalizeFailure(Object error) {
     if (error is MangaPageFetchException) return error;
     if (error is DioException) {
-      if (_closed || error.type == DioExceptionType.cancel) {
+      if (_closed) {
+        return const MangaPageFetchException(
+          'The manga page loader is closed.',
+          reasonCode: 'loader_closed',
+        );
+      }
+      if (error.type == DioExceptionType.cancel) {
         return const MangaPageFetchException(
           'The manga page loader was interrupted.',
           reasonCode: 'request_cancelled',
@@ -234,13 +267,14 @@ class MangaPageFetchClient {
   Future<Uint8List> _fetchWithPermit(
     MangaRemotePageResource resource,
     CancelToken lifetimeToken,
+    _MangaPageFetchContext context,
   ) async {
     var acquired = false;
     try {
       await _acquirePermit(lifetimeToken);
       acquired = true;
       if (lifetimeToken.isCancelled) throw lifetimeToken.cancelError!;
-      return await _fetchValidated(resource, lifetimeToken);
+      return await _fetchValidated(resource, lifetimeToken, context);
     } finally {
       if (acquired) _releasePermit();
     }
@@ -312,6 +346,7 @@ class MangaPageFetchClient {
   Future<Uint8List> _fetchValidated(
     MangaRemotePageResource resource,
     CancelToken lifetimeToken,
+    _MangaPageFetchContext context,
   ) async {
     final originalOrigin = _origin(resource.uri);
     var target = requireMangaPublicHttpsUri(
@@ -359,11 +394,13 @@ class MangaPageFetchClient {
             reasonCode: 'invalid_redirect',
           );
         }
-        target = resolveMangaPublicHttpsReference(
+        final redirected = resolveMangaPublicHttpsReference(
           target,
           location,
           field: 'Manga page redirect',
         );
+        context.recordRedirect(from: target, to: redirected);
+        target = redirected;
         continue;
       }
       if (status != HttpStatus.ok) {
@@ -447,10 +484,9 @@ class MangaPageFetchClient {
   void close() {
     if (_closed) return;
     _closed = true;
-    for (final token in _activeTokens.toList(growable: false)) {
-      token.cancel('Manga page loader closed.');
-    }
-    _activeTokens.clear();
+    // Complete permit waiters explicitly before cancelling their lifetime
+    // tokens. Otherwise the cancellation callback can race this loop and turn
+    // a deliberate loader shutdown into a misleading request_cancelled error.
     while (_permitWaiters.isNotEmpty) {
       final waiter = _permitWaiters.removeFirst();
       if (!waiter.completer.isCompleted) {
@@ -462,6 +498,10 @@ class MangaPageFetchClient {
         );
       }
     }
+    for (final token in _activeTokens.toList(growable: false)) {
+      token.cancel('Manga page loader closed.');
+    }
+    _activeTokens.clear();
     _cache.clear();
     _cachedBytes = 0;
     _dio.close(force: true);
@@ -507,6 +547,16 @@ class _MangaPagePermitWaiter {
   final Completer<void> completer = Completer<void>();
 }
 
+class _MangaPageFetchContext {
+  int redirectCount = 0;
+  bool crossOriginRedirect = false;
+
+  void recordRedirect({required Uri from, required Uri to}) {
+    redirectCount++;
+    if (_origin(from) != _origin(to)) crossOriginRedirect = true;
+  }
+}
+
 String _cacheKey(MangaRemotePageResource resource) {
   final values = <int>[...resource.uri.toString().codeUnits];
   final keys = resource.headers.keys.toList()..sort();
@@ -534,7 +584,12 @@ Map<String, String> _pageRequestHeaders(
   for (final header in headers.entries) {
     final name = header.key.toLowerCase();
     if (sameOrigin) {
-      safe[header.key] = header.value;
+      final value = switch (name) {
+        'origin' => canonicalMangaPageOriginHeader(header.value),
+        'referer' => canonicalMangaPageRefererHeader(header.value),
+        _ => header.value,
+      };
+      if (value != null) safe[header.key] = value;
       continue;
     }
     if (_crossOriginSafePageHeaders.contains(name)) {
@@ -554,12 +609,11 @@ Map<String, String> _pageRequestHeaders(
 }
 
 String? _safeCrossOriginHeaderValue(String name, String value) {
-  if (name != 'origin' && name != 'referer') return value;
-  final uri = safePublicHttpsUri(value);
-  if (uri == null) return null;
-  // A provider may need the source site for hotlink checks, but a path or
-  // query can contain a chapter capability. Only forward the validated origin.
-  return name == 'referer' ? '${uri.origin}/' : uri.origin;
+  return switch (name) {
+    'origin' => canonicalMangaPageOriginHeader(value),
+    'referer' => canonicalMangaPageRefererHeader(value, originOnly: true),
+    _ => value,
+  };
 }
 
 MangaPageFetchException _httpPageFailure(int status) => switch (status) {

--- a/lib/features/manga/data/manga_uri_policy.dart
+++ b/lib/features/manga/data/manga_uri_policy.dart
@@ -56,6 +56,46 @@ Uri resolveMangaPublicHttpsReference(
   return requireMangaPublicHttpsUri(resolved.toString(), field: field);
 }
 
+/// Returns a canonical, origin-only value suitable for an HTTP `Origin`
+/// header, or `null` when [value] is not a public HTTPS URL.
+///
+/// Origin headers never carry paths, queries, fragments, or user info. A
+/// provider occasionally supplies a full page URL here; canonicalizing it to
+/// its origin is safe and prevents path/query capabilities from being sent.
+/// Keeping this rule in the URI policy prevents the reader and downloader from
+/// gradually developing different handling for extension-supplied metadata.
+String? canonicalMangaPageOriginHeader(Object? value) {
+  final uri = _safeMangaPageHeaderUri(value);
+  return uri?.origin;
+}
+
+/// Returns a canonical value suitable for an HTTP `Referer` header.
+///
+/// A same-origin request may retain the public HTTPS path/query because some
+/// manga hosts use it for hotlink checks. Across an origin boundary only the
+/// origin is retained, matching modern browser referrer behavior and ensuring
+/// chapter capabilities in a path or query never reach another host.
+String? canonicalMangaPageRefererHeader(
+  Object? value, {
+  bool originOnly = false,
+}) {
+  final uri = _safeMangaPageHeaderUri(value);
+  if (uri == null) return null;
+  return originOnly ? '${uri.origin}/' : uri.toString();
+}
+
+Uri? _safeMangaPageHeaderUri(Object? value) {
+  if (value is! String) return null;
+  final normalized = value.trim();
+  if (normalized.isEmpty ||
+      normalized.codeUnits.any((unit) => unit < 0x20 || unit == 0x7f)) {
+    return null;
+  }
+  final parsed = Uri.tryParse(normalized);
+  if (parsed == null || parsed.hasFragment) return null;
+  return safePublicHttpsUri(normalized);
+}
+
 bool _isCredentialQueryKey(String normalized) {
   if (_credentialQueryKeys.contains(normalized)) return true;
   return normalized.endsWith('token') ||

--- a/lib/features/manga/presentation/manga_reader_screen.dart
+++ b/lib/features/manga/presentation/manga_reader_screen.dart
@@ -821,8 +821,11 @@ class _MangaPageView extends ConsumerWidget {
               future: ref.read(mangaPageFetchClientProvider).fetch(resource),
               builder: (context, snapshot) {
                 if (snapshot.hasError) {
-                  return const _PageFailure(
-                    message: 'This page could not be loaded securely.',
+                  final error = snapshot.error;
+                  return _PageFailure(
+                    message: error is MangaPageFetchException
+                        ? error.message
+                        : 'This manga page could not be loaded. Try again.',
                   );
                 }
                 final bytes = snapshot.data;

--- a/lib/features/player/presentation/player_paused_metadata_overlay.dart
+++ b/lib/features/player/presentation/player_paused_metadata_overlay.dart
@@ -1,0 +1,201 @@
+import 'dart:async';
+import 'dart:math' as math;
+
+import 'package:anime_tv/core/theme/app_theme.dart';
+import 'package:flutter/material.dart';
+
+const playerPausedMetadataScrollDelay = Duration(seconds: 5);
+const _playerPausedMetadataScrollPixelsPerSecond = 13.0;
+
+/// Episode context shown above the transport controls while playback is
+/// paused. The synopsis is clipped to three lines and scrolls only when its
+/// full text does not fit in that viewport.
+class PlayerPausedMetadataOverlay extends StatefulWidget {
+  const PlayerPausedMetadataOverlay({
+    required this.visible,
+    required this.episodeTitle,
+    required this.description,
+    super.key,
+  });
+
+  final bool visible;
+  final String episodeTitle;
+  final String description;
+
+  @override
+  State<PlayerPausedMetadataOverlay> createState() =>
+      _PlayerPausedMetadataOverlayState();
+}
+
+class _PlayerPausedMetadataOverlayState
+    extends State<PlayerPausedMetadataOverlay> {
+  final ScrollController _descriptionController = ScrollController();
+  Timer? _descriptionScrollTimer;
+
+  bool get _canShow =>
+      widget.visible &&
+      (widget.episodeTitle.isNotEmpty || widget.description.isNotEmpty);
+
+  @override
+  void initState() {
+    super.initState();
+    if (_canShow) _scheduleDescriptionScroll();
+  }
+
+  @override
+  void didUpdateWidget(covariant PlayerPausedMetadataOverlay oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    final contentChanged =
+        oldWidget.episodeTitle != widget.episodeTitle ||
+        oldWidget.description != widget.description;
+    final visibilityChanged = oldWidget.visible != widget.visible;
+    if (!contentChanged && !visibilityChanged) return;
+    _cancelDescriptionScroll();
+    _resetDescriptionScroll();
+    if (_canShow) _scheduleDescriptionScroll();
+  }
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    if (!_canShow) return;
+    _cancelDescriptionScroll();
+    _resetDescriptionScroll();
+    _scheduleDescriptionScroll();
+  }
+
+  @override
+  void dispose() {
+    _cancelDescriptionScroll();
+    _descriptionController.dispose();
+    super.dispose();
+  }
+
+  void _scheduleDescriptionScroll() {
+    if (widget.description.isEmpty) return;
+    _descriptionScrollTimer = Timer(playerPausedMetadataScrollDelay, () {
+      if (!mounted || !_canShow || !_descriptionController.hasClients) return;
+      if (MediaQuery.disableAnimationsOf(context)) return;
+      final extent = _descriptionController.position.maxScrollExtent;
+      if (extent <= 0) return;
+      final duration = Duration(
+        milliseconds: math.max(
+          1500,
+          (extent / _playerPausedMetadataScrollPixelsPerSecond * 1000).round(),
+        ),
+      );
+      unawaited(
+        _descriptionController
+            .animateTo(extent, duration: duration, curve: Curves.linear)
+            .catchError((Object _) {
+              // Hiding the HUD or leaving playback intentionally cancels it.
+            }),
+      );
+    });
+  }
+
+  void _cancelDescriptionScroll() {
+    _descriptionScrollTimer?.cancel();
+    _descriptionScrollTimer = null;
+  }
+
+  void _resetDescriptionScroll() {
+    if (!_descriptionController.hasClients) return;
+    _descriptionController.jumpTo(0);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final palette = context.appPalette;
+    final viewport = MediaQuery.sizeOf(context);
+    final compact = viewport.width < 720;
+    final titleStyle = Theme.of(context).textTheme.headlineSmall?.copyWith(
+      color: palette.primaryText,
+      fontSize: compact ? 22 : 30,
+      height: 1.08,
+      fontWeight: FontWeight.w800,
+      shadows: const [
+        Shadow(color: Colors.black, blurRadius: 12),
+        Shadow(color: Colors.black, blurRadius: 4, offset: Offset(1, 1)),
+      ],
+    );
+    final descriptionStyle = Theme.of(context).textTheme.bodyLarge?.copyWith(
+      color: palette.primaryText.withValues(alpha: .9),
+      fontSize: compact ? 14 : 18,
+      height: 1.3,
+      fontWeight: FontWeight.w600,
+      shadows: const [
+        Shadow(color: Colors.black, blurRadius: 10),
+        Shadow(color: Colors.black, blurRadius: 3, offset: Offset(1, 1)),
+      ],
+    );
+    final descriptionFontSize = descriptionStyle?.fontSize ?? 18;
+    final descriptionLineHeight = descriptionStyle?.height ?? 1.3;
+    final descriptionViewportHeight =
+        MediaQuery.textScalerOf(context).scale(descriptionFontSize) *
+        descriptionLineHeight *
+        3;
+
+    return ExcludeSemantics(
+      excluding: !_canShow,
+      child: IgnorePointer(
+        child: AnimatedSlide(
+          offset: _canShow ? Offset.zero : const Offset(0, -.08),
+          duration: const Duration(milliseconds: 180),
+          curve: Curves.easeOutCubic,
+          child: AnimatedOpacity(
+            opacity: _canShow ? 1 : 0,
+            duration: const Duration(milliseconds: 180),
+            child: Semantics(
+              container: true,
+              label: [
+                if (widget.episodeTitle.isNotEmpty) widget.episodeTitle,
+                if (widget.description.isNotEmpty) widget.description,
+              ].join(', '),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  if (widget.episodeTitle.isNotEmpty)
+                    Text(
+                      widget.episodeTitle,
+                      key: const ValueKey('player-paused-episode-title'),
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                      style: titleStyle,
+                    ),
+                  if (widget.episodeTitle.isNotEmpty &&
+                      widget.description.isNotEmpty)
+                    SizedBox(height: compact ? 5 : 8),
+                  if (widget.description.isNotEmpty)
+                    SizedBox(
+                      height: descriptionViewportHeight,
+                      child: ClipRect(
+                        child: ScrollConfiguration(
+                          behavior: ScrollConfiguration.of(
+                            context,
+                          ).copyWith(scrollbars: false, overscroll: false),
+                          child: SingleChildScrollView(
+                            key: const ValueKey(
+                              'player-paused-description-scroll',
+                            ),
+                            controller: _descriptionController,
+                            physics: const NeverScrollableScrollPhysics(),
+                            child: Text(
+                              widget.description,
+                              key: const ValueKey('player-paused-description'),
+                              style: descriptionStyle,
+                            ),
+                          ),
+                        ),
+                      ),
+                    ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/player/presentation/tv_player_screen.dart
+++ b/lib/features/player/presentation/tv_player_screen.dart
@@ -18,6 +18,7 @@ import 'package:anime_tv/features/player/application/playback_audio_diagnostics.
 import 'package:anime_tv/features/catalog/application/filler_episode_providers.dart';
 import 'package:anime_tv/features/catalog/domain/filler_episode_lookup.dart';
 import 'package:anime_tv/features/catalog/domain/anime_summary.dart';
+import 'package:anime_tv/features/catalog/domain/catalog_episode_metadata.dart';
 import 'package:anime_tv/features/local_media/domain/library_episode_source.dart';
 import 'package:anime_tv/features/player/application/filler_episode_navigation.dart';
 import 'package:anime_tv/features/player/application/next_episode_prewarm_policy.dart';
@@ -28,6 +29,7 @@ import 'package:anime_tv/features/player/presentation/filler_skip_notification.d
 import 'package:anime_tv/features/player/presentation/player_control_overlay.dart';
 import 'package:anime_tv/features/player/presentation/player_failover_coordinator.dart';
 import 'package:anime_tv/features/player/presentation/player_failover_notification.dart';
+import 'package:anime_tv/features/player/presentation/player_paused_metadata_overlay.dart';
 import 'package:anime_tv/features/player/presentation/player_presentation_palette.dart';
 import 'package:anime_tv/features/player/presentation/player_stream_source_picker.dart';
 import 'package:anime_tv/features/player/presentation/teto_player_chrome.dart';
@@ -526,6 +528,16 @@ String _formatPlayerDuration(Duration value) {
   return hours > 0 ? '$hours:$minutes:$seconds' : '${value.inMinutes}:$seconds';
 }
 
+String? _normalizedPlayerHudText(String? value, {required int maxLength}) {
+  final normalized = value
+      ?.replaceAll(RegExp(r'[\u0000-\u001f\u007f]'), ' ')
+      .replaceAll(RegExp(r'\s+'), ' ')
+      .trim();
+  if (normalized == null || normalized.isEmpty) return null;
+  if (normalized.length <= maxLength) return normalized;
+  return '${normalized.substring(0, maxLength).trimRight()}…';
+}
+
 class TvPlayerScreen extends ConsumerStatefulWidget {
   const TvPlayerScreen({
     required this.source,
@@ -892,6 +904,10 @@ class _MpvTvPlayerScreenState extends ConsumerState<MpvTvPlayerScreen> {
   DateTime _lastCheckpointSave = DateTime.fromMillisecondsSinceEpoch(0);
   DateTime _lastMediaSessionUpdate = DateTime.fromMillisecondsSinceEpoch(0);
   StreamSubscription<bool>? _playingSubscription;
+  bool _playerHasStartedPlayback = false;
+  bool _lastPlayerPlaying = false;
+  CatalogEpisodeMetadata? _pausedHudEpisodeMetadata;
+  int _pausedHudMetadataGeneration = 0;
   StreamSubscription<MediaAction>? _mediaActionSubscription;
   SeriesPlaybackPreferences _seriesPreferences =
       const SeriesPlaybackPreferences();
@@ -1006,6 +1022,52 @@ class _MpvTvPlayerScreenState extends ConsumerState<MpvTvPlayerScreen> {
       : widget.launch.episode.malMediaId;
   int? get _catalogEpisodeNumber =>
       _animeFeaturesEnabled ? widget.episode : _libraryCatalogIdentity?.episode;
+
+  String get _pausedHudEpisodeTitle {
+    final metadataTitle = _normalizedPlayerHudText(
+      _pausedHudEpisodeMetadata?.title,
+      maxLength: 180,
+    );
+    if (metadataTitle != null) return metadataTitle;
+    if (!_animeFeaturesEnabled) {
+      final libraryTitle = _normalizedPlayerHudText(
+        widget.libraryPlayback?.request.title,
+        maxLength: 180,
+      );
+      if (libraryTitle != null) return libraryTitle;
+    }
+    final episode = _catalogEpisodeNumber ?? widget.launch.episode.episode;
+    return episode > 0 ? 'Episode $episode' : 'Episode';
+  }
+
+  String get _pausedHudDescription =>
+      _normalizedPlayerHudText(
+        _pausedHudEpisodeMetadata?.synopsis,
+        maxLength: 1600,
+      ) ??
+      '';
+
+  Future<void> _loadPausedHudMetadata() async {
+    final mediaId = _catalogAnilistMediaId;
+    final episode = _catalogEpisodeNumber;
+    if (mediaId == null || mediaId <= 0 || episode == null || episode <= 0) {
+      return;
+    }
+    final generation = ++_pausedHudMetadataGeneration;
+    final catalog = ref.read(catalogClientProvider);
+    // Missing optional metadata is deliberately fail-open and can never delay
+    // media playback.
+    CatalogEpisodeMetadata? episodeMetadata;
+    try {
+      episodeMetadata = (await catalog.episodeMetadata(mediaId))[episode];
+    } catch (_) {
+      // Playback and its controls remain independent of metadata uptime.
+    }
+    if (!mounted || generation != _pausedHudMetadataGeneration) return;
+    setState(() {
+      _pausedHudEpisodeMetadata = episodeMetadata;
+    });
+  }
 
   PlaybackDiagnosticSourceKind get _diagnosticSourceKind {
     final libraryProvider = widget.libraryPlayback?.request.sourceProviderId
@@ -1365,6 +1427,7 @@ class _MpvTvPlayerScreenState extends ConsumerState<MpvTvPlayerScreen> {
     _currentRelease = widget.launch.selectedRelease;
     _currentStream = widget.launch.stream;
     _requestedAudio = widget.launch.requestedAudio;
+    unawaited(_loadPausedHudMetadata());
     _playbackDiagnostics = PlaybackDiagnosticSessionRecorder(
       database: _database,
     );
@@ -1540,7 +1603,20 @@ class _MpvTvPlayerScreenState extends ConsumerState<MpvTvPlayerScreen> {
       unawaited(_matchContentFrameRate());
       unawaited(_inspectDecodedVideo(params));
     });
-    _playingSubscription = _player.stream.playing.listen((_) {
+    _lastPlayerPlaying = _player.state.playing;
+    _playerHasStartedPlayback = _lastPlayerPlaying;
+    _playingSubscription = _player.stream.playing.listen((playing) {
+      final wasPlaying = _lastPlayerPlaying;
+      _lastPlayerPlaying = playing;
+      if (playing) _playerHasStartedPlayback = true;
+      if (mounted && wasPlaying && !playing && !_engineHandoffInProgress) {
+        // A paused player keeps its HUD available so the episode synopsis can
+        // be read. It can still be dismissed immediately with Back or a tap.
+        _controlsTimer?.cancel();
+        if (!_controlsVisible) setState(() => _controlsVisible = true);
+      } else if (mounted && !wasPlaying && playing && _controlsVisible) {
+        _scheduleControlsHide();
+      }
       _reportLibraryPlayback(force: true);
       _publishWatchPartyPlayback();
       unawaited(_updateMediaSession(force: true));
@@ -6367,7 +6443,10 @@ class _MpvTvPlayerScreenState extends ConsumerState<MpvTvPlayerScreen> {
 
   void _scheduleControlsHide() {
     _controlsTimer?.cancel();
-    if (_hudAutoHideSuspended) return;
+    if (_hudAutoHideSuspended ||
+        (_playerHasStartedPlayback && !_player.state.playing)) {
+      return;
+    }
     _controlsTimer = Timer(playerControlsIdleTimeout, () {
       if (mounted && !_hudAutoHideSuspended) _hideControls();
     });
@@ -6632,26 +6711,23 @@ class _MpvTvPlayerScreenState extends ConsumerState<MpvTvPlayerScreen> {
                   ),
                 if (!_engineHandoffInProgress)
                   Positioned(
-                    left: 34,
-                    right: 34,
-                    top: 28,
+                    left: 34 + MediaQuery.paddingOf(context).left,
+                    right: MediaQuery.sizeOf(context).width / 2,
+                    top: 28 + MediaQuery.paddingOf(context).top,
                     child: StreamBuilder<bool>(
                       stream: _player.stream.playing,
                       initialData: _player.state.playing,
                       builder: (context, snapshot) {
-                        if (snapshot.data == true) {
-                          return const SizedBox.shrink();
-                        }
-                        return Text(
-                          widget.title,
-                          maxLines: 1,
-                          overflow: TextOverflow.ellipsis,
-                          style: Theme.of(context).textTheme.headlineSmall
-                              ?.copyWith(
-                                shadows: const [
-                                  Shadow(color: Colors.black, blurRadius: 12),
-                                ],
-                              ),
+                        final paused = snapshot.data == false;
+                        return PlayerPausedMetadataOverlay(
+                          visible:
+                              _controlsVisible &&
+                              _playerHasStartedPlayback &&
+                              paused &&
+                              !_completionHandled &&
+                              _playbackError == null,
+                          episodeTitle: _pausedHudEpisodeTitle,
+                          description: _pausedHudDescription,
                         );
                       },
                     ),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: 'none'
 # Public and Beta artifacts built from the same source use one monotonically
 # increasing Android versionCode. The project default carries the Beta display
 # version; the Public universal APK overrides the build name to the 1.x line.
-version: 2.0.69+410046
+version: 2.0.70+410047
 
 environment:
   sdk: ^3.12.2

--- a/test/manga_page_fetch_client_test.dart
+++ b/test/manga_page_fetch_client_test.dart
@@ -42,6 +42,12 @@ void main() {
           uri: Uri.parse('https://pages.example/start'),
           headers: const <String, String>{
             HttpHeaders.authorizationHeader: 'Bearer protected',
+            HttpHeaders.cookieHeader: 'session=private',
+            'X-Api-Key': 'private-key',
+            HttpHeaders.refererHeader:
+                'https://reader.example/chapter/1?capability=private',
+            'Origin': 'https://reader.example/private?capability=private',
+            HttpHeaders.userAgentHeader: 'Manga extension agent',
           },
         ),
       );
@@ -59,12 +65,222 @@ void main() {
         adapter.requests.last.headers[HttpHeaders.authorizationHeader],
         isNull,
       );
+      expect(adapter.requests.last.headers[HttpHeaders.cookieHeader], isNull);
+      expect(adapter.requests.last.headers['X-Api-Key'], isNull);
+      expect(
+        adapter.requests.last.headers[HttpHeaders.refererHeader],
+        'https://reader.example/',
+      );
+      expect(adapter.requests.last.headers['Origin'], 'https://reader.example');
+      expect(
+        adapter.requests.last.headers[HttpHeaders.userAgentHeader],
+        'Manga extension agent',
+      );
+      expect(
+        adapter.requests.last.headers[HttpHeaders.acceptHeader],
+        isNotNull,
+      );
       expect(
         adapter.requests.every((request) => !request.followRedirects),
         isTrue,
       );
     },
   );
+
+  test(
+    'adds bounded image request defaults without replacing provider values',
+    () async {
+      final adapter = _PageRoutingAdapter(<String, _PageResponseFactory>{
+        'https://pages.example/page.png': (_) =>
+            ResponseBody.fromBytes(_pngBytes, HttpStatus.ok),
+        'https://pages.example/custom.png': (_) =>
+            ResponseBody.fromBytes(_pngBytes, HttpStatus.ok),
+      });
+      final client = _client(adapter);
+      addTearDown(client.close);
+
+      await client.fetch(
+        MangaRemotePageResource(
+          uri: Uri.parse('https://pages.example/page.png'),
+        ),
+      );
+      await client.fetch(
+        MangaRemotePageResource(
+          uri: Uri.parse('https://pages.example/custom.png'),
+          headers: const <String, String>{
+            HttpHeaders.acceptHeader: 'image/png',
+            HttpHeaders.userAgentHeader: 'Provider agent',
+          },
+        ),
+      );
+
+      expect(
+        adapter.requests.first.headers[HttpHeaders.acceptHeader],
+        contains('image/webp'),
+      );
+      expect(
+        adapter.requests.first.headers[HttpHeaders.userAgentHeader],
+        'TetoTV/2 Android manga',
+      );
+      expect(
+        adapter.requests.last.headers[HttpHeaders.acceptHeader],
+        'image/png',
+      );
+      expect(
+        adapter.requests.last.headers[HttpHeaders.userAgentHeader],
+        'Provider agent',
+      );
+    },
+  );
+
+  test('same-origin redirects retain provider credentials', () async {
+    final adapter = _PageRoutingAdapter(<String, _PageResponseFactory>{
+      'https://pages.example/start': (_) => ResponseBody.fromBytes(
+        const <int>[],
+        HttpStatus.found,
+        headers: <String, List<String>>{
+          HttpHeaders.locationHeader: <String>['/page.png'],
+        },
+      ),
+      'https://pages.example/page.png': (_) =>
+          ResponseBody.fromBytes(_pngBytes, HttpStatus.ok),
+    });
+    final client = _client(adapter);
+    addTearDown(client.close);
+
+    await client.fetch(
+      MangaRemotePageResource(
+        uri: Uri.parse('https://pages.example/start'),
+        headers: const <String, String>{
+          HttpHeaders.authorizationHeader: 'Bearer same-origin',
+          'X-Provider-Key': 'same-origin-key',
+        },
+      ),
+    );
+
+    expect(
+      adapter.requests.last.headers[HttpHeaders.authorizationHeader],
+      'Bearer same-origin',
+    );
+    expect(adapter.requests.last.headers['X-Provider-Key'], 'same-origin-key');
+  });
+
+  test('reports a bounded reason without request details', () async {
+    final reported = Completer<MangaPageFetchException>();
+    final adapter = _PageRoutingAdapter(<String, _PageResponseFactory>{
+      'https://pages.example/forbidden': (_) =>
+          ResponseBody.fromBytes(const <int>[], HttpStatus.forbidden),
+    });
+    final client = _client(
+      adapter,
+      reportFailure: (failure) {
+        if (!reported.isCompleted) reported.complete(failure);
+      },
+    );
+    addTearDown(client.close);
+
+    await expectLater(
+      client.fetch(
+        MangaRemotePageResource(
+          uri: Uri.parse('https://pages.example/forbidden'),
+          headers: const <String, String>{
+            HttpHeaders.authorizationHeader: 'Bearer private',
+          },
+        ),
+      ),
+      throwsA(isA<MangaPageFetchException>()),
+    );
+    final failure = await reported.future;
+
+    expect(failure.reasonCode, 'http_forbidden');
+    expect(failure.statusCode, HttpStatus.forbidden);
+    expect(failure.toString(), isNot(contains('pages.example')));
+    expect(failure.toString(), isNot(contains('private')));
+  });
+
+  test('classifies common HTTP failures accurately', () async {
+    final cases = <(int, String, String)>[
+      (HttpStatus.unauthorized, 'http_unauthorized', 'access credential'),
+      (HttpStatus.forbidden, 'http_forbidden', 'refused'),
+      (HttpStatus.notFound, 'http_not_found', 'no longer available'),
+      (HttpStatus.tooManyRequests, 'http_rate_limited', 'limiting requests'),
+      (HttpStatus.serviceUnavailable, 'http_server_failure', 'unavailable'),
+    ];
+    final adapter = _PageRoutingAdapter(<String, _PageResponseFactory>{
+      for (final (status, _, _) in cases)
+        'https://pages.example/$status': (_) =>
+            ResponseBody.fromBytes(const <int>[], status),
+    });
+    final client = _client(adapter);
+    addTearDown(client.close);
+
+    for (final (status, reasonCode, message) in cases) {
+      await expectLater(
+        client.fetch(
+          MangaRemotePageResource(
+            uri: Uri.parse('https://pages.example/$status'),
+          ),
+        ),
+        throwsA(
+          isA<MangaPageFetchException>()
+              .having((failure) => failure.reasonCode, 'reason', reasonCode)
+              .having(
+                (failure) => failure.message,
+                'message',
+                contains(message),
+              )
+              .having((failure) => failure.statusCode, 'status', status),
+        ),
+      );
+    }
+  });
+
+  test('drops unsafe cross-origin Referer and Origin values', () async {
+    final adapter = _PageRoutingAdapter(<String, _PageResponseFactory>{
+      'https://pages.example/start': (_) => ResponseBody.fromBytes(
+        const <int>[],
+        HttpStatus.found,
+        headers: <String, List<String>>{
+          HttpHeaders.locationHeader: <String>['https://cdn.example/page.png'],
+        },
+      ),
+      'https://cdn.example/page.png': (_) =>
+          ResponseBody.fromBytes(_pngBytes, HttpStatus.ok),
+    });
+    final client = _client(adapter);
+    addTearDown(client.close);
+
+    await client.fetch(
+      MangaRemotePageResource(
+        uri: Uri.parse('https://pages.example/start'),
+        headers: const <String, String>{
+          HttpHeaders.refererHeader: 'https://127.0.0.1/private?token=secret',
+          'Origin': 'http://reader.example',
+        },
+      ),
+    );
+
+    expect(adapter.requests.last.headers[HttpHeaders.refererHeader], isNull);
+    expect(adapter.requests.last.headers['Origin'], isNull);
+  });
+
+  test('does not report an expected cancellation', () async {
+    final failures = <MangaPageFetchException>[];
+    final adapter = _CancellationPageAdapter();
+    final client = _client(adapter, reportFailure: failures.add);
+
+    final future = client.fetch(
+      MangaRemotePageResource(
+        uri: Uri.parse('https://pages.example/cancelled.png'),
+      ),
+    );
+    await adapter.started.future;
+    client.close();
+
+    await expectLater(future, throwsA(isA<MangaPageFetchException>()));
+    await Future<void>.delayed(Duration.zero);
+    expect(failures, isEmpty);
+  });
 
   test(
     'bounds streamed bytes and rejects a fake image without retrying',
@@ -318,6 +534,7 @@ MangaPageFetchClient _client(
   int maximumConcurrentRequests = 8,
   int maximumCacheEntries = 64,
   Duration requestDeadline = const Duration(seconds: 45),
+  MangaPageFailureReporter? reportFailure,
 }) {
   final dio = Dio()..httpClientAdapter = adapter;
   return MangaPageFetchClient(
@@ -328,6 +545,7 @@ MangaPageFetchClient _client(
     maximumConcurrentRequests: maximumConcurrentRequests,
     maximumCacheEntries: maximumCacheEntries,
     requestDeadline: requestDeadline,
+    reportFailure: reportFailure,
   );
 }
 
@@ -387,6 +605,28 @@ class _GatePageAdapter implements HttpClientAdapter {
 
   @override
   void close({bool force = false}) => release();
+}
+
+class _CancellationPageAdapter implements HttpClientAdapter {
+  final Completer<void> started = Completer<void>();
+
+  @override
+  Future<ResponseBody> fetch(
+    RequestOptions options,
+    Stream<Uint8List>? requestStream,
+    Future<void>? cancelFuture,
+  ) async {
+    if (!started.isCompleted) started.complete();
+    await cancelFuture;
+    throw DioException(
+      requestOptions: options,
+      type: DioExceptionType.cancel,
+      message: 'cancelled',
+    );
+  }
+
+  @override
+  void close({bool force = false}) {}
 }
 
 class _DripPageAdapter implements HttpClientAdapter {

--- a/test/manga_page_fetch_client_test.dart
+++ b/test/manga_page_fetch_client_test.dart
@@ -4,11 +4,40 @@ import 'dart:typed_data';
 
 import 'package:anime_tv/features/manga/data/manga_image_safety.dart';
 import 'package:anime_tv/features/manga/data/manga_page_fetch_client.dart';
+import 'package:anime_tv/features/manga/data/manga_uri_policy.dart';
 import 'package:anime_tv/features/manga/domain/manga_reader_models.dart';
 import 'package:dio/dio.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
+  test('canonicalizes safe manga Origin and Referer metadata', () {
+    expect(
+      canonicalMangaPageOriginHeader(' https://Reader.Example:443/ '),
+      'https://reader.example',
+    );
+    expect(
+      canonicalMangaPageOriginHeader('https://reader.example/path?secret=1'),
+      'https://reader.example',
+    );
+    expect(
+      canonicalMangaPageRefererHeader(
+        'https://Reader.Example:443/chapter/1?capability=private',
+      ),
+      'https://reader.example/chapter/1?capability=private',
+    );
+    expect(
+      canonicalMangaPageRefererHeader(
+        'https://reader.example/chapter/1?capability=private',
+        originOnly: true,
+      ),
+      'https://reader.example/',
+    );
+    expect(
+      canonicalMangaPageRefererHeader('https://reader.example/#private'),
+      isNull,
+    );
+  });
+
   test(
     'validates every redirect and strips credentials across origins',
     () async {
@@ -198,6 +227,43 @@ void main() {
     expect(failure.toString(), isNot(contains('private')));
   });
 
+  test('reports privacy-safe redirect context without request URLs', () async {
+    final reported = Completer<MangaPageFetchException>();
+    final adapter = _PageRoutingAdapter(<String, _PageResponseFactory>{
+      'https://pages.example/start': (_) => ResponseBody.fromBytes(
+        const <int>[],
+        HttpStatus.found,
+        headers: <String, List<String>>{
+          HttpHeaders.locationHeader: <String>[
+            'https://cdn.example/private/page.png?capability=secret',
+          ],
+        },
+      ),
+      'https://cdn.example/private/page.png?capability=secret': (_) =>
+          ResponseBody.fromBytes(const <int>[], HttpStatus.forbidden),
+    });
+    final client = _client(
+      adapter,
+      reportFailure: (failure) {
+        if (!reported.isCompleted) reported.complete(failure);
+      },
+    );
+    addTearDown(client.close);
+
+    await expectLater(
+      client.fetch(
+        MangaRemotePageResource(uri: Uri.parse('https://pages.example/start')),
+      ),
+      throwsA(isA<MangaPageFetchException>()),
+    );
+    final failure = await reported.future;
+
+    expect(failure.redirectCount, 1);
+    expect(failure.crossOriginRedirect, isTrue);
+    expect(failure.toString(), isNot(contains('cdn.example')));
+    expect(failure.toString(), isNot(contains('secret')));
+  });
+
   test('classifies common HTTP failures accurately', () async {
     final cases = <(int, String, String)>[
       (HttpStatus.unauthorized, 'http_unauthorized', 'access credential'),
@@ -278,6 +344,64 @@ void main() {
     client.close();
 
     await expectLater(future, throwsA(isA<MangaPageFetchException>()));
+    await Future<void>.delayed(Duration.zero);
+    expect(failures, isEmpty);
+  });
+
+  test('does not report a transport-level request cancellation', () async {
+    final failures = <MangaPageFetchException>[];
+    final adapter = _ImmediateCancellationPageAdapter();
+    final client = _client(adapter, reportFailure: failures.add);
+    addTearDown(client.close);
+
+    await expectLater(
+      client.fetch(
+        MangaRemotePageResource(
+          uri: Uri.parse('https://pages.example/cancelled.png'),
+        ),
+      ),
+      throwsA(
+        isA<MangaPageFetchException>().having(
+          (failure) => failure.reasonCode,
+          'reason',
+          'request_cancelled',
+        ),
+      ),
+    );
+    await Future<void>.delayed(Duration.zero);
+    expect(failures, isEmpty);
+  });
+
+  test('closing marks active and queued page loads as loader_closed', () async {
+    final failures = <MangaPageFetchException>[];
+    final adapter = _CancellationPageAdapter();
+    final client = _client(
+      adapter,
+      maximumConcurrentRequests: 1,
+      maximumCacheEntries: 2,
+      reportFailure: failures.add,
+    );
+
+    final active = client.fetch(
+      MangaRemotePageResource(
+        uri: Uri.parse('https://pages.example/active.png'),
+      ),
+    );
+    await adapter.started.future;
+    final queued = client.fetch(
+      MangaRemotePageResource(
+        uri: Uri.parse('https://pages.example/queued.png'),
+      ),
+    );
+    client.close();
+
+    final loaderClosed = isA<MangaPageFetchException>().having(
+      (failure) => failure.reasonCode,
+      'reason',
+      'loader_closed',
+    );
+    await expectLater(active, throwsA(loaderClosed));
+    await expectLater(queued, throwsA(loaderClosed));
     await Future<void>.delayed(Duration.zero);
     expect(failures, isEmpty);
   });
@@ -624,6 +748,24 @@ class _CancellationPageAdapter implements HttpClientAdapter {
       message: 'cancelled',
     );
   }
+
+  @override
+  void close({bool force = false}) {}
+}
+
+class _ImmediateCancellationPageAdapter implements HttpClientAdapter {
+  @override
+  Future<ResponseBody> fetch(
+    RequestOptions options,
+    Stream<Uint8List>? requestStream,
+    Future<void>? cancelFuture,
+  ) => Future<ResponseBody>.error(
+    DioException(
+      requestOptions: options,
+      type: DioExceptionType.cancel,
+      message: 'cancelled',
+    ),
+  );
 
   @override
   void close({bool force = false}) {}

--- a/test/manga_reader_screen_test.dart
+++ b/test/manga_reader_screen_test.dart
@@ -75,6 +75,42 @@ void main() {
     expect(provider.width, inInclusiveRange(1, 4096));
   });
 
+  testWidgets('shows the safe manga page failure reason', (tester) async {
+    final roots = _temporaryRoots();
+    final request = MangaReaderRequest(
+      sourceId: 'remote-source',
+      publicationId: 'remote-publication',
+      chapterId: 'chapter-1',
+      seriesTitle: 'Remote series',
+      chapterTitle: 'Chapter 1',
+      pages: [
+        MangaReaderPage(
+          id: 'remote-0',
+          index: 0,
+          resource: MangaRemotePageResource(
+            uri: Uri.parse('https://reader.example.test/page-1.png'),
+          ),
+        ),
+      ],
+    );
+
+    await tester.pumpWidget(
+      _readerHarness(
+        request: request,
+        roots: roots,
+        pageFetchClient: _FailingMangaPageFetchClient(),
+      ),
+    );
+    await tester.pump();
+    await tester.pump();
+
+    expect(
+      find.text('The manga source refused this page request.'),
+      findsOneWidget,
+    );
+    expect(find.text('This page could not be loaded securely.'), findsNothing);
+  });
+
   testWidgets('resolves a trusted local page through app-owned roots', (
     tester,
   ) async {
@@ -897,6 +933,18 @@ class _MemoryMangaPageFetchClient extends MangaPageFetchClient {
     lastResource = resource;
     return _transparentPng;
   }
+}
+
+class _FailingMangaPageFetchClient extends MangaPageFetchClient {
+  @override
+  Future<Uint8List> fetch(MangaRemotePageResource resource) =>
+      Future<Uint8List>.error(
+        const MangaPageFetchException(
+          'The manga source refused this page request.',
+          reasonCode: 'http_forbidden',
+          statusCode: HttpStatus.forbidden,
+        ),
+      );
 }
 
 class _SilentMangaHubController extends MangaHubController {

--- a/test/player_hud_parity_test.dart
+++ b/test/player_hud_parity_test.dart
@@ -74,6 +74,19 @@ void main() {
     expect(player, contains('_handleProgressScrubInteraction'));
   });
 
+  test('paused episode metadata follows the shared HUD lifecycle', () {
+    expect(player, contains('PlayerPausedMetadataOverlay('));
+    expect(player, contains('_controlsVisible &&'));
+    expect(player, contains('_playerHasStartedPlayback &&'));
+    expect(player, contains('paused &&'));
+    expect(player, contains('episodeTitle: _pausedHudEpisodeTitle'));
+    expect(player, contains('description: _pausedHudDescription'));
+    expect(
+      player,
+      contains('(_playerHasStartedPlayback && !_player.state.playing)'),
+    );
+  });
+
   test('every HUD interaction and picker suspends idle auto-hide', () {
     expect(chrome, contains('onInteraction?.call();'));
     expect(chrome, contains('event is! KeyRepeatEvent'));

--- a/test/player_paused_metadata_overlay_test.dart
+++ b/test/player_paused_metadata_overlay_test.dart
@@ -1,0 +1,129 @@
+import 'package:anime_tv/core/theme/app_theme.dart';
+import 'package:anime_tv/features/player/presentation/player_paused_metadata_overlay.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('keeps the title fixed and scrolls an overflowing synopsis', (
+    tester,
+  ) async {
+    tester.view.physicalSize = const Size(1000, 600);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    final description = List.filled(
+      20,
+      'A long episode synopsis continues with another important detail.',
+    ).join(' ');
+    await tester.pumpWidget(_testApp(visible: true, description: description));
+    await tester.pump();
+
+    final title = tester.widget<Text>(
+      find.byKey(const ValueKey('player-paused-episode-title')),
+    );
+    expect(title.data, 'The Choice of Steins Gate');
+    expect(title.maxLines, 1);
+    expect(title.overflow, TextOverflow.ellipsis);
+
+    final scroll = tester.widget<SingleChildScrollView>(
+      find.byKey(const ValueKey('player-paused-description-scroll')),
+    );
+    expect(scroll.physics, isA<NeverScrollableScrollPhysics>());
+    expect(scroll.controller!.offset, 0);
+    expect(
+      tester
+          .getSize(
+            find.byKey(const ValueKey('player-paused-description-scroll')),
+          )
+          .height,
+      closeTo(70.2, .1),
+    );
+
+    await tester.pump(
+      playerPausedMetadataScrollDelay - const Duration(milliseconds: 1),
+    );
+    expect(scroll.controller!.offset, 0);
+    await tester.pump(const Duration(milliseconds: 1));
+    await tester.pump(const Duration(milliseconds: 500));
+    expect(scroll.controller!.offset, greaterThan(0));
+    expect(title.data, 'The Choice of Steins Gate');
+
+    await tester.pumpWidget(_testApp(visible: false, description: description));
+    await tester.pump();
+    expect(scroll.controller!.offset, 0);
+    expect(
+      tester.widget<AnimatedOpacity>(find.byType(AnimatedOpacity)).opacity,
+      0,
+    );
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('does not move text that fits or when motion is disabled', (
+    tester,
+  ) async {
+    tester.view.physicalSize = const Size(1000, 600);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    await tester.pumpWidget(
+      _testApp(visible: true, description: 'A short synopsis.'),
+    );
+    await tester.pump(playerPausedMetadataScrollDelay);
+    await tester.pump(const Duration(seconds: 2));
+    var scroll = tester.widget<SingleChildScrollView>(
+      find.byKey(const ValueKey('player-paused-description-scroll')),
+    );
+    expect(scroll.controller!.offset, 0);
+
+    final longDescription = List.filled(
+      20,
+      'This synopsis would overflow if accessibility motion were enabled.',
+    ).join(' ');
+    await tester.pumpWidget(
+      _testApp(
+        visible: true,
+        description: longDescription,
+        disableAnimations: true,
+      ),
+    );
+    await tester.pump(playerPausedMetadataScrollDelay);
+    await tester.pump(const Duration(seconds: 2));
+    scroll = tester.widget<SingleChildScrollView>(
+      find.byKey(const ValueKey('player-paused-description-scroll')),
+    );
+    expect(scroll.controller!.offset, 0);
+    expect(tester.takeException(), isNull);
+  });
+}
+
+Widget _testApp({
+  required bool visible,
+  required String description,
+  bool disableAnimations = false,
+}) {
+  return MaterialApp(
+    theme: AppTheme.dark,
+    home: MediaQuery(
+      data: MediaQueryData(
+        size: const Size(1000, 600),
+        disableAnimations: disableAnimations,
+      ),
+      child: Scaffold(
+        backgroundColor: Colors.black,
+        body: Align(
+          alignment: Alignment.topLeft,
+          child: SizedBox(
+            width: 466,
+            child: PlayerPausedMetadataOverlay(
+              visible: visible,
+              episodeTitle: 'The Choice of Steins Gate',
+              description: description,
+            ),
+          ),
+        ),
+      ),
+    ),
+  );
+}


### PR DESCRIPTION
Prepare Beta 2.0.70 with hardened secure manga-page loading and paused-player episode details. Manga redirects are HTTPS-only, bounded, destination-revalidated, and strip sensitive headers across origins; diagnostics remain privacy-safe. The player shows the episode title and a bounded three-line synopsis while paused, with delayed reduced-motion-aware scrolling for overflow. Validation: flutter analyze passed; full Flutter suite passed (2,351 passed, 33 skipped); release/source/native/ABI/docs policy checks passed.