### PR TITLE
Release beta 2.0.74: optional Media3 SurfaceView

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 
 <p align="center">
   <a href="https://github.com/LindersOSX/TetoTV-Beta/releases/latest"><strong>Download Beta</strong></a>
-  · <a href="docs/RELEASE_NOTES_2.0.73.md">What's new</a>
+  · <a href="docs/RELEASE_NOTES_2.0.74.md">What's new</a>
   · <a href="https://github.com/LindersOSX/TetoTV-Beta/issues/new">Report an issue</a>
   · <a href="https://discord.gg/juC6k7d4WY">Discord</a>
   · <a href="https://www.youtube.com/@TetoTVApp">YouTube</a>
@@ -97,10 +97,10 @@ TetoTV runs directly on the Android device with no companion server required for
 | Channel | Version | Best for |
 | --- | --- | --- |
 | Public | Not published | Source and release-readiness documents are available, but no Public APK is currently offered |
-| Beta | [2.0.73](docs/RELEASE_NOTES_2.0.73.md) | Optional Media3 playback with the shared HUD and improved crash diagnostics |
+| Beta | [2.0.74](docs/RELEASE_NOTES_2.0.74.md) | Optional Media3 SurfaceView rendering and cleaner scrubbing; MPV unchanged |
 
 > [!WARNING]
-> Beta 2.0.73 uses the repository's explicit unreviewed-Beta exception. Its native-library and corresponding-source material did not receive independent license review, and automated integrity checks are not a legal compliance determination. Read the [complete Beta disclosure](docs/RELEASE_NOTES_2.0.73.md). This exception does not apply to a future Public release.
+> Beta 2.0.74 uses the repository's explicit unreviewed-Beta exception. Its native-library and corresponding-source material did not receive independent license review, and automated integrity checks are not a legal compliance determination. Read the [complete Beta disclosure](docs/RELEASE_NOTES_2.0.74.md). This exception does not apply to a future Public release.
 
 The Public updater repository intentionally has no release while the Public build is held for review. Existing Beta installations continue to update from the Beta repository. Android never permits an in-place install of an APK with a lower build code; Developer Mode does not bypass that platform rule.
 

--- a/android/app/src/main/kotlin/dev/animetv/anime_tv/player/Media3BridgePolicy.kt
+++ b/android/app/src/main/kotlin/dev/animetv/anime_tv/player/Media3BridgePolicy.kt
@@ -9,7 +9,21 @@ internal object Media3BridgePolicy {
     const val MAX_SIDECARS = 32
     const val MAX_PLAYERS = 2
     const val RELEASE_TIMEOUT_MS = 1_000L
+    const val SCREENSHOT_MAX_DIMENSION = 480
+    const val SCREENSHOT_MAX_BYTES = 256 * 1024
     private val headerName = Regex("^[!#$%&'*+.^_`|~0-9A-Za-z-]{1,128}$")
+
+    fun surfaceType(raw: Any?): String = when (raw) {
+        null, "texture" -> "texture"
+        "surface" -> "surface"
+        else -> throw IllegalArgumentException("invalid_surface_type")
+    }
+
+    fun screenshotSize(width: Int, height: Int): Pair<Int, Int>? {
+        if (width <= 0 || height <= 0) return null
+        val scale = minOf(1.0, SCREENSHOT_MAX_DIMENSION.toDouble() / maxOf(width, height))
+        return maxOf(1, (width * scale).toInt()) to maxOf(1, (height * scale).toInt())
+    }
 
     fun supportedUri(value: String): Boolean {
         if (value.isBlank() || value.length > 16_384 || value.any { it.code < 32 }) return false
@@ -148,4 +162,16 @@ internal class Media3CallbackEpoch {
     fun begin(openId: Long): Ticket = Ticket(++generation, openId).also { current = it }
     fun invalidate() { generation++; current = null }
     fun accepts(ticket: Ticket): Boolean = current === ticket
+}
+
+/** A detached/disposed capture replies with null once, even if PixelCopy finishes later. */
+internal class Media3ScreenshotResult(reply: (ByteArray?) -> Unit) {
+    private var reply: ((ByteArray?) -> Unit)? = reply
+    val isPending: Boolean get() = reply != null
+
+    fun complete(bytes: ByteArray?) {
+        val callback = reply ?: return
+        reply = null
+        callback(bytes)
+    }
 }

--- a/android/app/src/main/kotlin/dev/animetv/anime_tv/player/Media3FlutterBridge.kt
+++ b/android/app/src/main/kotlin/dev/animetv/anime_tv/player/Media3FlutterBridge.kt
@@ -11,6 +11,8 @@ import android.os.SystemClock
 import android.util.Base64
 import android.util.TypedValue
 import android.view.LayoutInflater
+import android.view.PixelCopy
+import android.view.SurfaceView
 import android.view.TextureView
 import android.view.View
 import android.view.ViewGroup
@@ -75,10 +77,12 @@ class Media3FlutterBridge(context: Context, engine: FlutterEngine) :
             "dev.tetotv/media3/video",
             object : PlatformViewFactory(StandardMessageCodec.INSTANCE) {
                 override fun create(context: Context, viewId: Int, args: Any?): PlatformView {
-                    val id = (args as? Map<*, *>)?.get("id") as? Number
+                    val params = args as? Map<*, *>
+                    val surfaceType = Media3BridgePolicy.surfaceType(params?.get("surfaceType"))
+                    val id = params?.get("id") as? Number
                     val session = id?.toLong()?.let(sessions::get)
                         ?: throw IllegalArgumentException("Media3 player is unavailable")
-                    return Media3VideoView(context, session)
+                    return Media3VideoView(context, session, surfaceType)
                 }
             },
         )
@@ -145,7 +149,12 @@ class Media3FlutterBridge(context: Context, engine: FlutterEngine) :
                     result.success(session.addSubtitle(call.arguments as? Map<*, *> ?: emptyMap<Any, Any>()))
                     return
                 }
-                "screenshot" -> { result.success(session.screenshot(call.argument<String>("format") ?: "image/jpeg")); return }
+                "screenshot" -> {
+                    session.screenshot(call.argument<String>("format") ?: "image/jpeg") { bytes ->
+                        runCatching { result.success(bytes) }
+                    }
+                    return
+                }
                 "readProperty" -> { result.success(session.readProperty(call.argument<String>("property").orEmpty())); return }
                 "ready" -> { result.success(true); return }
                 else -> { result.notImplemented(); return }
@@ -179,8 +188,10 @@ class Media3FlutterBridge(context: Context, engine: FlutterEngine) :
 }
 
 @androidx.annotation.OptIn(UnstableApi::class)
