### PR TITLE
Finalize TetoTV Beta 2.0.72

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 
 <p align="center">
   <a href="https://github.com/LindersOSX/TetoTV-Beta/releases/latest"><strong>Download Beta</strong></a>
-  · <a href="docs/RELEASE_NOTES_2.0.71.md">What's new</a>
+  · <a href="docs/RELEASE_NOTES_2.0.72.md">What's new</a>
   · <a href="https://github.com/LindersOSX/TetoTV-Beta/issues/new">Report an issue</a>
   · <a href="https://discord.gg/juC6k7d4WY">Discord</a>
   · <a href="https://www.youtube.com/@TetoTVApp">YouTube</a>
@@ -96,10 +96,10 @@ TetoTV runs directly on the Android device with no companion server required for
 | Channel | Version | Best for |
 | --- | --- | --- |
 | Public | Not published | Source and release-readiness documents are available, but no Public APK is currently offered |
-| Beta | [2.0.71](docs/RELEASE_NOTES_2.0.71.md) | Customizable manga reading and more useful playback diagnostics |
+| Beta | [2.0.72](docs/RELEASE_NOTES_2.0.72.md) | Customizable manga reading and more useful playback diagnostics |
 
 > [!WARNING]
-> Beta 2.0.71 uses the repository's explicit unreviewed-Beta exception. Its native-library and corresponding-source material did not receive independent license review, and automated integrity checks are not a legal compliance determination. Read the [complete Beta disclosure](docs/RELEASE_NOTES_2.0.71.md). This exception does not apply to a future Public release.
+> Beta 2.0.72 uses the repository's explicit unreviewed-Beta exception. Its native-library and corresponding-source material did not receive independent license review, and automated integrity checks are not a legal compliance determination. Read the [complete Beta disclosure](docs/RELEASE_NOTES_2.0.72.md). This exception does not apply to a future Public release.
 
 The Public updater repository intentionally has no release while the Public build is held for review. Existing Beta installations continue to update from the Beta repository. Android never permits an in-place install of an APK with a lower build code; Developer Mode does not bypass that platform rule.
 

--- a/docs/BUILD_WINDOWS.md
+++ b/docs/BUILD_WINDOWS.md
@@ -220,39 +220,39 @@ APK containing both supported application ABIs.
 Public and Beta updates use anonymous GitHub requests. No Beta key, GitHub
 token, update-proxy URL, or update-specific Dart define is required. Every
 published APK uses the production signing identity. No Public APK is currently
-published. Beta 2.0.71 uses Android build code `410048`. Flutter reuses
+published. Beta 2.0.72 uses Android build code `410049`. Flutter reuses
 `app-release.apk`, so copy and rename the Beta artifact immediately after the
 build:
 
 ```powershell
-New-Item -ItemType Directory -Force .\build\fire-tv\v2.0.71 | Out-Null
+New-Item -ItemType Directory -Force .\build\fire-tv\v2.0.72 | Out-Null
 
-# Beta 2.0.71
+# Beta 2.0.72
 flutter build apk --release --target-platform android-arm,android-arm64 `
-  --build-name 2.0.71 --build-number 410048 --no-tree-shake-icons
+  --build-name 2.0.72 --build-number 410049 --no-tree-shake-icons
 Copy-Item .\build\app\outputs\flutter-apk\app-release.apk `
-  .\build\fire-tv\v2.0.71\TetoTV-v2.0.71-universal.apk
+  .\build\fire-tv\v2.0.72\TetoTV-v2.0.72-universal.apk
 
 .\tool\release\verify_release_apk.ps1 `
   -Channel Beta `
-  -ApkPath .\build\fire-tv\v2.0.71\TetoTV-v2.0.71-universal.apk
+  -ApkPath .\build\fire-tv\v2.0.72\TetoTV-v2.0.72-universal.apk
 
 .\tool\release\verify_native_redistribution.ps1 `
   -RequireResolvedBinaries `
   -ResolvedBinaryDirectory .\build\native-playback\outputs `