-private class Media3VideoView(context: Context, private val session: Media3Session) : PlatformView {
-    private val video = (LayoutInflater.from(context).inflate(R.layout.media3_flutter_video, null) as PlayerView).apply {
+private class Media3VideoView(context: Context, private val session: Media3Session, surfaceType: String) : PlatformView {
+    // PlayerView chooses its rendering surface at inflation time, before player attachment.
+    private val layout = if (surfaceType == "surface") R.layout.media3_flutter_surface_video else R.layout.media3_flutter_video
+    private val video = (LayoutInflater.from(context).inflate(layout, null) as PlayerView).apply {
         useController = false
         controllerAutoShow = false
         isFocusable = false
@@ -214,6 +225,10 @@ private class Media3Session(
     private var eventGeneration = 0L
     private var openId = 0L
     private var disposed = false
+    // Separate from the bridge handler, whose callbacks are cleared on teardown:
+    // a completed PixelCopy must still recycle its destination bitmap.
+    private val screenshotHandler = Handler(Looper.getMainLooper())
+    private var pendingScreenshot: Media3ScreenshotResult? = null
     private var desiredPlaying = false
     private var rate = 1f
     private var volume = 1f
@@ -384,8 +399,9 @@ private class Media3Session(
     fun seek(positionMs: Long) { player?.seekTo(request?.endMs?.let { minOf(positionMs, it) } ?: positionMs); emitState() }
     fun setRate(value: Float) { rate = value; player?.setPlaybackSpeed(value); emitState() }
     fun setVolume(value: Float) { volume = value; player?.volume = value; emitState() }
-    fun stop() { desiredPlaying = false; player?.pause(); player?.stop(); handler.removeCallbacks(tick); emitState() }
+    fun stop() { cancelScreenshot(); desiredPlaying = false; player?.pause(); player?.stop(); handler.removeCallbacks(tick); emitState() }
     fun setForeground(value: Boolean) {
+        if (!value) cancelScreenshot()
         foreground = value
         player?.playWhenReady = desiredPlaying && value
         scheduleTick()
@@ -457,12 +473,14 @@ private class Media3Session(
 
     fun attach(surface: PlayerView) {
         if (view === surface) return
+        cancelScreenshot()
         view?.player = null
         view = surface
         surface.player = player
         applyOptions()
     }
     fun detach(surface: PlayerView) {
+        if (view === surface) cancelScreenshot()
         surface.player = null
         if (view === surface) view = null
     }
@@ -688,20 +706,67 @@ private class Media3Session(
         }
     }
 
-    fun screenshot(format: String): ByteArray? {
+    fun screenshot(format: String, reply: (ByteArray?) -> Unit) {
         require(format in setOf("image/jpeg", "image/png"))
-        val texture = view?.videoSurfaceView as? TextureView ?: return null
-        if (!texture.isAvailable || firstFrameAfterMs == null) return null
-        val width = minOf(texture.width, 480).coerceAtLeast(1)
-        val height = (texture.height.toDouble() * width / texture.width.coerceAtLeast(1)).toInt().coerceIn(1, 480)
-        val bitmap = texture.getBitmap(width, height) ?: return null
+        val attached = view
+        val source = attached?.videoSurfaceView
+        val native = player
+        val size = source?.let { Media3BridgePolicy.screenshotSize(it.width, it.height) }
+        if (disposed || !foreground || native == null || firstFrameAfterMs == null || size == null) {
+            reply(null)
+            return
+        }
+        when (source) {
+            is TextureView -> {
+                val bitmap = if (source.isAvailable) source.getBitmap(size.first, size.second) else null
+                reply(bitmap?.let { encodeScreenshot(it, format) })
+            }
+            is SurfaceView -> {
+                // Keep allocation bounded to one outstanding copy per player, even
+                // when its result has already been cancelled by lifecycle changes.
+                if (pendingScreenshot != null || !source.holder.surface.isValid) {
+                    reply(null)
+                    return
+                }
+                val bitmap = Bitmap.createBitmap(size.first, size.second, Bitmap.Config.ARGB_8888)
+                val capture = Media3ScreenshotResult(reply)
+                pendingScreenshot = capture
+                try {
+                    // This overload is available on API 24, including supported Fire OS devices.
+                    PixelCopy.request(source, bitmap, { status ->
+                        if (pendingScreenshot === capture) pendingScreenshot = null
+                        val current = capture.isPending && !disposed && foreground &&
+                            player === native && view === attached && attached.videoSurfaceView === source
+                        val bytes = if (status == PixelCopy.SUCCESS && current) {
+                            encodeScreenshot(bitmap, format)
+                        } else {
+                            bitmap.recycle()
+                            null
+                        }
+                        capture.complete(bytes)
+                    }, screenshotHandler)
+                } catch (_: Exception) {
+                    if (pendingScreenshot === capture) pendingScreenshot = null
+                    bitmap.recycle()
+                    capture.complete(null)
+                }
+            }
+            else -> reply(null)
+        }
+    }
+
+    private fun encodeScreenshot(bitmap: Bitmap, format: String): ByteArray? {
         return try {
             ByteArrayOutputStream().use { output ->
                 if (!bitmap.compress(if (format == "image/png") Bitmap.CompressFormat.PNG else Bitmap.CompressFormat.JPEG, 65, output)) return null
-                output.toByteArray().takeIf { it.size <= 256 * 1024 }
+                output.toByteArray().takeIf { it.size <= Media3BridgePolicy.SCREENSHOT_MAX_BYTES }
             }
+        } catch (_: Exception) {
+            null
         } finally { bitmap.recycle() }
     }
+
+    private fun cancelScreenshot() { pendingScreenshot?.complete(null) }
 
     private fun scheduleTick() {
         handler.removeCallbacks(tick)
@@ -709,6 +774,7 @@ private class Media3Session(
     }
 
     private fun releasePlayer() {
+        cancelScreenshot()
         callbacks.invalidate() // Before detach/release can enqueue events.
         handler.removeCallbacks(tick)
         val old = player

--- a/android/app/src/main/res/layout/media3_flutter_surface_video.xml
+++ b/android/app/src/main/res/layout/media3_flutter_surface_video.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.media3.ui.PlayerView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@android:color/black"
+    android:focusable="false"
+    android:focusableInTouchMode="false"
+    android:keepScreenOn="true"
+    app:surface_type="surface_view"
+    app:use_controller="false"
+    app:show_buffering="never"
+    app:use_artwork="false" />

--- a/android/app/src/test/kotlin/dev/animetv/anime_tv/player/Media3SurfacePolicyTest.kt
+++ b/android/app/src/test/kotlin/dev/animetv/anime_tv/player/Media3SurfacePolicyTest.kt
@@ -1,0 +1,50 @@
+package dev.animetv.anime_tv.player
+
+import org.junit.Assert.*
+import org.junit.Test
+
+class Media3SurfacePolicyTest {
+    @Test fun omittedSurfaceTypeRetainsTextureViewAndOnlyExplicitSurfaceOptInChangesIt() {
+        assertEquals("texture", Media3BridgePolicy.surfaceType(null))
+        assertEquals("texture", Media3BridgePolicy.surfaceType("texture"))
+        assertEquals("surface", Media3BridgePolicy.surfaceType("surface"))
+        for (raw in listOf("", "SurfaceView", "surface_view", "SURFACE", " texture", true, 1, emptyMap<String, String>())) {
+            assertThrows(IllegalArgumentException::class.java) { Media3BridgePolicy.surfaceType(raw) }
+        }
+    }
+
+    @Test fun capturesStayBoundedAndKeepLandscapeAndPortraitAspectRatios() {
+        assertEquals(480 to 270, Media3BridgePolicy.screenshotSize(1920, 1080))
+        assertEquals(270 to 480, Media3BridgePolicy.screenshotSize(1080, 1920))
+        assertEquals(320 to 240, Media3BridgePolicy.screenshotSize(320, 240))
+        assertEquals(480 to 480, Media3BridgePolicy.screenshotSize(Int.MAX_VALUE, Int.MAX_VALUE))
+        assertEquals(1 to 480, Media3BridgePolicy.screenshotSize(1, Int.MAX_VALUE))
+        for ((width, height) in listOf(0 to 100, 100 to 0, -1 to 100, 100 to -1)) {
+            assertNull(Media3BridgePolicy.screenshotSize(width, height))
+        }
+        assertEquals(256 * 1024, Media3BridgePolicy.SCREENSHOT_MAX_BYTES)
+    }
+
+    @Test fun cancelledCaptureCompletesOnceAndDiscardsLateCopiedPixels() {
+        val replies = mutableListOf<ByteArray?>()
+        val capture = Media3ScreenshotResult { replies.add(it) }
+        assertTrue(capture.isPending)
+        capture.complete(null)
+        assertFalse(capture.isPending)
+        capture.complete(byteArrayOf(1, 2, 3))
+        capture.complete(null)
+        assertEquals(1, replies.size)
+        assertNull(replies.single())
+    }
+
+    @Test fun successfulCapturePreservesByteResponseAndCannotCompleteTwice() {
+        val replies = mutableListOf<ByteArray?>()
+        val capture = Media3ScreenshotResult { replies.add(it) }
+        val pixels = byteArrayOf(4, 5, 6)
+        capture.complete(pixels)
+        capture.complete(null)
+        assertFalse(capture.isPending)
+        assertEquals(1, replies.size)
+        assertSame(pixels, replies.single())
+    }
+}

--- a/docs/BUILD_WINDOWS.md
+++ b/docs/BUILD_WINDOWS.md
@@ -220,39 +220,39 @@ APK containing both supported application ABIs.
 Public and Beta updates use anonymous GitHub requests. No Beta key, GitHub
 token, update-proxy URL, or update-specific Dart define is required. Every
 published APK uses the production signing identity. No Public APK is currently
-published. Beta 2.0.73 uses Android build code `410050`. Flutter reuses
+published. Beta 2.0.74 uses Android build code `410051`. Flutter reuses
 `app-release.apk`, so copy and rename the Beta artifact immediately after the
 build:
 
 ```powershell
-New-Item -ItemType Directory -Force .\build\fire-tv\v2.0.73 | Out-Null
+New-Item -ItemType Directory -Force .\build\fire-tv\v2.0.74 | Out-Null
 
-# Beta 2.0.73
+# Beta 2.0.74
 flutter build apk --release --target-platform android-arm,android-arm64 `
-  --build-name 2.0.73 --build-number 410050 --no-tree-shake-icons
+  --build-name 2.0.74 --build-number 410051 --no-tree-shake-icons
 Copy-Item .\build\app\outputs\flutter-apk\app-release.apk `
-  .\build\fire-tv\v2.0.73\TetoTV-v2.0.73-universal.apk
+  .\build\fire-tv\v2.0.74\TetoTV-v2.0.74-universal.apk
 
 .\tool\release\verify_release_apk.ps1 `
   -Channel Beta `
-  -ApkPath .\build\fire-tv\v2.0.73\TetoTV-v2.0.73-universal.apk
+  -ApkPath .\build\fire-tv\v2.0.74\TetoTV-v2.0.74-universal.apk
 
 .\tool\release\verify_native_redistribution.ps1 `
   -RequireResolvedBinaries `
   -ResolvedBinaryDirectory .\build\native-playback\outputs `
-  -StageBundle -ReleaseTag v2.0.73
+  -StageBundle -ReleaseTag v2.0.74
 
 .\tool\release\new_release_checksums.ps1 `
-  -ApkPath .\build\fire-tv\v2.0.73\TetoTV-v2.0.73-universal.apk `
-  -NativeSourcePath .\build\release-compliance\v2.0.73\TetoTV-v2.0.73-native-playback-sources.zip `
-  -OutputPath .\build\fire-tv\v2.0.73\SHA256SUMS
+  -ApkPath .\build\fire-tv\v2.0.74\TetoTV-v2.0.74-universal.apk `
+  -NativeSourcePath .\build\release-compliance\v2.0.74\TetoTV-v2.0.74-native-playback-sources.zip `
+  -OutputPath .\build\fire-tv\v2.0.74\SHA256SUMS
 
 .\tool\release\verify_release_payloads.ps1 `
   -Channel Beta `
-  -ApkPath .\build\fire-tv\v2.0.73\TetoTV-v2.0.73-universal.apk `
-  -NativeSourcePath .\build\release-compliance\v2.0.73\TetoTV-v2.0.73-native-playback-sources.zip `
-  -ChecksumsPath .\build\fire-tv\v2.0.73\SHA256SUMS `
-  -ReleaseNotesPath .\docs\RELEASE_NOTES_2.0.73.md `
+  -ApkPath .\build\fire-tv\v2.0.74\TetoTV-v2.0.74-universal.apk `
+  -NativeSourcePath .\build\release-compliance\v2.0.74\TetoTV-v2.0.74-native-playback-sources.zip `
+  -ChecksumsPath .\build\fire-tv\v2.0.74\SHA256SUMS `
+  -ReleaseNotesPath .\docs\RELEASE_NOTES_2.0.74.md `
   -ResolvedBinaryDirectory .\build\native-playback\outputs
 ```
 

--- a/docs/MEDIA3_PLAYBACK.md
+++ b/docs/MEDIA3_PLAYBACK.md
@@ -2,6 +2,12 @@
 
 MPV remains the default. On Android, choose **Settings → Playback → Default player → Media3 (Built in)** to use AndroidX Media3/ExoPlayer for the next playback session. Choose MPV again to switch back. Existing preferences are not migrated to an external player.
 
+Android Playback settings also include **Media3 SurfaceView** (experimental, off by default). Off uses the existing TextureView video output. Enabling it selects Media3 as the default player and uses SurfaceView for the next playback session. Disabling it returns Media3 to TextureView without changing the selected player. A later explicit choice of MPV is respected; the rendering preference never changes MPV's output or decoder configuration.
+
+SurfaceView uses native hierarchy composition beneath the shared Flutter HUD. It is an optional device-comparison setting, not a guarantee of higher FPS. Both modes retain the same controls, native captions, fit/zoom options, and screenshot API. Rendering mode does not change in the middle of an active playback session. Media3 scrubbing shows only the timestamp bubble, without scene thumbnails.
+
+The SurfaceView option was checked on the Android TV API 36 emulator in both modes: playback, seeking, caption/audio selection, decoder changes, HUD input, view recreation, sizing, screenshots, and bounded playback end passed. Settings tests cover persistence, startup races, reset, automatic Media3 selection, and later explicit MPV selection. These checks do not establish an FPS improvement on the customer's physical TV.
+
 Both engines use the existing TetoTV player screen and controls: resume, pause, seeking, episode switching, skip controls, speed, audio/CC selection, caption preferences, fit/zoom, Watch Party, tracking and Discord activity. Media3 renders video and native captions underneath that shared Flutter interface; Android's own player controls are disabled.
 
 Plex/Jellyfin playback continues through the same server playback requests, audio/subtitle metadata and compatibility recovery. External subtitle tracks are registered together, retaining language and selection metadata. Media3 decoder preferences and outcomes do not overwrite MPV's saved per-series decoder preference or device-health history.

--- a/docs/RELEASE_NOTES_2.0.74.md
+++ b/docs/RELEASE_NOTES_2.0.74.md
@@ -1,0 +1,28 @@
+# TetoTV 2.0.74 Beta
+
+> [!WARNING]
+> No independent native-license review: This Beta has not received independent native-library licensing review. Automated checks verify the APK, native-source bundle, notices, pinned inputs, and checksums, but do not establish legal compliance or reproducible builds.
+
+## What's changed
+
+- Added **Settings → Playback → Media3 SurfaceView**, an experimental rendering toggle for Android. Off uses TextureView (the default). Turning it on automatically selects **Media3 (Built in)** for the next video.
+- Turning it off returns Media3 to TextureView without changing your selected player. You can still select MPV independently; MPV playback and rendering are unchanged.
+- Both Media3 modes use the same TetoTV HUD, captions, seeking and sizing controls. Rendering changes apply when you next open a video, not during playback.
+- Removed the Media3 scrubbing scene-preview window. The seek timestamp bubble remains.
+- SurfaceView is an optional device-specific comparison, not a guaranteed fix for low FPS.
+- AI tools assisted with implementation, testing and documentation. The project owner remains responsible for the release.
+
+## Install
+
+Download **TetoTV-v2.0.74-universal.apk** for supported Android phones, tablets, Android TV, Google TV and Fire TV devices.
+
+**TetoTV-v2.0.74-native-playback-sources.zip** is developer/license material, not an app installer. **SHA256SUMS** provides integrity hashes.
+
+## Verification and channel
+
+- Focused player, settings/navigation and native Media3 tests passed. Both rendering modes passed Android TV emulator playback, seeking, captions, HUD input, resizing, screenshots and view-recreation checks.
+- Physical-TV performance improvement has not been established. Existing engine differences, including MPV-only manual audio/subtitle timing offsets, remain.
+- Beta only, Android build code **410051**. No Public APK is being published.
+- No repository, provider, catalog or media content is bundled or recommended by this update.
+
+<!-- tetotv-android-version-code: 410051 -->

--- a/integration_test/media3_playback_test.dart
+++ b/integration_test/media3_playback_test.dart
@@ -11,195 +11,228 @@ import 'package:media_kit/media_kit.dart';
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
-  testWidgets(
-    'built-in Media3 renders, seeks, selects captions and reopens',
-    (tester) async {
-      // Deliberately do not call MediaKit.ensureInitialized(): this test must
-      // render through Android Media3 without opening the MPV engine.
-      final backend = Media3PlatformPlayer();
-      final player = Player(platformPlayer: backend);
-      final errors = <String>[];
-      final subscription = player.stream.error.listen(errors.add);
-      final temporary = await Directory.systemTemp.createTemp(
-        'tetotv-media3-smoke-',
-      );
-      final asset = await rootBundle.load('assets/videos/mpv_smoke.mp4');
-      final videoFile = await File(
-        '${temporary.path}/sample.mp4',
-      ).writeAsBytes(asset.buffer.asUint8List());
-      addTearDown(() async {
-        await subscription.cancel();
-        await player.dispose();
-        await temporary.delete(recursive: true);
-      });
-      await tester.pumpWidget(
-        MaterialApp(
+  for (final useSurfaceView in [false, true]) {
+    testWidgets(
+      'built-in Media3 ${useSurfaceView ? "SurfaceView" : "TextureView"} renders, seeks, selects captions and reopens',
+      (tester) async {
+        // Deliberately do not call MediaKit.ensureInitialized(): this test must
+        // render through Android Media3 without opening the MPV engine.
+        final backend = Media3PlatformPlayer();
+        final player = Player(platformPlayer: backend);
+        final errors = <String>[];
+        final subscription = player.stream.error.listen(errors.add);
+        final temporary = await Directory.systemTemp.createTemp(
+          'tetotv-media3-smoke-',
+        );
+        final asset = await rootBundle.load('assets/videos/mpv_smoke.mp4');
+        final videoFile = await File(
+          '${temporary.path}/sample.mp4',
+        ).writeAsBytes(asset.buffer.asUint8List());
+        addTearDown(() async {
+          await subscription.cancel();
+          await player.dispose();
+          await temporary.delete(recursive: true);
+        });
+        var hudTapCount = 0;
+        Widget playerView() => MaterialApp(
           home: Scaffold(
             body: Stack(
               children: [
-                Positioned.fill(child: Media3VideoSurface(player: backend)),
-                const Positioned(
+                Positioned.fill(
+                  child: Media3VideoSurface(
+                    player: backend,
+                    useSurfaceView: useSurfaceView,
+                  ),
+                ),
+                Positioned(
                   top: 10,
                   left: 10,
-                  child: Text('TetoTV shared HUD'),
+                  child: TextButton(
+                    onPressed: () => hudTapCount++,
+                    child: const Text('TetoTV shared HUD'),
+                  ),
                 ),
               ],
             ),
           ),
-        ),
-      );
-
-      Future<void> waitUntil(bool Function() condition) async {
-        final watch = Stopwatch()..start();
-        while (!condition() && watch.elapsed < const Duration(seconds: 30)) {
-          await tester.pump(const Duration(milliseconds: 200));
-        }
-        expect(
-          condition(),
-          isTrue,
-          reason:
-              'Media3 did not reach expected state; errors=$errors; '
-              'subtitles=${player.state.tracks.subtitle.map((t) => '${t.id}:${t.language}').toList()}; '
-              'selected=${player.state.track.subtitle.id}',
         );
-      }
+        await tester.pumpWidget(playerView());
 
-      await player.open(Media(videoFile.path));
-      await waitUntil(
-        () =>
-            (player.state.width ?? 0) > 0 &&
-            player.state.position.inMilliseconds > 500,
-      );
-      expect(
-        await backend.readProperty('tetotv-rendered-frame-count'),
-        isNotNull,
-      );
-      await player.pause();
-      await waitUntil(() => !player.state.playing);
-      await player.seek(const Duration(seconds: 1));
-      await waitUntil(
-        () => (player.state.position.inMilliseconds - 1000).abs() < 300,
-      );
-      await player.setRate(1.25);
-      await waitUntil(() => player.state.rate == 1.25);
-      await backend.setOptions({
-        'subtitleSize': 28,
-        'subtitlePosition': 88,
-        'fit': 'contain',
-      });
-      await player.setSubtitleTrack(
-        SubtitleTrack.data(
-          'WEBVTT\n\n00:00.000 --> 00:30.000\nMedia3 caption smoke test\n',
-          title: 'English test',
-          language: 'en',
-        ),
-      );
-      await waitUntil(
-        () => player.state.tracks.subtitle.any((t) => t.language == 'en'),
-      );
-      await player.setSubtitleTrack(SubtitleTrack.no());
-      await waitUntil(() => player.state.track.subtitle.id == 'no');
-      await player.play();
-      await waitUntil(() => player.state.playing);
-      final english = await File(
-        '${temporary.path}/english.vtt',
-      ).writeAsString('WEBVTT\n\n00:00.000 --> 00:30.000\nEnglish sidecar\n');
-      final spanish = await File(
-        '${temporary.path}/spanish.vtt',
-      ).writeAsString('WEBVTT\n\n00:00.000 --> 00:30.000\nSpanish sidecar\n');
-      await player.open(
-        Media(
-          videoFile.path,
-          extras: {
-            'mimeType': 'video/mp4',
-            'subtitles': [
-              {
-                'uri': english.uri.toString(),
-                'title': 'English',
-                'language': 'en',
-                'mimeType': 'text/vtt',
-              },
-              {
-                'uri': spanish.uri.toString(),
-                'title': 'Spanish',
-                'language': 'es',
-                'mimeType': 'text/vtt',
-              },
-            ],
-          },
-        ),
-        play: false,
-      );
-      await waitUntil(
-        () => (player.state.width ?? 0) > 0 && !player.state.buffering,
-      );
-      expect(player.state.playing, isFalse);
-      await waitUntil(
-        () =>
-            player.state.tracks.subtitle
-                .where((t) => t.id.startsWith('sidecar:'))
-                .length ==
-            2,
-      );
-      await player.setSubtitleTrack(
-        SubtitleTrack.uri(
-          spanish.uri.toString(),
-          title: 'Spanish',
-          language: 'es',
-        ),
-      );
-      await waitUntil(() => player.state.track.subtitle.language == 'es');
-      expect(
-        player.state.tracks.subtitle
-            .where((t) => t.id.startsWith('sidecar:'))
-            .length,
-        2,
-      );
-      final selectedAudio = player.state.tracks.audio.firstWhere(
-        (track) => track.id != 'auto' && track.id != 'no',
-      );
-      await player.setAudioTrack(selectedAudio);
-      await waitUntil(() => player.state.track.audio.id == selectedAudio.id);
-      await backend.setDecoderMode('software');
-      await waitUntil(
-        () =>
-            (player.state.width ?? 0) > 0 &&
-            !player.state.buffering &&
-            player.state.track.audio.id == selectedAudio.id &&
-            player.state.track.subtitle.language == 'es',
-      );
-      expect(player.state.playing, isFalse);
-      expect(player.state.rate, 1.25);
-      await backend.setDecoderMode('hardware');
-      await waitUntil(
-        () =>
-            (player.state.width ?? 0) > 0 &&
-            !player.state.buffering &&
-            player.state.track.audio.id == selectedAudio.id &&
-            player.state.track.subtitle.language == 'es',
-      );
-      expect(player.state.playing, isFalse);
-      final screenshot = await backend.screenshot(format: 'image/png');
-      expect(screenshot, isNotNull);
-      expect(screenshot!.take(8), [137, 80, 78, 71, 13, 10, 26, 10]);
-      await player.open(
-        Media(
-          videoFile.path,
-          start: const Duration(seconds: 1),
-          end: const Duration(seconds: 2),
-        ),
-      );
-      await waitUntil(() => player.state.completed);
-      expect(player.state.duration, const Duration(seconds: 2));
-      expect(
-        player.state.position.inMilliseconds,
-        inInclusiveRange(1900, 2100),
-      );
-      expect(errors, isEmpty);
-      expect(tester.takeException(), isNull);
-      await tester.pumpWidget(const SizedBox.shrink());
-      await player.dispose();
-    },
-    timeout: const Timeout(Duration(minutes: 3)),
-  );
+        Future<void> waitUntil(bool Function() condition) async {
+          final watch = Stopwatch()..start();
+          while (!condition() && watch.elapsed < const Duration(seconds: 30)) {
+            await tester.pump(const Duration(milliseconds: 200));
+          }
+          expect(
+            condition(),
+            isTrue,
+            reason:
+                'Media3 did not reach expected state; errors=$errors; '
+                'subtitles=${player.state.tracks.subtitle.map((t) => '${t.id}:${t.language}').toList()}; '
+                'selected=${player.state.track.subtitle.id}',
+          );
+        }
+
+        await player.open(Media(videoFile.path));
+        await waitUntil(
+          () =>
+              (player.state.width ?? 0) > 0 &&
+              player.state.position.inMilliseconds > 500,
+        );
+        expect(
+          await backend.readProperty('tetotv-rendered-frame-count'),
+          isNotNull,
+        );
+        await tester.tap(find.text('TetoTV shared HUD'));
+        await tester.pump();
+        expect(
+          hudTapCount,
+          1,
+          reason: 'Flutter HUD must remain above the video',
+        );
+        await player.pause();
+        await waitUntil(() => !player.state.playing);
+        await player.seek(const Duration(seconds: 1));
+        await waitUntil(
+          () => (player.state.position.inMilliseconds - 1000).abs() < 300,
+        );
+        await player.setRate(1.25);
+        await waitUntil(() => player.state.rate == 1.25);
+        await backend.setOptions({
+          'subtitleSize': 28,
+          'subtitlePosition': 88,
+          'fit': 'contain',
+        });
+        await player.setSubtitleTrack(
+          SubtitleTrack.data(
+            'WEBVTT\n\n00:00.000 --> 00:30.000\nMedia3 caption smoke test\n',
+            title: 'English test',
+            language: 'en',
+          ),
+        );
+        await waitUntil(
+          () => player.state.tracks.subtitle.any((t) => t.language == 'en'),
+        );
+        await player.setSubtitleTrack(SubtitleTrack.no());
+        await waitUntil(() => player.state.track.subtitle.id == 'no');
+        await player.play();
+        await waitUntil(() => player.state.playing);
+        final english = await File(
+          '${temporary.path}/english.vtt',
+        ).writeAsString('WEBVTT\n\n00:00.000 --> 00:30.000\nEnglish sidecar\n');
+        final spanish = await File(
+          '${temporary.path}/spanish.vtt',
+        ).writeAsString('WEBVTT\n\n00:00.000 --> 00:30.000\nSpanish sidecar\n');
+        await player.open(
+          Media(
+            videoFile.path,
+            extras: {
+              'mimeType': 'video/mp4',
+              'subtitles': [
+                {
+                  'uri': english.uri.toString(),
+                  'title': 'English',
+                  'language': 'en',
+                  'mimeType': 'text/vtt',
+                },
+                {
+                  'uri': spanish.uri.toString(),
+                  'title': 'Spanish',
+                  'language': 'es',
+                  'mimeType': 'text/vtt',
+                },
+              ],
+            },
+          ),
+          play: false,
+        );
+        await waitUntil(
+          () => (player.state.width ?? 0) > 0 && !player.state.buffering,
+        );
+        expect(player.state.playing, isFalse);
+        await waitUntil(
+          () =>
+              player.state.tracks.subtitle
+                  .where((t) => t.id.startsWith('sidecar:'))
+                  .length ==
+              2,
+        );
+        await player.setSubtitleTrack(
+          SubtitleTrack.uri(
+            spanish.uri.toString(),
+            title: 'Spanish',
+            language: 'es',
+          ),
+        );
+        await waitUntil(() => player.state.track.subtitle.language == 'es');
+        expect(
+          player.state.tracks.subtitle
+              .where((t) => t.id.startsWith('sidecar:'))
+              .length,
+          2,
+        );
+        final selectedAudio = player.state.tracks.audio.firstWhere(
+          (track) => track.id != 'auto' && track.id != 'no',
+        );
+        await player.setAudioTrack(selectedAudio);
+        await waitUntil(() => player.state.track.audio.id == selectedAudio.id);
+        await backend.setDecoderMode('software');
+        await waitUntil(
+          () =>
+              (player.state.width ?? 0) > 0 &&
+              !player.state.buffering &&
+              player.state.track.audio.id == selectedAudio.id &&
+              player.state.track.subtitle.language == 'es',
+        );
+        expect(player.state.playing, isFalse);
+        expect(player.state.rate, 1.25);
+        await backend.setDecoderMode('hardware');
+        await waitUntil(
+          () =>
+              (player.state.width ?? 0) > 0 &&
+              !player.state.buffering &&
+              player.state.track.audio.id == selectedAudio.id &&
+              player.state.track.subtitle.language == 'es',
+        );
+        expect(player.state.playing, isFalse);
+        final screenshot = await backend.screenshot(format: 'image/png');
+        expect(screenshot, isNotNull);
+        expect(screenshot!.take(8), [137, 80, 78, 71, 13, 10, 26, 10]);
+        for (final fit in ['cover', 'fill', 'contain']) {
+          await backend.setOptions({'fit': fit});
+          await tester.pump(const Duration(milliseconds: 200));
+          expect(tester.takeException(), isNull);
+        }
+        // Recreate only the native view (not the player) to exercise lifecycle
+        // recovery without losing selected tracks or the overlaid Flutter HUD.
+        await tester.pumpWidget(const SizedBox.shrink());
+        await tester.pump();
+        await tester.pumpWidget(playerView());
+        await tester.pump(const Duration(milliseconds: 500));
+        expect(player.state.track.subtitle.language, 'es');
+        await tester.tap(find.text('TetoTV shared HUD'));
+        expect(hudTapCount, 2);
+        await player.play();
+        await waitUntil(() => player.state.playing);
+        await player.open(
+          Media(
+            videoFile.path,
+            start: const Duration(seconds: 1),
+            end: const Duration(seconds: 2),
+          ),
+        );
+        await waitUntil(() => player.state.completed);
+        expect(player.state.duration, const Duration(seconds: 2));
+        expect(
+          player.state.position.inMilliseconds,
+          inInclusiveRange(1900, 2100),
+        );
+        expect(errors, isEmpty);
+        expect(tester.takeException(), isNull);
+        await tester.pumpWidget(const SizedBox.shrink());
+        await player.dispose();
+      },
+      timeout: const Timeout(Duration(minutes: 3)),
+    );
+  }
 }

--- a/lib/features/player/presentation/media3_video_surface.dart
+++ b/lib/features/player/presentation/media3_video_surface.dart
@@ -1,5 +1,8 @@
 import 'package:anime_tv/features/player/application/media3_platform_player.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
 import 'package:flutter/services.dart';
 
 /// Media3 video/subtitle output only. TetoTV owns every control and gesture.
@@ -7,10 +10,12 @@ class Media3VideoSurface extends StatefulWidget {
   const Media3VideoSurface({
     required this.player,
     this.fit = BoxFit.contain,
+    this.useSurfaceView = false,
     super.key,
   });
   final Media3PlatformPlayer player;
   final BoxFit fit;
+  final bool useSurfaceView;
 
   @override
   State<Media3VideoSurface> createState() => _Media3VideoSurfaceState();
@@ -51,16 +56,49 @@ class _Media3VideoSurfaceState extends State<Media3VideoSurface> {
     builder: (context, snapshot) {
       if (!snapshot.hasData) return const ColoredBox(color: Colors.black);
       return IgnorePointer(
-        child: ExcludeFocus(
-          child: AndroidView(
-            key: ValueKey('media3-video-${snapshot.data}'),
-            viewType: 'dev.tetotv/media3/video',
-            layoutDirection: TextDirection.ltr,
-            creationParams: {'id': snapshot.data},
-            creationParamsCodec: const StandardMessageCodec(),
-          ),
-        ),
+        child: ExcludeFocus(child: _buildPlatformView(snapshot.data!)),
       );
     },
   );
+
+  Widget _buildPlatformView(int id) {
+    const viewType = 'dev.tetotv/media3/video';
+    final creationParams = {
+      'id': id,
+      'surfaceType': widget.useSurfaceView ? 'surface' : 'texture',
+    };
+    if (!widget.useSurfaceView) {
+      // Preserve the current rendering path when the experimental mode is off.
+      return AndroidView(
+        key: ValueKey('media3-video-$id'),
+        viewType: viewType,
+        layoutDirection: TextDirection.ltr,
+        creationParams: creationParams,
+        creationParamsCodec: const StandardMessageCodec(),
+      );
+    }
+    // A SurfaceView needs native hierarchy composition; putting it through the
+    // default texture-backed AndroidView would defeat the separate video layer.
+    // Do not enable any global Flutter renderer flag: MPV remains unchanged.
+    return PlatformViewLink(
+      key: ValueKey('media3-surface-video-$id'),
+      viewType: viewType,
+      surfaceFactory: (context, controller) => AndroidViewSurface(
+        controller: controller as AndroidViewController,
+        gestureRecognizers: const <Factory<OneSequenceGestureRecognizer>>{},
+        hitTestBehavior: PlatformViewHitTestBehavior.transparent,
+      ),
+      onCreatePlatformView: (params) =>
+          PlatformViewsService.initExpensiveAndroidView(
+              id: params.id,
+              viewType: viewType,
+              layoutDirection: TextDirection.ltr,
+              creationParams: creationParams,
+              creationParamsCodec: const StandardMessageCodec(),
+              onFocus: () => params.onFocusChanged(true),
+            )
+            ..addOnPlatformViewCreatedListener(params.onPlatformViewCreated)
+            ..create(),
+    );
+  }
 }

--- a/lib/features/player/presentation/tv_player_screen.dart
+++ b/lib/features/player/presentation/tv_player_screen.dart
@@ -837,6 +837,7 @@ class _MpvTvPlayerScreenState extends ConsumerState<MpvTvPlayerScreen>
   late final Player _player;
   VideoController? _controller;
   late final bool _usesMedia3;
+  late final bool _media3SurfaceViewEnabled;
   Media3PlatformPlayer? _media3Player;
   String get _engineKey => _usesMedia3 ? 'media3' : 'mpv';
   String get _engineLabel => _usesMedia3 ? 'Media3 (Built in)' : 'MPV';
@@ -1414,6 +1415,11 @@ class _MpvTvPlayerScreenState extends ConsumerState<MpvTvPlayerScreen>
       platform: defaultTargetPlatform,
       isWeb: kIsWeb,
     );
+    // Rendering is fixed for this playback session. Settings changes apply on
+    // the next open, without recreating a playing surface or affecting MPV.
+    _media3SurfaceViewEnabled =
+        _usesMedia3 &&
+        ref.read(settingsPreferencesProvider).media3SurfaceViewEnabled;
     final initialParty = ref.read(watchPartyControllerProvider);
     _watchPartyStatus = watchPartyPlayerStatus(initialParty);
     _watchPartyActive = initialParty.isActive;
@@ -6241,6 +6247,9 @@ class _MpvTvPlayerScreenState extends ConsumerState<MpvTvPlayerScreen>
   }
 
   Future<void> _captureTrickplay(Duration target, int generation) async {
+    // Media3 scrubbing uses only the shared timestamp bubble, not a scene
+    // thumbnail. Skip the capture too, including committed and button seeks.
+    if (_usesMedia3) return;
     try {
       // media_kit can complete seek before the newly decoded frame reaches
       // MPV's screenshot surface. Give it one short frame window, then keep
@@ -7068,7 +7077,11 @@ class _MpvTvPlayerScreenState extends ConsumerState<MpvTvPlayerScreen>
               fit: StackFit.expand,
               children: [
                 if (!_engineHandoffInProgress && _media3Player != null)
-                  Media3VideoSurface(player: _media3Player!, fit: _videoFit)
+                  Media3VideoSurface(
+                    player: _media3Player!,
+                    fit: _videoFit,
+                    useSurfaceView: _media3SurfaceViewEnabled,
+                  )
                 else if (!_engineHandoffInProgress)
                   Video(
                     controller: _controller!,
@@ -7162,7 +7175,10 @@ class _MpvTvPlayerScreenState extends ConsumerState<MpvTvPlayerScreen>
                             seekForwardSeconds: _seekForwardSeconds,
                             onSeek: _seekTo,
                             onSeekPreview:
-                                supportsProvisionalSeekPreview(_currentStream)
+                                !_usesMedia3 &&
+                                    supportsProvisionalSeekPreview(
+                                      _currentStream,
+                                    )
                                 ? (target) {
                                     unawaited(_seekTo(target));
                                   }
@@ -7273,7 +7289,7 @@ class _MpvTvPlayerScreenState extends ConsumerState<MpvTvPlayerScreen>
                       ),
                     ),
                   ),
-                if (_seekPreview case final preview?)
+                if (_seekPreview case final preview? when !_usesMedia3)
                   Positioned(
                     left: playerSeekPreviewLeft(
                       viewportWidth: MediaQuery.sizeOf(context).width,

--- a/lib/features/settings/application/settings_preferences_controller.dart
+++ b/lib/features/settings/application/settings_preferences_controller.dart
@@ -45,6 +45,7 @@ const _navigationSoundsKey = 'audio_navigation_sounds';
 const _clickSoundsKey = 'audio_click_sounds';
 const _defaultLandingPageKey = 'navigation_default_landing_page';
 const _preferredPlayerKey = 'player_preferred_engine';
+const _media3SurfaceViewEnabledKey = 'player_media3_surface_view_enabled';
 const _preferredAudioKey = 'player_preferred_audio';
 const _preferredAudioLanguageKey = 'player_preferred_audio_language';
 const _preferredCaptionsKey = 'player_preferred_captions';
@@ -467,6 +468,7 @@ class SettingsPreferences {
     this.clickSounds = true,
     this.defaultLandingPage = LandingPage.home,
     this.preferredPlayer = PreferredPlayer.mpv,
+    this.media3SurfaceViewEnabled = false,
     this.preferredAudio = PlaybackAudioPreference.dub,
     this.preferredAudioLanguage = 'auto',
     this.preferredCaptionMode = PreferredCaptionMode.automatic,
@@ -541,6 +543,9 @@ class SettingsPreferences {
   final bool clickSounds;
   final LandingPage defaultLandingPage;
   final PreferredPlayer preferredPlayer;
+
+  /// Rendering preference for Media3 only; MPV keeps its existing renderer.
+  final bool media3SurfaceViewEnabled;
   final PlaybackAudioPreference preferredAudio;
   final String preferredAudioLanguage;
   final PreferredCaptionMode preferredCaptionMode;
@@ -625,6 +630,7 @@ class SettingsPreferences {
     bool? clickSounds,
     LandingPage? defaultLandingPage,
     PreferredPlayer? preferredPlayer,
+    bool? media3SurfaceViewEnabled,
     PlaybackAudioPreference? preferredAudio,
     String? preferredAudioLanguage,
     PreferredCaptionMode? preferredCaptionMode,
@@ -693,6 +699,8 @@ class SettingsPreferences {
     clickSounds: clickSounds ?? this.clickSounds,
     defaultLandingPage: defaultLandingPage ?? this.defaultLandingPage,
     preferredPlayer: preferredPlayer ?? this.preferredPlayer,
+    media3SurfaceViewEnabled:
+        media3SurfaceViewEnabled ?? this.media3SurfaceViewEnabled,
     preferredAudio: preferredAudio ?? this.preferredAudio,
     preferredAudioLanguage: preferredAudioLanguage == null
         ? this.preferredAudioLanguage
@@ -985,6 +993,8 @@ class SettingsPreferencesController extends StateNotifier<SettingsPreferences> {
       // Preferred audio language is append-only. `auto` preserves the legacy
       // Dub/Sub behavior until the viewer explicitly chooses a language.
       _safeRead(_preferredAudioLanguageKey),
+      // Media3 rendering is append-only; missing values keep TextureView.
+      _safeRead(_media3SurfaceViewEnabledKey),
     ]);
 
     bool canRestore(String key, int index) {
@@ -1362,6 +1372,11 @@ class SettingsPreferencesController extends StateNotifier<SettingsPreferences> {
         preferredAudioLanguage: _normalizePreferredAudioLanguage(valueAt(60)),
       );
     }
+    if (canRestore(_media3SurfaceViewEnabledKey, 61)) {
+      restored = restored.copyWith(
+        media3SurfaceViewEnabled: valueAt(61) == 'true',
+      );
+    }
     if (restored.preferredPlayer == PreferredPlayer.external &&
         (!restored.externalPlayerEnabled ||
             restored.selectedExternalPlayerPackage == null)) {
@@ -1677,6 +1692,19 @@ class SettingsPreferencesController extends StateNotifier<SettingsPreferences> {
   Future<void> setPreferredPlayer(PreferredPlayer value) => _update(
     state.copyWith(preferredPlayer: value),
     {_preferredPlayerKey: value.name},
+  );
+
+  /// SurfaceView opts the next video into Media3. Later explicit player
+  /// choices remain independent, and disabling only restores TextureView.
+  Future<void> setMedia3SurfaceViewEnabled(bool value) => _update(
+    state.copyWith(
+      media3SurfaceViewEnabled: value,
+      preferredPlayer: value ? PreferredPlayer.media3 : state.preferredPlayer,
+    ),
+    {
+      _media3SurfaceViewEnabledKey: value.toString(),
+      if (value) _preferredPlayerKey: PreferredPlayer.media3.name,
+    },
   );
 
   Future<void> setDefaultExternalPlayer({
@@ -2065,6 +2093,7 @@ class SettingsPreferencesController extends StateNotifier<SettingsPreferences> {
       _seekBackSecondsKey,
       _seekForwardSecondsKey,
       _preferredPlayerKey,
+      _media3SurfaceViewEnabledKey,
       _preferredAudioKey,
       _preferredAudioLanguageKey,
       _preferredCaptionsKey,
@@ -2087,6 +2116,7 @@ class SettingsPreferencesController extends StateNotifier<SettingsPreferences> {
       seekBackSeconds: defaults.seekBackSeconds,
       seekForwardSeconds: defaults.seekForwardSeconds,
       preferredPlayer: defaults.preferredPlayer,
+      media3SurfaceViewEnabled: defaults.media3SurfaceViewEnabled,
       preferredAudio: defaults.preferredAudio,
       preferredAudioLanguage: defaults.preferredAudioLanguage,
       preferredCaptionMode: defaults.preferredCaptionMode,

--- a/lib/features/settings/presentation/accounts_screen.dart
+++ b/lib/features/settings/presentation/accounts_screen.dart
@@ -33,6 +33,7 @@ import 'package:anime_tv/features/settings/presentation/theme_studio_screen.dart
 import 'package:anime_tv/features/streaming/domain/debrid_service.dart';
 import 'package:anime_tv/features/streaming/domain/stream_ranking_preferences.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/foundation.dart' show defaultTargetPlatform, kIsWeb;
 import 'package:flutter/rendering.dart' show ScrollCacheExtent;
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -239,6 +240,10 @@ extension _SettingsSectionMetadata on _SettingsSection {
       'Default player',
       'MPV',
       'Media3',
+      'Media3 SurfaceView',
+      'SurfaceView',
+      'TextureView',
+      'Video rendering',
       'ExoPlayer',
       'Built-in player',
       'Preferred audio',
@@ -564,6 +569,9 @@ class _AccountsScreenState extends ConsumerState<AccountsScreen> {
   );
   final _playerControlsSectionFocus = FocusNode(
     debugLabel: 'accounts.section.player-controls',
+  );
+  final _media3SurfaceViewFocus = FocusNode(
+    debugLabel: 'accounts.playback.media3-surface-view',
   );
   final _fillerIndicatorsFocus = FocusNode(
     debugLabel: 'accounts.playback.filler-indicators',
@@ -1106,6 +1114,10 @@ class _AccountsScreenState extends ConsumerState<AccountsScreen> {
       'text color' => _captionTextColorFocus,
       'text size' => _captionTextSizeFocus,
       'default player' => _playerControlsSectionFocus,
+      'media3 surfaceview' ||
+      'surfaceview' ||
+      'textureview' ||
+      'video rendering' => _media3SurfaceViewFocus,
       'filler episode labels' => _fillerIndicatorsFocus,
       'debrid provider' ||
       'real debrid' ||
@@ -1333,6 +1345,7 @@ class _AccountsScreenState extends ConsumerState<AccountsScreen> {
     _captionTextColorFocus.dispose();
     _captionTextSizeFocus.dispose();
     _playerControlsSectionFocus.dispose();
+    _media3SurfaceViewFocus.dispose();
     _fillerIndicatorsFocus.dispose();
     _customizationResetFocus.dispose();
     _setupFocus.dispose();
@@ -1529,6 +1542,7 @@ class _AccountsScreenState extends ConsumerState<AccountsScreen> {
       _captionTextColorFocus,
       _captionTextSizeFocus,
       _playerControlsSectionFocus,
+      _media3SurfaceViewFocus,
       _customizationResetFocus,
       ...shelfNodes,
       _customizationFocus,
@@ -2674,6 +2688,7 @@ class _AccountsScreenState extends ConsumerState<AccountsScreen> {
       captionTextColorFocusNode: _captionTextColorFocus,
       captionTextSizeFocusNode: _captionTextSizeFocus,
       playerControlsSectionFocusNode: _playerControlsSectionFocus,
+      media3SurfaceViewFocusNode: _media3SurfaceViewFocus,
       fillerIndicatorsFocusNode: _fillerIndicatorsFocus,
       resetFocusNode: _customizationResetFocus,
       expandedSections: _expandedCustomizationSections,
@@ -5874,6 +5889,7 @@ class _CustomizationPanel extends StatelessWidget {
     required this.captionTextColorFocusNode,
     required this.captionTextSizeFocusNode,
     required this.playerControlsSectionFocusNode,
+    required this.media3SurfaceViewFocusNode,
     required this.fillerIndicatorsFocusNode,
     required this.resetFocusNode,
     required this.expandedSections,
@@ -5908,6 +5924,7 @@ class _CustomizationPanel extends StatelessWidget {
   final FocusNode captionTextColorFocusNode;
   final FocusNode captionTextSizeFocusNode;
   final FocusNode playerControlsSectionFocusNode;
+  final FocusNode media3SurfaceViewFocusNode;
   final FocusNode fillerIndicatorsFocusNode;
   final FocusNode resetFocusNode;
   final Set<_CustomizationSection> expandedSections;
@@ -6354,6 +6371,19 @@ class _CustomizationPanel extends StatelessWidget {
                       ? playerControlsSectionFocusNode
                       : null,
                 ),
+                if (!kIsWeb && defaultTargetPlatform == TargetPlatform.android)
+                  _AppearanceToggleRow(
+                    key: const ValueKey('settings-media3-surface-view'),
+                    label: 'Media3 SurfaceView',
+                    subtitle: preferences.media3SurfaceViewEnabled
+                        ? 'SurfaceView (experimental). Media3 only; applies to the next video.'
+                        : 'TextureView (default). Turn on to use SurfaceView and select Media3 for the next video.',
+                    icon: Icons.video_settings_rounded,
+                    focusNode: media3SurfaceViewFocusNode,
+                    value: preferences.media3SurfaceViewEnabled,
+                    showDivider: true,
+                    onChanged: controller.setMedia3SurfaceViewEnabled,
+                  ),
                 const SizedBox(height: 8),
                 _AppearanceSelectionRow<PlaybackAudioPreference>(
                   label: 'Preferred audio',
@@ -6577,7 +6607,9 @@ class _ExternalPlayerDefaultSelectionState
                 }
                 if (value == _media3Value) {
                   unawaited(
-                    widget.controller.setPreferredPlayer(PreferredPlayer.media3),
+                    widget.controller.setPreferredPlayer(
+                      PreferredPlayer.media3,
+                    ),
                   );
                   return;
                 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: 'none'
 # Public and Beta artifacts built from the same source use one monotonically
 # increasing Android versionCode. The project default carries the Beta display
 # version; the Public universal APK overrides the build name to the 1.x line.
-version: 2.0.73+410050
+version: 2.0.74+410051
 
 environment:
   sdk: ^3.12.2

--- a/test/media3_player_screen_integration_test.dart
+++ b/test/media3_player_screen_integration_test.dart
@@ -73,6 +73,52 @@ void main() {
     expect(metrics, contains('return media3.readProperty(property)'));
   });
 
+  test('alternate surface is captured only for Media3 at session creation', () {
+    expect(source, contains('late final bool _media3SurfaceViewEnabled;'));
+    expect(
+      RegExp(
+        r'_media3SurfaceViewEnabled\s*=\s*_usesMedia3 &&\s*ref.read\(settingsPreferencesProvider\).media3SurfaceViewEnabled',
+      ).hasMatch(source),
+      isTrue,
+    );
+    expect(source, contains('useSurfaceView: _media3SurfaceViewEnabled'));
+    final surface = File(
+      'lib/features/player/presentation/media3_video_surface.dart',
+    ).readAsStringSync();
+    expect(surface, contains('this.useSurfaceView = false'));
+    expect(surface, contains('if (!widget.useSurfaceView)'));
+    expect(surface, contains('return AndroidView('));
+    expect(surface, contains('return PlatformViewLink('));
+    expect(surface, contains('PlatformViewsService.initExpensiveAndroidView('));
+    expect(surface, contains("widget.useSurfaceView ? 'surface' : 'texture'"));
+  });
+
+  test('Media3 seeks never capture or render a scene thumbnail', () {
+    final capture = method(
+      'Future<void> _captureTrickplay(',
+      'Future<void> _openAudioTrackPicker()',
+    );
+    expect(capture, contains('if (_usesMedia3) return;'));
+    expect(
+      capture.indexOf('if (_usesMedia3) return;'),
+      lessThan(capture.indexOf('await Future<void>.delayed')),
+    );
+    expect(capture, contains("_player.screenshot(format: 'image/jpeg')"));
+    expect(
+      source,
+      contains('if (_seekPreview case final preview? when !_usesMedia3)'),
+    );
+    expect(
+      RegExp(
+        r'onSeekPreview:\s*!_usesMedia3 &&\s*supportsProvisionalSeekPreview\(\s*_currentStream,?\s*\)',
+      ).hasMatch(source),
+      isTrue,
+    );
+    // Final seek commits still use the normal queue and diagnostics.
+    expect(source, contains('onSeek: _seekTo'));
+    expect(source, contains('await _seekWithPerformanceDiagnostics(target)'));
+  });
+
   test(
     'MPV performance recovery and surface internals do not run on Media3',
     () {

--- a/test/settings_player_selection_test.dart
+++ b/test/settings_player_selection_test.dart
@@ -35,18 +35,38 @@ void main() {
         await tester.pumpAndSettle();
 
         final row = find.byKey(const ValueKey('settings-default-player'));
+        final surfaceViewToggle = find.byKey(
+          const ValueKey('settings-media3-surface-view'),
+        );
+        final container = ProviderScope.containerOf(tester.element(row));
+        expect(
+          container.read(settingsPreferencesProvider).media3SurfaceViewEnabled,
+          isFalse,
+        );
+        await tester.ensureVisible(surfaceViewToggle);
+        await tester.pumpAndSettle();
+        await tester.tap(surfaceViewToggle);
+        await tester.pumpAndSettle();
+        expect(
+          container.read(settingsPreferencesProvider).media3SurfaceViewEnabled,
+          isTrue,
+        );
+        expect(
+          container.read(settingsPreferencesProvider).preferredPlayer,
+          PreferredPlayer.media3,
+        );
+
         await tester.ensureVisible(row);
         await tester.pumpAndSettle();
         await tester.tap(row);
         await tester.pumpAndSettle();
 
-        expect(find.text('Media3 (Built in)'), findsOneWidget);
+        expect(find.text('Media3 (Built in)'), findsWidgets);
         expect(find.text('MPV (Built in)'), findsWidgets);
         expect(find.text('Unavailable player'), findsNothing);
-        await tester.tap(find.text('Media3 (Built in)'));
+        await tester.tap(find.text('Media3 (Built in)').last);
         await tester.pumpAndSettle();
 
-        final container = ProviderScope.containerOf(tester.element(row));
         expect(
           container.read(settingsPreferencesProvider).preferredPlayer,
           PreferredPlayer.media3,
@@ -67,8 +87,53 @@ void main() {
           container.read(settingsPreferencesProvider).preferredPlayer,
           PreferredPlayer.mpv,
         );
+        expect(
+          container.read(settingsPreferencesProvider).media3SurfaceViewEnabled,
+          isTrue,
+        );
+        await tester.ensureVisible(surfaceViewToggle);
+        await tester.pumpAndSettle();
+        await tester.tap(surfaceViewToggle);
+        await tester.pumpAndSettle();
+        expect(
+          container.read(settingsPreferencesProvider).media3SurfaceViewEnabled,
+          isFalse,
+        );
+        expect(
+          container.read(settingsPreferencesProvider).preferredPlayer,
+          PreferredPlayer.mpv,
+        );
         expect(tester.takeException(), isNull);
       },
     );
   }
+
+  testWidgets(
+    'Media3 SurfaceView toggle is hidden outside Android',
+    (tester) async {
+      FlutterSecureStorage.setMockInitialValues({});
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [isTelevisionProvider.overrideWithValue(false)],
+          child: MaterialApp(
+            theme: AppTheme.dark,
+            home: const TvShortcuts(child: AccountsScreen()),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+      await tester.tap(find.byKey(const ValueKey('settings-area-playback')));
+      await tester.pumpAndSettle();
+      expect(
+        find.byKey(const ValueKey('settings-default-player')),
+        findsOneWidget,
+      );
+      expect(
+        find.byKey(const ValueKey('settings-media3-surface-view')),
+        findsNothing,
+      );
+      expect(tester.takeException(), isNull);
+    },
+    variant: const TargetPlatformVariant({TargetPlatform.windows}),
+  );
 }

--- a/test/settings_preferences_controller_test.dart
+++ b/test/settings_preferences_controller_test.dart
@@ -547,48 +547,191 @@ void main() {
     expect(restored.state.externalPlayerEnabled, isTrue);
   });
 
-  test('MPV stays the default and Media3 persists as a built-in choice', () async {
+  test(
+    'MPV stays the default and Media3 persists as a built-in choice',
+    () async {
+      FlutterSecureStorage.setMockInitialValues({});
+      const storage = FlutterSecureStorage();
+      final controller = SettingsPreferencesController(storage);
+      await controller.load();
+
+      expect(controller.state.preferredPlayer, PreferredPlayer.mpv);
+      expect(PreferredPlayer.media3.displayName, 'Media3 (Built in)');
+
+      await controller.setPreferredPlayer(PreferredPlayer.media3);
+      expect(await storage.read(key: 'player_preferred_engine'), 'media3');
+      final restored = SettingsPreferencesController(storage);
+      await restored.load();
+
+      expect(restored.state.preferredPlayer, PreferredPlayer.media3);
+      expect(restored.state.externalPlayerEnabled, isFalse);
+      expect(restored.state.selectedExternalPlayerPackage, isNull);
+
+      await restored.setPreferredPlayer(PreferredPlayer.mpv);
+      final switchedBack = SettingsPreferencesController(storage);
+      await switchedBack.load();
+      expect(switchedBack.state.preferredPlayer, PreferredPlayer.mpv);
+    },
+  );
+
+  test(
+    'disabling external handoff preserves a selected Media3 engine',
+    () async {
+      FlutterSecureStorage.setMockInitialValues({});
+      const storage = FlutterSecureStorage();
+      final controller = SettingsPreferencesController(storage);
+      await controller.setDefaultExternalPlayer(
+        packageName: 'org.example.player',
+        label: 'Example Player',
+      );
+      await controller.setPreferredPlayer(PreferredPlayer.media3);
+      await controller.setExternalPlayerEnabled(false);
+
+      final restored = SettingsPreferencesController(storage);
+      await restored.load();
+      expect(restored.state.preferredPlayer, PreferredPlayer.media3);
+      expect(restored.state.externalPlayerEnabled, isFalse);
+      expect(restored.state.selectedExternalPlayerPackage, isNull);
+      expect(restored.state.selectedExternalPlayerLabel, isNull);
+    },
+  );
+
+  test(
+    'Media3 rendering defaults to TextureView for existing installs',
+    () async {
+      for (final storedValue in [null, 'false', 'invalid']) {
+        FlutterSecureStorage.setMockInitialValues({
+          'player_preferred_engine': 'media3',
+          'player_media3_surface_view_enabled': ?storedValue,
+        });
+        final controller = SettingsPreferencesController(
+          const FlutterSecureStorage(),
+        );
+        addTearDown(controller.dispose);
+        expect(controller.state.media3SurfaceViewEnabled, isFalse);
+        await controller.load();
+        expect(controller.state.media3SurfaceViewEnabled, isFalse);
+        expect(controller.state.preferredPlayer, PreferredPlayer.media3);
+      }
+    },
+  );
+
+  test(
+    'enabling SurfaceView selects Media3 and persists both choices',
+    () async {
+      FlutterSecureStorage.setMockInitialValues({});
+      const storage = FlutterSecureStorage();
+      final controller = SettingsPreferencesController(storage);
+      addTearDown(controller.dispose);
+      await controller.load();
+      await controller.setDefaultExternalPlayer(
+        packageName: 'org.example.player',
+        label: 'Example player',
+      );
+
+      final save = controller.setMedia3SurfaceViewEnabled(true);
+      expect(controller.state.media3SurfaceViewEnabled, isTrue);
+      expect(controller.state.preferredPlayer, PreferredPlayer.media3);
+      await save;
+      expect(
+        await storage.read(key: 'player_media3_surface_view_enabled'),
+        'true',
+      );
+      expect(await storage.read(key: 'player_preferred_engine'), 'media3');
+
+      final restored = SettingsPreferencesController(storage);
+      addTearDown(restored.dispose);
+      await restored.load();
+      expect(restored.state.media3SurfaceViewEnabled, isTrue);
+      expect(restored.state.preferredPlayer, PreferredPlayer.media3);
+      expect(restored.state.externalPlayerEnabled, isTrue);
+      expect(
+        restored.state.selectedExternalPlayerPackage,
+        'org.example.player',
+      );
+
+      await restored.setMedia3SurfaceViewEnabled(false);
+      expect(restored.state.media3SurfaceViewEnabled, isFalse);
+      expect(restored.state.preferredPlayer, PreferredPlayer.media3);
+      expect(
+        await storage.read(key: 'player_media3_surface_view_enabled'),
+        'false',
+      );
+      expect(await storage.read(key: 'player_preferred_engine'), 'media3');
+    },
+  );
+
+  test('SurfaceView preference never overrides a later MPV choice', () async {
     FlutterSecureStorage.setMockInitialValues({});
     const storage = FlutterSecureStorage();
     final controller = SettingsPreferencesController(storage);
-    await controller.load();
+    addTearDown(controller.dispose);
+    await controller.setMedia3SurfaceViewEnabled(true);
+    await controller.setPreferredPlayer(PreferredPlayer.mpv);
 
-    expect(controller.state.preferredPlayer, PreferredPlayer.mpv);
-    expect(PreferredPlayer.media3.displayName, 'Media3 (Built in)');
-
-    await controller.setPreferredPlayer(PreferredPlayer.media3);
-    expect(await storage.read(key: 'player_preferred_engine'), 'media3');
     final restored = SettingsPreferencesController(storage);
+    addTearDown(restored.dispose);
     await restored.load();
+    expect(restored.state.media3SurfaceViewEnabled, isTrue);
+    expect(restored.state.preferredPlayer, PreferredPlayer.mpv);
 
-    expect(restored.state.preferredPlayer, PreferredPlayer.media3);
-    expect(restored.state.externalPlayerEnabled, isFalse);
-    expect(restored.state.selectedExternalPlayerPackage, isNull);
-
-    await restored.setPreferredPlayer(PreferredPlayer.mpv);
-    final switchedBack = SettingsPreferencesController(storage);
-    await switchedBack.load();
-    expect(switchedBack.state.preferredPlayer, PreferredPlayer.mpv);
+    await restored.setMedia3SurfaceViewEnabled(false);
+    expect(restored.state.media3SurfaceViewEnabled, isFalse);
+    expect(restored.state.preferredPlayer, PreferredPlayer.mpv);
+    expect(await storage.read(key: 'player_preferred_engine'), 'mpv');
   });
 
-  test('disabling external handoff preserves a selected Media3 engine', () async {
+  test('full preference reset restores Media3 TextureView', () async {
     FlutterSecureStorage.setMockInitialValues({});
     const storage = FlutterSecureStorage();
     final controller = SettingsPreferencesController(storage);
-    await controller.setDefaultExternalPlayer(
-      packageName: 'org.example.player',
-      label: 'Example Player',
+    addTearDown(controller.dispose);
+    await controller.setMedia3SurfaceViewEnabled(true);
+    expect(
+      controller.state.copyWith(loaded: true).media3SurfaceViewEnabled,
+      isTrue,
     );
-    await controller.setPreferredPlayer(PreferredPlayer.media3);
-    await controller.setExternalPlayerEnabled(false);
+    await controller.resetAppearance();
+    expect(controller.state.media3SurfaceViewEnabled, isFalse);
+    expect(controller.state.preferredPlayer, PreferredPlayer.mpv);
+    expect(
+      await storage.read(key: 'player_media3_surface_view_enabled'),
+      isNull,
+    );
 
     final restored = SettingsPreferencesController(storage);
+    addTearDown(restored.dispose);
     await restored.load();
-    expect(restored.state.preferredPlayer, PreferredPlayer.media3);
-    expect(restored.state.externalPlayerEnabled, isFalse);
-    expect(restored.state.selectedExternalPlayerPackage, isNull);
-    expect(restored.state.selectedExternalPlayerLabel, isNull);
+    expect(restored.state.media3SurfaceViewEnabled, isFalse);
   });
+
+  for (final beforeLoad in [true, false]) {
+    test(
+      'SurfaceView choice ${beforeLoad ? 'before' : 'during'} startup survives stale restore',
+      () async {
+        FlutterSecureStorage.setMockInitialValues({});
+        final gate = Completer<void>();
+        final controller = SettingsPreferencesController(
+          const FlutterSecureStorage(),
+          readValue: (key) async {
+            await gate.future;
+            return const {
+              'player_preferred_engine': 'mpv',
+              'player_media3_surface_view_enabled': 'false',
+            }[key];
+          },
+        );
+        addTearDown(controller.dispose);
+        if (beforeLoad) await controller.setMedia3SurfaceViewEnabled(true);
+        final load = controller.load();
+        if (!beforeLoad) await controller.setMedia3SurfaceViewEnabled(true);
+        gate.complete();
+        await load;
+        expect(controller.state.media3SurfaceViewEnabled, isTrue);
+        expect(controller.state.preferredPlayer, PreferredPlayer.media3);
+      },
+    );
+  }
 
   test(
     'specific default external player persists and can fall back to MPV',
@@ -1303,7 +1446,7 @@ void main() {
       gate.complete();
       await Future.wait([firstLoad, duplicateLoad]);
 
-      expect(reads, 61, reason: 'duplicate startup loads must be coalesced');
+      expect(reads, 62, reason: 'duplicate startup loads must be coalesced');
       expect(controller.state.webStreamsEnabled, isTrue);
       expect(controller.state.navigationSounds, isFalse);
     },

--- a/test/teto_player_chrome_test.dart
+++ b/test/teto_player_chrome_test.dart
@@ -928,6 +928,67 @@ void main() {
     expect(tester.takeException(), isNull);
   });
 
+  testWidgets(
+    'Media3-style scrubbing keeps the time bubble without scene previews',
+    (tester) async {
+      final playFocus = FocusNode();
+      final progressFocus = FocusNode();
+      final seeks = <Duration>[];
+      addTearDown(playFocus.dispose);
+      addTearDown(progressFocus.dispose);
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: TetoPlayerChrome(
+              engineKey: 'media3',
+              title: 'Episode',
+              streamLabel: 'Stream',
+              position: const Duration(minutes: 3),
+              duration: const Duration(minutes: 24),
+              isPlaying: true,
+              playFocusNode: playFocus,
+              progressFocusNode: progressFocus,
+              seekBackSeconds: 10,
+              seekForwardSeconds: 30,
+              onSeek: seeks.add,
+              onSeekPreview: null,
+              onRewind: () {},
+              onPlayPause: () {},
+              onForward: () {},
+              onAudio: () {},
+              onSubtitles: () {},
+              onPicture: () {},
+              onOptions: () {},
+              onDismiss: () {},
+            ),
+          ),
+        ),
+      );
+
+      progressFocus.requestFocus();
+      await tester.pump();
+      await tester.sendKeyDownEvent(LogicalKeyboardKey.arrowRight);
+      await tester.pump(const Duration(milliseconds: 150));
+      final bubble = find.byKey(
+        const ValueKey('media3-player-seek-time-bubble'),
+      );
+      expect(bubble, findsOneWidget);
+      expect(
+        find.descendant(of: bubble, matching: find.text('03:30')),
+        findsOneWidget,
+      );
+      expect(seeks, isEmpty);
+      expect(find.byType(Image), findsNothing);
+
+      await tester.sendKeyUpEvent(LogicalKeyboardKey.arrowRight);
+      await tester.pump();
+      expect(seeks, [const Duration(minutes: 3, seconds: 30)]);
+      expect(find.byType(Image), findsNothing);
+      expect(tester.takeException(), isNull);
+    },
+  );
+
   testWidgets('held TV scrubbing shows its target time and avoids exact EOF', (
     tester,
   ) async {

--- a/tool/release/native_playback_manifest.json
+++ b/tool/release/native_playback_manifest.json
@@ -375,10 +375,10 @@
     {
       "path": "lib/arm64-v8a/libapp.so",
       "size": 13894544,
-      "sha256": "727e01943f798fdae2042267931adfbbb75d46bdc7f3c726dfee1c071ba10e2e",
-      "origin": "TetoTV Flutter application AOT 2.0.73",
+      "sha256": "672774178622f7cc1e5c4e18a6c8c987daf610fcc8950076682a38a913dc1200",
+      "origin": "TetoTV Flutter application AOT 2.0.74",
       "license": "MIT",
-      "sourceLocator": "Git tag v2.0.73",
+      "sourceLocator": "Git tag v2.0.74",
       "noticeLocator": "LICENSE"
     },
     {
@@ -423,7 +423,7 @@
       "sha256": "dc05f53278b2733094f12aeaed54c080329309762ce49e6de4118e4bfb0fff55",
       "origin": "TetoTV source build of media-kit Android helper at 42054e5d479f39ccbb0ae604862e2bcaf59b74c2",
       "license": "MIT",
-      "sourceLocator": "TetoTV-v2.0.73-native-playback-sources.zip: sources/media-kit-android-helper-42054e5d479f39ccbb0ae604862e2bcaf59b74c2.zip",
+      "sourceLocator": "TetoTV-v2.0.74-native-playback-sources.zip: sources/media-kit-android-helper-42054e5d479f39ccbb0ae604862e2bcaf59b74c2.zip",
       "noticeLocator": "assets/legal/native/MEDIA_KIT_ANDROID_HELPER_LICENSE.txt; assets/legal/native/NATIVE_PLAYBACK_NOTICE.txt"
     },
     {
@@ -432,7 +432,7 @@
       "sha256": "a7399d0be70844e5ee94cc5b1acc1516571113c50561fe0a5d05b49101c53ef2",
       "origin": "TetoTV source build of the pinned mpv and FFmpeg native playback stack",
       "license": "LGPL-3.0-or-later (conservative combined classification) plus component terms",
-      "sourceLocator": "TetoTV-v2.0.73-native-playback-sources.zip and tool/native/build_native_playback.sh",
+      "sourceLocator": "TetoTV-v2.0.74-native-playback-sources.zip and tool/native/build_native_playback.sh",
       "noticeLocator": "assets/legal/native/NATIVE_PLAYBACK_NOTICE.txt and its referenced exact license assets"
     },
     {
@@ -450,16 +450,16 @@
       "sha256": "263ba714570fb3acfc308cce52776b00506ec8809d225617e52352336144cfa2",
       "origin": "TetoTV source build of the pinned libtorrent4j and libtorrent-rasterbar stack",
       "license": "Mixed MIT, BSD, Boost-1.0, Apache-2.0, and MPL-2.0 component terms",
-      "sourceLocator": "TetoTV-v2.0.73-native-playback-sources.zip and tool/native/build_native_playback.sh",
+      "sourceLocator": "TetoTV-v2.0.74-native-playback-sources.zip and tool/native/build_native_playback.sh",
       "noticeLocator": "assets/legal/native/DIRECT_TORRENT_NATIVE_NOTICE.txt and its referenced exact license assets"
     },
     {
       "path": "lib/armeabi-v7a/libapp.so",
-      "size": 15204940,
-      "sha256": "6c07c4a418d47f93599f11b5bc61b0305529f7d9d6a28cb2b80c1509b0516830",
-      "origin": "TetoTV Flutter application AOT 2.0.73",
+      "size": 15237708,
+      "sha256": "c6d92bb73f3a0f810cb663f4bb2c289c4add132750191aff562c387e67163f2d",
+      "origin": "TetoTV Flutter application AOT 2.0.74",
       "license": "MIT",
-      "sourceLocator": "Git tag v2.0.73",
+      "sourceLocator": "Git tag v2.0.74",
       "noticeLocator": "LICENSE"
     },
     {
@@ -504,7 +504,7 @@
       "sha256": "8820a12e07bb3dc45f5b4286acf6918827fba4c265767e7f1cc8f07215c84b6a",
       "origin": "TetoTV source build of media-kit Android helper at 42054e5d479f39ccbb0ae604862e2bcaf59b74c2",
       "license": "MIT",
-      "sourceLocator": "TetoTV-v2.0.73-native-playback-sources.zip: sources/media-kit-android-helper-42054e5d479f39ccbb0ae604862e2bcaf59b74c2.zip",
+      "sourceLocator": "TetoTV-v2.0.74-native-playback-sources.zip: sources/media-kit-android-helper-42054e5d479f39ccbb0ae604862e2bcaf59b74c2.zip",
       "noticeLocator": "assets/legal/native/MEDIA_KIT_ANDROID_HELPER_LICENSE.txt; assets/legal/native/NATIVE_PLAYBACK_NOTICE.txt"
     },
     {
@@ -513,7 +513,7 @@
       "sha256": "d5a220fdf41edde10f161f86addc846ae9cb18137ea48e4db541cd703fec5092",
       "origin": "TetoTV source build of the pinned mpv and FFmpeg native playback stack",
       "license": "LGPL-3.0-or-later (conservative combined classification) plus component terms",
-      "sourceLocator": "TetoTV-v2.0.73-native-playback-sources.zip and tool/native/build_native_playback.sh",
+      "sourceLocator": "TetoTV-v2.0.74-native-playback-sources.zip and tool/native/build_native_playback.sh",
       "noticeLocator": "assets/legal/native/NATIVE_PLAYBACK_NOTICE.txt and its referenced exact license assets"
     },
     {
@@ -531,7 +531,7 @@
       "sha256": "ba0a19d2730969b8e6107db1847888ea8d3b8cafd14a535a3259dd04f8b28d60",
       "origin": "TetoTV source build of the pinned libtorrent4j and libtorrent-rasterbar stack",
       "license": "Mixed MIT, BSD, Boost-1.0, Apache-2.0, and MPL-2.0 component terms",
-      "sourceLocator": "TetoTV-v2.0.73-native-playback-sources.zip and tool/native/build_native_playback.sh",
+      "sourceLocator": "TetoTV-v2.0.74-native-playback-sources.zip and tool/native/build_native_playback.sh",
       "noticeLocator": "assets/legal/native/DIRECT_TORRENT_NATIVE_NOTICE.txt and its referenced exact license assets"
     }
   ],


### PR DESCRIPTION
Adds an Android-only Media3 SurfaceView toggle that selects Media3 for the next playback session; TextureView remains the default and MPV is unchanged. Removes Media3 scrub scene previews while preserving the timestamp bubble. Includes rendering lifecycle/screenshot support and regression tests. Verified both modes on Android TV emulator, focused Flutter/settings and native tests, and signed ARM universal APK/source/checksum payload gates. Updates beta version, release notes and native BOM. Native MPV binaries are unchanged; licensing disclosure remains the existing unreviewed-beta exception.