-  -StageBundle -ReleaseTag v2.0.71
+  -StageBundle -ReleaseTag v2.0.72
 
 .\tool\release\new_release_checksums.ps1 `
-  -ApkPath .\build\fire-tv\v2.0.71\TetoTV-v2.0.71-universal.apk `
-  -NativeSourcePath .\build\release-compliance\v2.0.71\TetoTV-v2.0.71-native-playback-sources.zip `
-  -OutputPath .\build\fire-tv\v2.0.71\SHA256SUMS
+  -ApkPath .\build\fire-tv\v2.0.72\TetoTV-v2.0.72-universal.apk `
+  -NativeSourcePath .\build\release-compliance\v2.0.72\TetoTV-v2.0.72-native-playback-sources.zip `
+  -OutputPath .\build\fire-tv\v2.0.72\SHA256SUMS
 
 .\tool\release\verify_release_payloads.ps1 `
   -Channel Beta `
-  -ApkPath .\build\fire-tv\v2.0.71\TetoTV-v2.0.71-universal.apk `
-  -NativeSourcePath .\build\release-compliance\v2.0.71\TetoTV-v2.0.71-native-playback-sources.zip `
-  -ChecksumsPath .\build\fire-tv\v2.0.71\SHA256SUMS `
-  -ReleaseNotesPath .\docs\RELEASE_NOTES_2.0.71.md `
+  -ApkPath .\build\fire-tv\v2.0.72\TetoTV-v2.0.72-universal.apk `
+  -NativeSourcePath .\build\release-compliance\v2.0.72\TetoTV-v2.0.72-native-playback-sources.zip `
+  -ChecksumsPath .\build\fire-tv\v2.0.72\SHA256SUMS `
+  -ReleaseNotesPath .\docs\RELEASE_NOTES_2.0.72.md `
   -ResolvedBinaryDirectory .\build\native-playback\outputs
 ```
 

--- a/docs/PLAYBACK_DIAGNOSTICS.md
+++ b/docs/PLAYBACK_DIAGNOSTICS.md
@@ -1,6 +1,6 @@
 # Playback diagnostics: investigating stutter
 
-Implementation status: included in TetoTV Beta 2.0.71, including the MPV player
+Implementation status: included in TetoTV Beta 2.0.72, including the MPV player
 integration, bounded local storage, and explicit report export.
 There has not yet been a real Android TV device validation run. Automated tests
 do not establish native property availability, device overhead, or that the

--- a/docs/RELEASE_NOTES_2.0.72.md
+++ b/docs/RELEASE_NOTES_2.0.72.md
@@ -1,4 +1,4 @@
-# TetoTV 2.0.71 Beta
+# TetoTV 2.0.72 Beta
 
 > [!WARNING]
 > No independent native-license review: This Beta has not received independent native-library licensing review. Automated checks verify the APK, native-source bundle, notices, pinned inputs, and checksums, but do not establish legal compliance or reproducible builds.
@@ -20,16 +20,16 @@ This Beta adds a more customizable manga reader and richer, privacy-safe playbac
 
 ## Release assets
 
-- `TetoTV-v2.0.71-universal.apk` — install this file on a supported Android phone, tablet, TV, Google TV, or Fire TV device.
-- `TetoTV-v2.0.71-native-playback-sources.zip` — native playback source and license material for developers and compliance review; normal users do not need it.
+- `TetoTV-v2.0.72-universal.apk` — install this file on a supported Android phone, tablet, TV, Google TV, or Fire TV device.
+- `TetoTV-v2.0.72-native-playback-sources.zip` — native playback source and license material for developers and compliance review; normal users do not need it.
 - `SHA256SUMS` — integrity hashes for the two files above.
 
 ## Beta notes
 
-- This is a Beta-channel build with Android build code `410048`.
+- This is a Beta-channel build with Android build code `410049`.
 - No Public APK is being published with this release.
 - This update adds diagnostic evidence; it does not claim that every device-specific playback lag issue is fixed. Native metric availability varies by device and stream.
 - No manga repository, extension, provider, catalog, or title is bundled or recommended by TetoTV.
-- Android does not permit an in-place install over an APK with a higher build code. A future Public counterpart must use build code `410048` or newer for data-preserving channel switching.
+- Android does not permit an in-place install over an APK with a higher build code. A future Public counterpart must use build code `410049` or newer for data-preserving channel switching.
 
-<!-- tetotv-android-version-code: 410048 -->
+<!-- tetotv-android-version-code: 410049 -->

--- a/docs/UPDATE_CHANNELS.md
+++ b/docs/UPDATE_CHANNELS.md
@@ -35,11 +35,11 @@ Beta reads completed 2.x releases from:
 https://api.github.com/repos/LindersOSX/TetoTV-Beta/releases/latest
 ```
 
-The current Beta source build is `v2.0.71` with Android build code `410048`.
+The current Beta source build is `v2.0.72` with Android build code `410049`.
 Its release title is:
 
 ```text
-TetoTV 2.0.71 Beta - Android TV / Google TV / Fire TV
+TetoTV 2.0.72 Beta - Android TV / Google TV / Fire TV
 ```
 
 Publish it as a normal, non-draft, non-prerelease GitHub release so
@@ -72,7 +72,7 @@ proxy.
 Release notes must include the exact asset names and this build-code marker:
 
 ```html
-<!-- tetotv-android-version-code: 410048 -->
+<!-- tetotv-android-version-code: 410049 -->
 ```
 
 When build-code metadata is present, the updater rejects a known lower build
@@ -94,10 +94,10 @@ These rules apply equally on phones, Android TV, Google TV, and Fire TV.
 
 ## Switching and rollback
 
-The current Beta uses build code `410048`. No Public counterpart is available.
+The current Beta uses build code `410049`. No Public counterpart is available.
 An older Public install can move to this Beta when Android accepts the higher
 build code, but it cannot move back in place until a future Public build uses
-code `410048` or higher. Uninstalling first permits an older APK but deletes
+code `410049` or higher. Uninstalling first permits an older APK but deletes
 local application data. Developer Mode and in-app settings cannot override
 this Android rule.
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: 'none'
 # Public and Beta artifacts built from the same source use one monotonically
 # increasing Android versionCode. The project default carries the Beta display
 # version; the Public universal APK overrides the build name to the 1.x line.
-version: 2.0.71+410048
+version: 2.0.72+410049
 
 environment:
   sdk: ^3.12.2

--- a/tool/release/native_playback_manifest.json
+++ b/tool/release/native_playback_manifest.json
@@ -376,9 +376,9 @@
       "path": "lib/arm64-v8a/libapp.so",
       "size": 13829008,
       "sha256": "c55a91e8decf9f75f565854b5553402c622d28e0eac39e3abb488fdb89070967",
-      "origin": "TetoTV Flutter application AOT 2.0.71",
+      "origin": "TetoTV Flutter application AOT 2.0.72",
       "license": "MIT",
-      "sourceLocator": "Git tag v2.0.71",
+      "sourceLocator": "Git tag v2.0.72",
       "noticeLocator": "LICENSE"
     },
     {
@@ -423,7 +423,7 @@
       "sha256": "dc05f53278b2733094f12aeaed54c080329309762ce49e6de4118e4bfb0fff55",
       "origin": "TetoTV source build of media-kit Android helper at 42054e5d479f39ccbb0ae604862e2bcaf59b74c2",
       "license": "MIT",
-      "sourceLocator": "TetoTV-v2.0.71-native-playback-sources.zip: sources/media-kit-android-helper-42054e5d479f39ccbb0ae604862e2bcaf59b74c2.zip",
+      "sourceLocator": "TetoTV-v2.0.72-native-playback-sources.zip: sources/media-kit-android-helper-42054e5d479f39ccbb0ae604862e2bcaf59b74c2.zip",
       "noticeLocator": "assets/legal/native/MEDIA_KIT_ANDROID_HELPER_LICENSE.txt; assets/legal/native/NATIVE_PLAYBACK_NOTICE.txt"
     },
     {
@@ -432,7 +432,7 @@
       "sha256": "a7399d0be70844e5ee94cc5b1acc1516571113c50561fe0a5d05b49101c53ef2",
       "origin": "TetoTV source build of the pinned mpv and FFmpeg native playback stack",
       "license": "LGPL-3.0-or-later (conservative combined classification) plus component terms",
-      "sourceLocator": "TetoTV-v2.0.71-native-playback-sources.zip and tool/native/build_native_playback.sh",
+      "sourceLocator": "TetoTV-v2.0.72-native-playback-sources.zip and tool/native/build_native_playback.sh",
       "noticeLocator": "assets/legal/native/NATIVE_PLAYBACK_NOTICE.txt and its referenced exact license assets"
     },
     {
@@ -450,16 +450,16 @@
       "sha256": "263ba714570fb3acfc308cce52776b00506ec8809d225617e52352336144cfa2",
       "origin": "TetoTV source build of the pinned libtorrent4j and libtorrent-rasterbar stack",
       "license": "Mixed MIT, BSD, Boost-1.0, Apache-2.0, and MPL-2.0 component terms",
-      "sourceLocator": "TetoTV-v2.0.71-native-playback-sources.zip and tool/native/build_native_playback.sh",
+      "sourceLocator": "TetoTV-v2.0.72-native-playback-sources.zip and tool/native/build_native_playback.sh",
       "noticeLocator": "assets/legal/native/DIRECT_TORRENT_NATIVE_NOTICE.txt and its referenced exact license assets"
     },
     {
       "path": "lib/armeabi-v7a/libapp.so",
       "size": 15106636,
       "sha256": "ac3e739779cd33ef10776c4abd65f8a7e80fbd630064f53b0d19931be80d4f9d",
-      "origin": "TetoTV Flutter application AOT 2.0.71",
+      "origin": "TetoTV Flutter application AOT 2.0.72",
       "license": "MIT",
-      "sourceLocator": "Git tag v2.0.71",
+      "sourceLocator": "Git tag v2.0.72",
       "noticeLocator": "LICENSE"
     },
     {
@@ -504,7 +504,7 @@
       "sha256": "8820a12e07bb3dc45f5b4286acf6918827fba4c265767e7f1cc8f07215c84b6a",
       "origin": "TetoTV source build of media-kit Android helper at 42054e5d479f39ccbb0ae604862e2bcaf59b74c2",
       "license": "MIT",
-      "sourceLocator": "TetoTV-v2.0.71-native-playback-sources.zip: sources/media-kit-android-helper-42054e5d479f39ccbb0ae604862e2bcaf59b74c2.zip",
+      "sourceLocator": "TetoTV-v2.0.72-native-playback-sources.zip: sources/media-kit-android-helper-42054e5d479f39ccbb0ae604862e2bcaf59b74c2.zip",
       "noticeLocator": "assets/legal/native/MEDIA_KIT_ANDROID_HELPER_LICENSE.txt; assets/legal/native/NATIVE_PLAYBACK_NOTICE.txt"
     },
     {
@@ -513,7 +513,7 @@
       "sha256": "d5a220fdf41edde10f161f86addc846ae9cb18137ea48e4db541cd703fec5092",
       "origin": "TetoTV source build of the pinned mpv and FFmpeg native playback stack",
       "license": "LGPL-3.0-or-later (conservative combined classification) plus component terms",
-      "sourceLocator": "TetoTV-v2.0.71-native-playback-sources.zip and tool/native/build_native_playback.sh",
+      "sourceLocator": "TetoTV-v2.0.72-native-playback-sources.zip and tool/native/build_native_playback.sh",
       "noticeLocator": "assets/legal/native/NATIVE_PLAYBACK_NOTICE.txt and its referenced exact license assets"
     },
     {
@@ -531,7 +531,7 @@
       "sha256": "ba0a19d2730969b8e6107db1847888ea8d3b8cafd14a535a3259dd04f8b28d60",
       "origin": "TetoTV source build of the pinned libtorrent4j and libtorrent-rasterbar stack",
       "license": "Mixed MIT, BSD, Boost-1.0, Apache-2.0, and MPL-2.0 component terms",
-      "sourceLocator": "TetoTV-v2.0.71-native-playback-sources.zip and tool/native/build_native_playback.sh",
+      "sourceLocator": "TetoTV-v2.0.72-native-playback-sources.zip and tool/native/build_native_playback.sh",
       "noticeLocator": "assets/legal/native/DIRECT_TORRENT_NATIVE_NOTICE.txt and its referenced exact license assets"
     }
   ],


### PR DESCRIPTION
## Summary

- advance the Beta release to 2.0.72/build 410049 after the protected v2.0.71 tag was created before the required squash merge
- bind release documentation and native source locators to v2.0.72
- preserve the already-merged manga reader and privacy-safe playback diagnostics changes

## Verification

- full app suite for the identical source tree: 2,483 passed; 33 skipped
- flutter analyze --no-pub: no issues
- release-policy/native-redistribution tests: 11 passed
- signed APK verification passed for package, signer, version 2.0.72 (410049), minimum SDK, both ARM ABIs, and 18 native entries

The actual v2.0.72 tag will be created only after this required PR is merged.